### PR TITLE
Remove unrelated from relationship options

### DIFF
--- a/configuration/management/commands/add_config.py
+++ b/configuration/management/commands/add_config.py
@@ -112,7 +112,6 @@ class Command(BaseCommand):
             "_default_message": "Boyfriend/Girlfriend",
         },
         "domesticPartner": {"_label": "relationshipOptions.domesticPartner", "_default_message": "Domestic Partner"},
-        "unrelated": {"_label": "relationshipOptions.unrelated", "_default_message": "Unrelated"},
         "relatedOther": {"_label": "relationshipOptions.relatedOther", "_default_message": "Related in some other way"},
     }
 


### PR DESCRIPTION
What (if anything) did you refactor?
- Remove unrelated from `add_config` relationship options.

This change is already in prod.