### PR TITLE
Add Private PE API

### DIFF
--- a/integrations/util/cache.py
+++ b/integrations/util/cache.py
@@ -1,8 +1,8 @@
-from sentry_sdk import capture_message
+from sentry_sdk import capture_exception, capture_message
 import datetime
 
 
-class Cache():
+class Cache:
     expire_time = 0
     default = 0
 
@@ -17,8 +17,8 @@ class Cache():
         try:
             self.data = self.update()
             self.last_update = datetime.datetime.now()
-        except Exception:
-            capture_message(f'Failed to update {self.__class__.__name__}', level='warning')
+        except Exception as e:
+            capture_exception(e, level="warning")
 
     def should_update(self):
         return datetime.datetime.now() > self.last_update + datetime.timedelta(seconds=self.expire_time)

--- a/integrations/util/cache.py
+++ b/integrations/util/cache.py
@@ -1,4 +1,4 @@
-from sentry_sdk import capture_exception, capture_message
+from sentry_sdk import capture_exception
 import datetime
 
 

--- a/programs/programs/co/pe/member.py
+++ b/programs/programs/co/pe/member.py
@@ -61,11 +61,12 @@ class Chp(PolicyEngineMembersCalculator):
     def value(self):
         total = 0
 
-        for pkey, pvalue in self.get_data().items():
-            if not self.in_tax_unit(pkey):
+        for member in self.screen.household_members.all():
+            if not self.in_tax_unit(member.id):
                 continue
 
-            if pvalue['co_chp_eligible'][self.pe_period] > 0 and self.screen.has_insurance_types(('none',)):
+            chp_eligible = self.sim.value(self.pe_category, str(member.id), 'co_chp_eligible', self.pe_period) > 0
+            if chp_eligible and self.screen.has_insurance_types(('none',)):
                 total += self.amount
 
         return total

--- a/programs/programs/co/pe/tax.py
+++ b/programs/programs/co/pe/tax.py
@@ -38,4 +38,4 @@ class Coctc(PolicyEngineTaxUnitCalulator):
                 multiplier = band['percent']
                 break
 
-        return self.get_data()[self.pe_name][self.pe_period] * multiplier
+        return self.get_variable() * multiplier

--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -23,9 +23,10 @@ class Wic(PolicyEngineMembersCalculator):
     def value(self):
         total = 0
 
-        for _, pvalue in self.get_data().items():
-            if pvalue[self.pe_name][self.pe_period] > 0:
-                total += self.wic_categories[pvalue['wic_category'][self.pe_period]] * 12
+        for member in self.screen.household_members.all():
+            if self.get_member_variable(member.id) > 0:
+                wic_category = self.sim.value('people', str(member.id), 'wic_category', self.pe_period)
+                total += self.wic_categories[wic_category] * 12
 
         return total
 
@@ -67,18 +68,29 @@ class Medicaid(PolicyEngineMembersCalculator):
     def value(self):
         total = 0
 
-        for pkey, pvalue in self.get_data().items():
-            # Skip any members that are not in the tax unit.
-            if not self.in_tax_unit(pkey):
+        members = self.screen.household_members.all()
+
+        for member in members:
+            if self.get_member_variable(member.id) <= 0:
                 continue
 
-            if pvalue[self.pe_name][self.pe_period] <= 0:
-                continue
+            # here we need to adjust for children as policy engine
+            # just uses the average which skews very high for adults and
+            # aged adults
 
-            total += self._value_by_age(pvalue['age'][self.pe_period])
+            if self._get_age(member.id) <= 18:
+                medicaid_estimated_value = self.child_medicaid_average
+            elif self._get_age(member.id) > 18 and self._get_age(member.id) < 65:
+                medicaid_estimated_value = self.adult_medicaid_average
+            elif self._get_age(member.id) >= 65:
+                medicaid_estimated_value = self.aged_medicaid_average
+            else:
+                medicaid_estimated_value = 0
+
+            total += medicaid_estimated_value
 
         in_wic_demographic = False
