### PR TITLE
Add Option to Only Create Batch Snapshots for Screens Without Them

### DIFF
--- a/screener/management/commands/batch_snapshots.py
+++ b/screener/management/commands/batch_snapshots.py
@@ -14,6 +14,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--limit', default=1, type=int)
         parser.add_argument('--all', default=False, type=bool)
+        parser.add_argument('--new', default=False, type=bool)
 
     def handle(self, *args, **options):
         # Get the screens
@@ -24,6 +25,9 @@ class Command(BaseCommand):
 
         if not options['all']:
             screens = screens.exclude(user__isnull=True)
+
+        if options['new']:
+            screens = screens.filter(eligibility_snapshots__isnull=True)
 
         # List[:None] is everything in the list
         limit = None if options['limit'] == -1 else options['limit']


### PR DESCRIPTION
What (if any) features are you implementing?
- Including `--new True` now only creates snapshots for new users.