### PR TITLE
Prevent Duplicate Marital Units

### DIFF
--- a/programs/programs/policyengine/policyengine.py
+++ b/programs/programs/policyengine/policyengine.py
@@ -398,8 +398,14 @@ def policy_engine_prepare_params(screen):
         policy_engine_params['household']['households']['household']['members'].append(member_id)
         policy_engine_params['household']['spm_units']['spm_unit']['members'].append(member_id)
 
+    already_added = set()
     for member_1, member_2 in screen.relationship_map().items():
+        if member_1 in already_added or member_2 in already_added:
+            continue
+
         marital_unit = (str(member_1), str(member_2)) if member_2 is not None else (str(member_1),)
         policy_engine_params['household']['marital_units']['-'.join(marital_unit)] = {'members': marital_unit}
+        already_added.add(member_1)
+        already_added.add(member_2)
 
     return policy_engine_params

--- a/screener/models.py
+++ b/screener/models.py
@@ -215,6 +215,7 @@ class Screen(models.Model):
             relationship_map[member['id']] = probable_spouse
             if probable_spouse is not None:
                 relationship_map[probable_spouse] = member['id']
+
         return relationship_map
 
     def has_insurance_types(self, types, strict=True):


### PR DESCRIPTION
What (if anything) did you refactor?
- Don't add marital unit if one of the members was already added.