### PR TITLE
Add check branch GH workflow

### DIFF
--- a/.github/workflows/enforcer.yaml
+++ b/.github/workflows/enforcer.yaml
@@ -1,0 +1,19 @@
+name: Check Branch
+
+on: pull_request
+
+jobs:
+  check_branch:
+    name: Check base and head branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: dev into main
+        if: ${{ github.base_ref == 'main' && github.head_ref == 'dev' }}
+        run: echo "Your pull request is for dev into main." && exit 0
+      - name: feature branch into dev
+        if: ${{ github.base_ref == 'dev' }}
+        run: echo "Your pull request is for a feature branch into dev." && exit 0
+      - name: non dev branch into main
+        if: ${{ github.base_ref == 'main' && github.head_ref != 'dev' }}
+        run: |
+          echo "ERROR: You can only merge the dev branch into main." && exit 1

--- a/.github/workflows/enforcer.yaml
+++ b/.github/workflows/enforcer.yaml
@@ -12,7 +12,7 @@ jobs:
         run: echo "Your pull request is for dev into main." && exit 0
       - name: feature branch into dev
         if: ${{ github.base_ref == 'dev' }}
-        run: echo "Your pull request is for a feature branch into dev." && exit 0
+        run: echo "TESTING Your pull request is for a feature branch into dev." && exit 0
       - name: non dev branch into main
         if: ${{ github.base_ref == 'main' && github.head_ref != 'dev' }}
         run: |


### PR DESCRIPTION
What (if any) features are you implementing?
- I added a workflow to check the `base` and `head` branches upon opening up a PR to ensure that only the `dev` branch is allowed to merge into `main`.

Is there anything that you need from your teammate?
- Please review and let me know if you have any questions or concerns. I'll be adding this workflow to our backend repo as well.