### PR TITLE
Cache the translations object

### DIFF
--- a/integrations/util/cache.py
+++ b/integrations/util/cache.py
@@ -9,18 +9,26 @@ class Cache:
     def __init__(self):
         self.data = self.default
         self.last_update = datetime.datetime.now() - datetime.timedelta(seconds=self.expire_time)
+        self.invalid = True
 
     def update(self):
         raise NotImplementedError()
 
     def _update_cache(self):
         try:
-            self.data = self.update()
+            self.save(self.update())
             self.last_update = datetime.datetime.now()
+            self.invalid = False
         except Exception as e:
             capture_exception(e, level="warning")
 
+    def save(self, data):
+        self.data = data
+
     def should_update(self):
+        if self.invalid is True:
+            return True
+
         return datetime.datetime.now() > self.last_update + datetime.timedelta(seconds=self.expire_time)
 
     def fetch(self):


### PR DESCRIPTION
What (if anything) did you refactor?
- Cache the translations result.
- Add ability to invalidate the cache.

**You can barely see the loading screen now.**

https://github.com/user-attachments/assets/e4378267-6e5f-4980-a4b7-154a982670f8

