### PR TITLE
Remove SNAP gross income test dependency

### DIFF
--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -11,7 +11,6 @@ class Snap(PolicyEngineSpmCalulator):
         dependency.spm.MeetsSnapCategoricalEligibilityDependency,
         dependency.spm.SnapEmergencyAllotmentDependency,
         dependency.spm.HousingCostDependency,
-        dependency.spm.MeetsSnapGrossIncomeTestDependency,
         dependency.spm.HasPhoneExpenseDependency,
         dependency.spm.HasHeatingCoolingExpenseDependency,
         dependency.spm.HeatingCoolingExpenseDependency,

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -54,22 +54,6 @@ class SnapGrossIncomeDependency(SpmUnit):
         return int(self.screen.calc_gross_income("yearly", ["all"]))
 
 
-class MeetsSnapGrossIncomeTestDependency(SpmUnit):
-    field = "meets_snap_gross_income_test"
-    dependencies = (
-        "income_amount",
-        "income_frequency",
-        "household_size",
-    )
-
-    def value(self):
-        fpl = FederalPoveryLimit.objects.get(year="THIS YEAR").as_dict()
-        snap_gross_income = self.screen.calc_gross_income("yearly", ["all"])
-        snap_gross_limit = 2 * fpl[self.screen.household_size]
-
-        return snap_gross_income < snap_gross_limit
-
-
 class SnapAlwaysUseSuaDependency(SpmUnit):
     field = "snap_state_using_standard_utility_allowance"
 


### PR DESCRIPTION
What (if anything) did you refactor?
- Remove SNAP gross income test dependency because it is handled in PE.