### PR TITLE
Bug/Document Translate Page Incorrect Redirect

### DIFF
--- a/programs/admin.py
+++ b/programs/admin.py
@@ -69,10 +69,8 @@ class ProgramAdmin(ModelAdmin):
             reverse("translation_admin_url", args=[category.id]),
             reverse("translation_admin_url", args=[learn_more_link.id]),
             reverse("translation_admin_url", args=[apply_button_link.id]),
-            reverse("translation_admin_url", args=[
-                    estimated_delivery_time.id]),
-            reverse("translation_admin_url", args=[
-                    estimated_application_time.id]),
+            reverse("translation_admin_url", args=[estimated_delivery_time.id]),
+            reverse("translation_admin_url", args=[estimated_application_time.id]),
             reverse("translation_admin_url", args=[value_type.id]),
             reverse("translation_admin_url", args=[warning.id]),
             reverse("translation_admin_url", args=[website_description.id]),

--- a/programs/admin.py
+++ b/programs/admin.py
@@ -69,8 +69,10 @@ class ProgramAdmin(ModelAdmin):
             reverse("translation_admin_url", args=[category.id]),
             reverse("translation_admin_url", args=[learn_more_link.id]),
             reverse("translation_admin_url", args=[apply_button_link.id]),
-            reverse("translation_admin_url", args=[estimated_delivery_time.id]),
-            reverse("translation_admin_url", args=[estimated_application_time.id]),
+            reverse("translation_admin_url", args=[
+                    estimated_delivery_time.id]),
+            reverse("translation_admin_url", args=[
+                    estimated_application_time.id]),
             reverse("translation_admin_url", args=[value_type.id]),
             reverse("translation_admin_url", args=[warning.id]),
             reverse("translation_admin_url", args=[website_description.id]),
@@ -194,6 +196,31 @@ class FederalPovertyLimitAdmin(ModelAdmin):
 
 class DocumentAdmin(ModelAdmin):
     search_fields = ("external_name",)
+    list_display = ["get_str", "action_buttons"]
+
+    def get_str(self, obj):
+        return str(obj)
+
+    get_str.admin_order_field = "external_name"
+    get_str.short_description = "Document"
+
+    def action_buttons(self, obj):
+        text = obj.text
+
+        return format_html(
+            """
+            <div class="dropdown">
+                <span class="dropdown-btn material-symbols-outlined"> menu </span>
+                <div class="dropdown-content">
+                    <a href="{}">Document Text</a>
+                </div>
+            </div>
+            """,
+            reverse("translation_admin_url", args=[text.id]),
+        )
+
+    action_buttons.short_description = "Translate:"
+    action_buttons.allow_tags = True
 
 
 class ReferrerAdmin(ModelAdmin):

--- a/translations/templates/documents/list.html
+++ b/translations/templates/documents/list.html
@@ -8,7 +8,7 @@
       <tr>
         <th>ID</th>
         <th>External Name</th>
-        <th>External Name Label</th>
+        <th>Text Label</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -17,7 +17,7 @@
       <tr>
         <td>{{ document.id }}</td>
         <td>{{ document.external_name }}</td>
-        <td>{{ document.name }}</td>
+        <td>{{ document.text }}</td>
         <td>
           <div class="dropdown">
             <div class="dropdown-trigger">
@@ -37,7 +37,7 @@
             >
               <div class="dropdown-content">
                 <a
-                  href="/api/translations/admin/{{ document.id }}"
+                  href="/api/translations/admin/{{ document.text.id }}"
                   class="dropdown-item"
                   >Edit</a
                 >

--- a/translations/templates/navigators/list.html
+++ b/translations/templates/navigators/list.html
@@ -74,13 +74,13 @@
       </tr>
       {% empty %}
       <tr>
-        <td colspan="5">No results</td>
+        <td colspan="6">No results</td>
       </tr>
       {% endfor %}
     </tbody>
     <tfoot>
       <tr>
-        <td colspan="5">Total: {{ page_obj.paginator.count }}</td>
+        <td colspan="6">Total: {{ page_obj.paginator.count }}</td>
       </tr>
     </tfoot>
   </table>

--- a/translations/templates/urgent_needs/list.html
+++ b/translations/templates/urgent_needs/list.html
@@ -82,13 +82,13 @@
       </tr>
       {% empty %}
       <tr>
-        <td colspan="4">No results</td>
+        <td colspan="5">No results</td>
       </tr>
       {% endfor %}
     </tbody>
     <tfoot>
       <tr>
-        <td colspan="4">Total: {{ page_obj.paginator.count }}</td>
+        <td colspan="5">Total: {{ page_obj.paginator.count }}</td>
       </tr>
     </tfoot>
   </table>


### PR DESCRIPTION
What (if anything) did you refactor?
- In the Documents table in the new Translations API dashboard, the edit button was incorrectly redirecting instead of showing the document's translate page, this is now fixed.
- Some tables in the new Translations API dashboard had inconsistent `colspan` values, made adjustments to fix this.
- Added a missing 'Translate' menu for the Documents tab in the new main Django admin dashboard.