-        for member in self.screen.household_members.all():
+        for member in members:
             if member.pregnant is True or member.age <= 5:
                 in_wic_demographic = True
         if total == 0 and in_wic_demographic:
@@ -88,6 +100,9 @@ class Medicaid(PolicyEngineMembersCalculator):
                 total = self.presumptive_amount
 
         return total
+
+    def _get_age(self, member_id: int) -> int:
+        return self.sim.value(self.pe_category, str(member_id), 'age', self.pe_period)
 
 
 class PellGrant(PolicyEngineMembersCalculator):

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -25,7 +25,7 @@ class Snap(PolicyEngineSpmCalulator):
     pe_output_period = SNAP_PERIOD
 
     def value(self):
-        return int(self.get_data()[self.pe_name][self.pe_output_period]) * 12
+        return int(self.sim.value(self.pe_category, self.pe_sub_category, self.pe_name, self.pe_output_period)) * 12
 
 
 class SchoolLunch(PolicyEngineSpmCalulator):
@@ -39,8 +39,8 @@ class SchoolLunch(PolicyEngineSpmCalulator):
         total = 0
         num_children = self.screen.num_children(3, 18)
 
-        if self.get_data()[self.pe_name][self.pe_period] > 0 and num_children > 0:
-            if self.get_data()['school_meal_tier'][self.pe_period] != 'PAID':
+        if self.get_variable() > 0 and num_children > 0:
+            if self.sim.value(self.pe_category, self.pe_sub_category, 'school_meal_tier', self.pe_period) != 'PAID':
                 total = SchoolLunch.amount * num_children
 
         return total

--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -1,0 +1,71 @@
+import requests
+
+
+class Sim:
+    method = ''
+
+    def __init__(self, data) -> None:
+        self.data = data
+
+    def value(self, unit, sub_unit, variable, period):
+        '''
+        Calculate variable at the period
+        '''
+        raise NotImplementedError
+
+    def members(self, unit, sub_unit):
+        '''
+        Return a list of the members in the sub unit
+        '''
+        raise NotImplementedError
+
+
+class ApiSim(Sim):
+    method_name = 'Policy Engine API'
+
+    def __init__(self, data) -> None:
+        response = requests.post("https://api.policyengine.org/us/calculate", json=data)
+        self.data = response.json()['result']
+
+    def value(self, unit, sub_unit, variable, period):
+        return self.data[unit][sub_unit][variable][period]
+
+    def members(self, unit, sub_unit):
+        return self.data[unit][sub_unit]['members']
+
+
+class PrivateApi(ApiSim):
+    method_name = 'Private Policy Engine API'
+
+
+# NOTE: Code to run Policy Engine locally. This is currently too CPU expensive to run in production.
+# Requires the Policy Engine package to be installed and imported.
+# class LocalSim(Sim):
+#     method_name = 'local package'
+#
+#     def __init__(self, data) -> None:
+#         self.household = data['household']
+#
+#         self.entity_map = {}
+#         for entity in self.household.keys():
+#             group_map = {}
+#
+#             for i, group in enumerate(self.household[entity].keys()):
+#                 group_map[group] = i
+#
+#             self.entity_map[entity] = group_map
+#
+#         self.sim = Simulation(situation=self.household)
+#
+#     def value(self, unit, sub_unit, variable, period):
+#         data = self.sim.calculate(variable, period)
+#
+#         index = self.entity_map[unit][sub_unit]
+#
+#         return data[index]
+#
+#     def members(self, unit, sub_unit):
+#         return self.household[unit][sub_unit]['members']
+
+
+pe_engines = [ApiSim]

--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -1,77 +1,83 @@
-import json
 from integrations.util.cache import Cache
 from decouple import config
 import requests
-import http.client
 
 
 class Sim:
-    method = ''
+    method = ""
 
     def __init__(self, data) -> None:
         self.data = data
 
     def value(self, unit, sub_unit, variable, period):
