### PR TITLE
Feat/Added new configuration data field UI

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "phonenumber_field",
     "parler",
+    'django_json_widget',
     "django_filters",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -82,7 +82,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "phonenumber_field",
     "parler",
-    'django_json_widget',
+    "django_json_widget",
     "django_filters",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/configuration/admin.py
+++ b/configuration/admin.py
@@ -1,10 +1,31 @@
 from django.contrib import admin
 from unfold.admin import ModelAdmin
+from django_json_widget.widgets import JSONEditorWidget
+from django.db.models import JSONField
 from .models import Configuration
+import json
 
 
 class ConfigurationAdmin(ModelAdmin):
+    formfield_overrides = {
+        JSONField: {'widget': JSONEditorWidget(
+            options={
+                'modes': ['tree', 'code'],
+                'mode': 'tree',
+                'enableDrag': False
+            }
+        )},
+    }
     search_fields = ("name",)
+
+    # Convert the JSON string to a dictionary
+    # This makes it so that the JSON data coming from the 'data' field of the Configuration model
+    # is displayed as a dictionary and without the escape characters
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        if obj and isinstance(obj.data, str):
+            obj.data = json.loads(obj.data)
+        return form
 
 
 admin.site.register(Configuration, ConfigurationAdmin)

--- a/configuration/admin.py
+++ b/configuration/admin.py
@@ -8,13 +8,9 @@ import json
 
 class ConfigurationAdmin(ModelAdmin):
     formfield_overrides = {
-        JSONField: {'widget': JSONEditorWidget(
-            options={
-                'modes': ['tree', 'code'],
-                'mode': 'tree',
-                'enableDrag': False
-            }
-        )},
+        JSONField: {
+            "widget": JSONEditorWidget(options={"modes": ["tree", "code"], "mode": "tree", "enableDrag": False})
+        },
     }
     search_fields = ("name",)
 

--- a/programs/migrations/0081_merge_20240802_1619.py
+++ b/programs/migrations/0081_merge_20240802_1619.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("programs", "0079_federalpoverylimit_pe_period"),
         ("programs", "0080_alter_navigatorlanguage_code"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Django==4.2.14
 django-cors-headers==3.13.0
 django-filter==21.1
 django-heroku==0.3.1
+django-json-widget==2.0.1
 django-parler==2.3
 django-parler-rest==2.2
 django-phonenumber-field==6.3.0


### PR DESCRIPTION
What (if any) features are you implementing?
- With the use of [django-json-widget](https://pypi.org/project/django-json-widget/) package, the `data` field of the Configuration model now utilizes a JSON editor window in the main Django admin dashboard. This change helps in providing a more user friendly interface for admins to manage the configuration instances of the screener.
- The JSON editor for the `data` field provides two different views, namely Tree and Code. The JSON editor also provides search, sort, order, and other features.
![image](https://github.com/user-attachments/assets/18eab89c-d674-448c-b7b2-30664b88d54b)

What (if anything) did you refactor?
- The JSON data, when saved in the data field of the Configuration model, previously included escape characters. However, after passing the data through `json.loads` in the `admin.py` of the Configuration model, the escape characters `\` are now excluded only while the `data` is being viewed in the JSON editor.

Any other comments, questions, or concerns?
- The django-json-widget package is added in the requirements.txt, the package needs to be installed for the new `data` UI to work. 