### PR TITLE
Move test referrer to bottom of list, move dhs under jeffco

### DIFF
--- a/configuration/management/commands/add_config.py
+++ b/configuration/management/commands/add_config.py
@@ -120,6 +120,7 @@ class Command(BaseCommand):
         "cch": "Colorado Coalition for the Homeless",
         "frca": "Family Resource Center Association",
         "jeffcoHS": "Jeffco Human Services",
+        "dhs": "Denver Human Services",
         "gac": "Get Ahead Colorado",
         "bia": "Benefits in Action",
         "arapahoectypublichealth": "Arapahoe County Public Health",
@@ -127,16 +128,15 @@ class Command(BaseCommand):
             "_label": "referralOptions.fircsummitresourcecenter",
             "_default_message": "FIRC Summit Resource Center",
         },
-        "dhs": "Denver Human Services",
         "ccig": "Colorado Community Insight Group",
         "eaglecounty": "Eagle County",
+        "searchEngine": {"_label": "referralOptions.searchEngine", "_default_message": "Google or other search engine"},
+        "socialMedia": {"_label": "referralOptions.socialMedia", "_default_message": "Social Media"},
+        "other": {"_label": "referralOptions.other", "_default_message": "Other"},
         "testOrProspect": {
             "_label": "referralOptions.testOrProspect",
             "_default_message": "Test / Prospective Partner",
         },
-        "searchEngine": {"_label": "referralOptions.searchEngine", "_default_message": "Google or other search engine"},
-        "socialMedia": {"_label": "referralOptions.socialMedia", "_default_message": "Social Media"},
-        "other": {"_label": "referralOptions.other", "_default_message": "Other"},
     }
 
     language_options = {


### PR DESCRIPTION
What (if anything) did you refactor?
- I moved the `Test/Prospective Partner` referral option to the bottom of the `referral_options` list.
- I moved `DHS` under `JeffCo`.
<img width="1421" alt="Screenshot 2024-10-21 at 9 45 27 AM" src="https://github.com/user-attachments/assets/ff9b2bc7-3f2f-49c7-af2d-0fe54070aedd">
