### PR TITLE
Policy Engine Tax Unit

### DIFF
--- a/programs/programs/policyengine/policyengine.py
+++ b/programs/programs/policyengine/policyengine.py
@@ -119,6 +119,13 @@ def eligibility_policy_engine(screen):
             eligibility['wic']['eligible'] = True
             eligibility['wic']['estimated_value'] += wic_categories[pvalue['wic_category']['2023']] * 12
 
+        in_tax_unit = str(pkey) in benefit_data['tax_units']['tax_unit']['members']
+
+        # The following programs use income from the tax unit,
+        # so we want to skip any members that are not in the tax unit.
+        if not in_tax_unit:
+            continue
+
         # MEDICAID
         if pvalue['medicaid']['2023'] > 0:
             eligibility['medicaid']['eligible'] = True

--- a/screener/models.py
+++ b/screener/models.py
@@ -277,6 +277,13 @@ class Screen(models.Model):
             (self.referrer_code is not None and self.referrer_code.lower() in referral_source_tests)
         self.save()
 
+    def get_head(self):
+        for member in self.household_members.all():
+            if member.relationship == 'headOfHousehold':
+                return member
+
+        raise Exception('No head of household')
+
     def eligibility_results(self):
         all_programs = Program.objects.all()
         screen = self


### PR DESCRIPTION
What (if any) features are you implementing?
- Add `get_head` method to screen model.

What (if anything) did you refactor?
- Only add dependents to tax unit.
- Split head and dependent incomes into the right fields.