### PR TITLE
Start Using CHP+ from Policy Engine Again

### DIFF
--- a/screener/views.py
+++ b/screener/views.py
@@ -181,7 +181,7 @@ def eligibility_results(screen, batch=False):
         'acp',
         'lifeline',
         'pell_grant',
-        # 'chp', wait until Medicaid Income is fixed to use CHP+ from PE
+        'chp',
     )
 
     def sort_first(program):


### PR DESCRIPTION
What (if anything) did you refactor?
- Use CHP+ from Policy Engine again.

**Policy Engine fixed the Medicaid income limits**