### PR TITLE
State specific SNAP spm calculators

### DIFF
--- a/programs/programs/co/pe/__init__.py
+++ b/programs/programs/co/pe/__init__.py
@@ -1,3 +1,4 @@
+from programs.programs.co.pe import spm
 import programs.programs.co.pe.tax as tax
 import programs.programs.co.pe.member as member
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
@@ -15,6 +16,10 @@ co_member_calculators = {
 co_tax_unit_calculators = {
     "coeitc": tax.Coeitc,
     "coctc": tax.Coctc,
+}
+
+co_spm_calculators = {
+    "co_snap": spm.CoSnap,
 }
 
 co_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {

--- a/programs/programs/co/pe/spm.py
+++ b/programs/programs/co/pe/spm.py
@@ -5,7 +5,6 @@ from programs.programs.federal.pe.spm import Snap, Tanf
 class CoSnap(Snap):
     pe_inputs = [
         *Snap.pe_inputs,
-        dependency.spm.ElectricityExpenseDependency,
         dependency.household.CoStateCode,
     ]
 

--- a/programs/programs/co/pe/spm.py
+++ b/programs/programs/co/pe/spm.py
@@ -6,6 +6,7 @@ class CoSnap(Snap):
     pe_inputs = [
         *Snap.pe_inputs,
         dependency.spm.ElectricityExpenseDependency,
+        dependency.household.CoStateCode,
     ]
 
 

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -20,7 +20,7 @@ class Snap(PolicyEngineSpmCalulator):
         dependency.spm.MeetsSnapAssetTestDependency,
         dependency.spm.SnapDependentCareDeductionDependency,
         dependency.spm.WaterExpenseDependency,
-        dependency.spm.PhoneExpenseDependency
+        dependency.spm.PhoneExpenseDependency,
     ]
     pe_outputs = [dependency.spm.Snap]
     pe_period_month = "01"

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -19,6 +19,8 @@ class Snap(PolicyEngineSpmCalulator):
         dependency.spm.SnapEarnedIncomeDependency,
         dependency.spm.MeetsSnapAssetTestDependency,
         dependency.spm.SnapDependentCareDeductionDependency,
+        dependency.spm.WaterExpenseDependency,
+        dependency.spm.PhoneExpenseDependency
     ]
     pe_outputs = [dependency.spm.Snap]
     pe_period_month = "01"

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -16,7 +16,6 @@ class Snap(PolicyEngineSpmCalulator):
         dependency.spm.HasPhoneExpenseDependency,
         dependency.spm.HasHeatingCoolingExpenseDependency,
         dependency.spm.HeatingCoolingExpenseDependency,
-        dependency.spm.ElectricityExpenseDependency,
         dependency.spm.SnapEarnedIncomeDependency,
         dependency.spm.MeetsSnapAssetTestDependency,
         dependency.spm.SnapDependentCareDeductionDependency,

--- a/programs/programs/nc/pe/__init__.py
+++ b/programs/programs/nc/pe/__init__.py
@@ -1,10 +1,13 @@
+from programs.programs.nc.pe import spm
 import programs.programs.nc.pe.member as member
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
 
 
 nc_member_calculators = {"nc_medicaid": member.NcMedicaid, "nc_wic": member.NcWic}
+nc_spm_calculators = {"nc_snap": spm.NcSnap}
 
 
 nc_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {
     **nc_member_calculators,
+    **nc_spm_calculators,
 }

--- a/programs/programs/nc/pe/spm.py
+++ b/programs/programs/nc/pe/spm.py
@@ -2,8 +2,9 @@ import programs.programs.policyengine.calculators.dependencies as dependency
 from programs.programs.federal.pe.spm import Snap
 
 
-class CoSnap(Snap):
+class NcSnap(Snap):
     pe_inputs = [
         *Snap.pe_inputs,
-        dependency.spm.ElectricityExpenseDependency,
+        dependency.spm.WaterExpenseDependency,
+        dependency.spm.PhoneExpenseDependency,
     ]

--- a/programs/programs/nc/pe/spm.py
+++ b/programs/programs/nc/pe/spm.py
@@ -7,6 +7,7 @@ class NcSnap(Snap):
         *Snap.pe_inputs,
         dependency.spm.WaterExpenseDependency,
         dependency.spm.PhoneExpenseDependency,
+        dependency.household.NcStateCode,
     ]
 
 

