### PR TITLE
Check WIC presumed eligibility is in right demographic

### DIFF
--- a/programs/programs/policyengine/policyengine.py
+++ b/programs/programs/policyengine/policyengine.py
@@ -90,7 +90,11 @@ def eligibility_policy_engine(screen):
             eligibility['ssi']['estimated_value'] += pvalue['ssi']['2023']
 
     # WIC PRESUMPTIVE ELIGIBILITY
-    if eligibility['wic']['eligible'] is False:
+    in_wic_demographic = False
+    for member in screen.household_members.all():
+        if member.pregnant is True or member.age <= 5:
+            in_wic_demographic = True
+    if eligibility['wic']['eligible'] is False and in_wic_demographic:
         if screen.has_medicaid is True \
                 or screen.has_tanf is True \
                 or screen.has_snap is True:


### PR DESCRIPTION
What features are you implementing?
- Added a check to make sure that the household has someone who is pregnant, or a child under 5 in presumed eligibility for WIC.
Were there any issues that arose?
- If you have programs without functions in the database, then you will get a key error.