### PR TITLE
Optional DB_HOST Variable

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -126,7 +126,7 @@ DATABASES = {
         'NAME': config('DB_NAME'),
         'USER': config('DB_USER'),
         'PASSWORD': config('DB_PASS'),
-        'HOST': 'localhost',
+        'HOST': config('DB_HOST', 'localhost'),
     }
 }
 


### PR DESCRIPTION
What (if anything) did you refactor?
- Added an optional `DB_HOST` variable so that I can connect to Postgres DB hosted on Windows from WSL.