### PR TITLE
Use Custom CHP+ Calculation

### DIFF
--- a/screener/views.py
+++ b/screener/views.py
@@ -181,7 +181,7 @@ def eligibility_results(screen, batch=False):
         'acp',
         'lifeline',
         'pell_grant',
-        'chp',
+        # 'chp', wait until Medicaid Income is fixed to use CHP+ from PE
     )
 
     def sort_first(program):


### PR DESCRIPTION
What (if anything) did you refactor?
- Don't use CHP+ from Policy Engine until Medicaid income level is fixed.