--- a/programs/programs/nc/pe/spm.py
+++ b/programs/programs/nc/pe/spm.py
@@ -5,8 +5,6 @@ from programs.programs.federal.pe.spm import Snap, Tanf
 class NcSnap(Snap):
     pe_inputs = [
         *Snap.pe_inputs,
-        dependency.spm.WaterExpenseDependency,
-        dependency.spm.PhoneExpenseDependency,
         dependency.household.NcStateCode,
     ]
 

--- a/programs/programs/policyengine/calculators/__init__.py
+++ b/programs/programs/policyengine/calculators/__init__.py
@@ -3,8 +3,8 @@ from programs.programs.federal.pe import (
     federal_spm_unit_calculators,
     federal_tax_unit_calculators,
 )
-from programs.programs.co.pe import co_member_calculators, co_tax_unit_calculators
-from programs.programs.nc.pe import nc_member_calculators
+from programs.programs.co.pe import co_member_calculators, co_tax_unit_calculators, co_spm_calculators
+from programs.programs.nc.pe import nc_member_calculators, nc_spm_calculators
 from .base import (
     PolicyEngineMembersCalculator,
     PolicyEngineSpmCalulator,
@@ -21,6 +21,8 @@ all_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
 
 all_spm_unit_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {
     **federal_spm_unit_calculators,
+    **nc_spm_calculators,
+    **co_spm_calculators,
 }
 
 all_tax_unit_calculators: dict[str, type[PolicyEngineTaxUnitCalulator]] = {

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -126,6 +126,13 @@ class ElectricityExpenseDependency(SpmUnit):
         return self.screen.calc_expenses("yearly", ["otherUtilities"])
 
 
+class WaterExpenseDependency(SpmUnit):
+    field = "water_expense"
+
+    def value(self):
+        return self.screen.calc_expenses("yearly", ["otherUtilities"])
+
+
 class SnapEmergencyAllotmentDependency(SpmUnit):
     field = "snap_emergency_allotment"
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -266,6 +266,8 @@ class Screen(models.Model):
             "wic": self.has_wic,
             "nc_wic": self.has_wic,
             "snap": self.has_snap,
+            "co_snap": self.has_snap,
+            "nc_snap": self.has_snap,
             "lifeline": self.has_lifeline,
             "acp": self.has_acp,
             "eitc": self.has_eitc,


### PR DESCRIPTION
What (if anything) did you refactor?
- Abstracted snap program's PolicyEngine SPM calculator to be state specific, there are now `NcSnap` and `CoSnap` spm classes.

Any other comments, questions, or concerns?
- The snap program's name abbreviated field needs to be changed to a state specific name through the dashboard. For NC it should be named `nc_snap` and for CO `co_snap`.
- Context for NC specific change: This PR also addresses the inaccurate results the screener was showing if a household was eligible for the snap program's [BUA or LUA](https://www.snapscreener.com/data#:~:text=If%20a%20household%20pays%20for%20two%20or%20more%20utility%20bills%2C%20this%20deduction%20amount%20can%20be%20claimed%20(but%20no%20other%20utility%20deductions)) (Basic or Limited utility allowance). According to the [snap screener](https://www.snapscreener.com/screener/north-carolina) and [PolicyEngine](https://github.com/PolicyEngine/policyengine-us/blob/master/policyengine_us/parameters/gov/usda/snap/income/deductions/utility/limited/main.yaml#L1), a household becomes eligible for LUA if they are paying at least two utility expenses (i.e. water, gas and fuel, electricity, sewage, phone) besides heating or cooling. For the state of North Carolina, there is no additional single utility allowance given besides a $41 allowance for phone expense. Currently in the screener, in order for a household to become eligible for a LUA deduction, they need to input 'Other Utilities' and 'Telephone' expense options in step-6 (other than rent). `PhoneExpenseDependency` was added to the `NcSnap` class's dependencies list in order to send the 'Telephone' expense amount to the PolicyEngine. The [SPM unit](https://github.com/Gary-Community-Ventures/benefits-api/blob/feat/seperate-snap/programs/programs/policyengine/calculators/dependencies/spm.py#L122) class `ElectricityExpenseDependency` responsible for processing the 'Other Utilites' expense option is mapped to a `electricity_expense` PolicyEngine variable. From my testing I wasn't able to make this dependency take effect. By replacing this dependency with another SPM unit class, `WaterExpenseDependency`, and mapping it to the `water_expense` PolicyEngine variable—which is calculated the same way as `electricity_expense`—with these changes, the estimated $ value returned from PolicyEngine whenever a household is eligible for LUA matches the results shown in the snap screener.