### PR TITLE
Translations Admin Translate Button

### DIFF
--- a/translations/templates/edit/lang_form.html
+++ b/translations/templates/edit/lang_form.html
@@ -7,8 +7,11 @@
     <p class="help is-danger">{{ error }}</p>
     {% endfor %}
   </div>
-  {% endfor %}
+  {% endfor %} {% if lang == 'en-us' %}
+  <button class="button" type="submit">Save All</button>
+  {% else %}
   <button class="button" type="submit">Save</button>
+  {% endif %} {% if lang != 'en-us' %}
   <button
     class="button"
     type="button"
@@ -19,5 +22,5 @@
   >
     Translate
   </button>
-  {% if error_message %} {% include "error.html" %} {% endif %}
+  {% endif %} {% if error_message %} {% include "error.html" %} {% endif %}
 </span>


### PR DESCRIPTION
What (if anything) did you refactor?
- The Translate button for 'en-us' language code in the Translations API (admin) does not perform any functions. Made it so that for this specific language code the Translate button won't appear.
- The Save button for 'en-us' language code in the Translations API (admin) upon press, translates and saves the inputted text in its field to all other language codes. Made it so that this button is more descriptive of this feature.

Before changes:
![Screenshot 2024-06-05 093927](https://github.com/Gary-Community-Ventures/benefits-api/assets/79583632/a370e58e-26b0-4403-a230-cead42f86e06)

After changes:
![Screenshot 2024-06-05 093913](https://github.com/Gary-Community-Ventures/benefits-api/assets/79583632/298ed609-7a5a-46c3-89df-2ffd871930b8)
