### PR TITLE
Reorder referral_options, add dhs, rm chs

### DIFF
--- a/configuration/management/commands/add_config.py
+++ b/configuration/management/commands/add_config.py
@@ -96,18 +96,17 @@ class Command(BaseCommand):
 
     referral_options = {
         "211co": "2-1-1 Colorado",
-        "cedp": "Community Economic Defense Project (CEDP)",
         "cch": "Colorado Coalition for the Homeless",
         "frca": "Family Resource Center Association",
         "jeffcoHS": "Jeffco Human Services",
         "gac": "Get Ahead Colorado",
         "bia": "Benefits in Action",
         "arapahoectypublichealth": "Arapahoe County Public Health",
-        "villageExchange": "Village Exchange",
         "fircsummitresourcecenter": {
             "_label": "referralOptions.fircsummitresourcecenter",
             "_default_message": "FIRC Summit Resource Center",
         },
+        "dhs": "Denver Human Services",
         "testOrProspect": {
             "_label": "referralOptions.testOrProspect",
             "_default_message": "Test / Prospective Partner",


### PR DESCRIPTION
What (if anything) did you refactor?
- I reordered the `referral_options`, added `dhs`, and removed `chs`.
- Please note that I have already changed this in the production `Configurations` admin. 
<img width="799" alt="Screenshot 2024-07-16 at 12 42 19 PM" src="https://github.com/user-attachments/assets/1c916af5-ccd1-4d4a-bc80-b6fe9012f696">