-        '''
+        """
         Calculate variable at the period
-        '''
+        """
         raise NotImplementedError
 
     def members(self, unit, sub_unit):
-        '''
+        """
         Return a list of the members in the sub unit
-        '''
+        """
         raise NotImplementedError
 
 
 class ApiSim(Sim):
-    method_name = 'Policy Engine API'
+    method_name = "Policy Engine API"
+    pe_url = "https://api.policyengine.org/us/calculate"
 
     def __init__(self, data) -> None:
-        response = requests.post("https://api.policyengine.org/us/calculate", json=data)
-        self.data = response.json()['result']
+        response = requests.post(self.pe_url, json=data)
+        self.data = response.json()["result"]
 
     def value(self, unit, sub_unit, variable, period):
         return self.data[unit][sub_unit][variable][period]
 
     def members(self, unit, sub_unit):
-        return self.data[unit][sub_unit]['members']
+        return self.data[unit][sub_unit]["members"]
 
 
 class PolicyEngineBearerTokenCache(Cache):
-    expire_time = 60 * 60 * 24 * 30
-    default = ''
-    client_id: str = config('POLICY_ENGINE_CLIENT_ID', '')
-    client_secret: str = config('POLICY_ENGINE_CLIENT_SECRET', '')
-    domain = 'https://policyengine.uk.auth0.com'
-    endpoint = '/oauth/token'
+    expire_time = 60 * 60 * 24 * 29
+    default = ""
+    client_id: str = config("POLICY_ENGINE_CLIENT_ID", "")
+    client_secret: str = config("POLICY_ENGINE_CLIENT_SECRET", "")
+    domain = "https://policyengine.uk.auth0.com"
+    endpoint = "/oauth/token"
 
     def update(self):
         # https://policyengine.org/us/api#fetch_token
 
-        if self.client_id == '' or self.client_secret == '':
-            raise Exception('client id or secret not configured')
+        if self.client_id == "" or self.client_secret == "":
+            raise Exception("client id or secret not configured")
 
         payload = {
-                'client_id': self.client_id,
-                'client_secret': self.client_secret,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "client_credentials",
+            "audience": "https://household.api.policyengine.org",
         }
 
+        res = requests.post(self.domain + self.endpoint, json=payload)
 
-        headers = { 'content-type': "application/json" }
-
-        res = requests.post(self.domain + self.endpoint, json=payload, headers=headers)
-
-        return res.json()
+        return res.json()["access_token"]
 
 
 class PrivateApiSim(ApiSim):
-    method_name = 'Private Policy Engine API'
+    method_name = "Private Policy Engine API"
     token = PolicyEngineBearerTokenCache()
+    pe_url = "https://household.api.policyengine.org/us/calculate"
 
     def __init__(self, data) -> None:
         token = self.token.fetch()
-        print(token)
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+        }
+
+        res = requests.post(self.pe_url, json=data, headers=headers)
+
+        self.data = res.json()["result"]
 
 
 # NOTE: Code to run Policy Engine locally. This is currently too CPU expensive to run in production.

--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -4,7 +4,7 @@ import requests
 
 
 class Sim:
-    method = ""
+    method_name = ""
 
     def __init__(self, data) -> None:
         self.data = data
@@ -111,4 +111,4 @@ class PrivateApiSim(ApiSim):
 #         return self.household[unit][sub_unit]['members']
 
 
-pe_engines = [PrivateApiSim, ApiSim]
+pe_engines: list[Sim] = [PrivateApiSim, ApiSim]


### PR DESCRIPTION
What (if any) features are you implementing?
- Add Policy Engine Private API.

What (if anything) did you refactor?
- Add ability to use different methods for using PE, and using other methods as fallback.
- Use `capture_exception` instead of `capture_message` for Sentry in some places.

To use the private PE API, `POLICY_ENGINE_CLIENT_ID` and `POLICY_ENGINE_CLIENT_SECRET` need to be set.