### PR TITLE
Reset Cached Data if There is an Error When Retrieving Cached Data

### DIFF
--- a/screener/views.py
+++ b/screener/views.py
@@ -143,7 +143,7 @@ def eligibility_results(screen):
                     })
             return data
     except Exception:
-        pass
+        data = []
 
     snapshot = EligibilitySnapshot.objects.create(screen=screen)
 


### PR DESCRIPTION
What (if any) features are you implementing?
- Default to recalculating eligibility if there is an error generating the results from snapshots.

Were there any issues that arose?
- We were calculating some benefits twice if the eligibility snapshot created an error. Which would cause an error on the front end because the datagrid table can not have duplicates.
