### PR TITLE
Removed option 'Unrelated' from the dropdown step 5

### DIFF
--- a/configuration/management/commands/add_config.py
+++ b/configuration/management/commands/add_config.py
@@ -90,7 +90,6 @@ class Command(BaseCommand):
             "_default_message": "Boyfriend/Girlfriend",
         },
         "domesticPartner": {"_label": "relationshipOptions.domesticPartner", "_default_message": "Domestic Partner"},
-        "unrelated": {"_label": "relationshipOptions.unrelated", "_default_message": "Unrelated"},
         "relatedOther": {"_label": "relationshipOptions.relatedOther", "_default_message": "Related in some other way"},
     }
 


### PR DESCRIPTION
## What (if any) features are you implementing?

Work for the issue [#1140](https://github.com/Gary-Community-Ventures/benefits-calculator/issues/1140)

Removing option 'Unrelated' from the step 5, dropdown