### PR TITLE
Added Result Key Back to Benefit Data

### DIFF
--- a/programs/programs/policyengine/policyengine.py
+++ b/programs/programs/policyengine/policyengine.py
@@ -55,7 +55,7 @@ def eligibility_policy_engine(screen):
         },
     }
 
-    benefit_data = policy_engine_calculate(screen)
+    benefit_data = policy_engine_calculate(screen)['result']
 
     # WIC & MEDICAID & SSI
     for pkey, pvalue in benefit_data['people'].items():


### PR DESCRIPTION
What (if anything) did you refactor?
- Added result key back because Policy Engine switched there api back.
