### PR TITLE
Bug/NC Medicaid incorrect values 

### DIFF
--- a/programs/programs/nc/pe/member.py
+++ b/programs/programs/nc/pe/member.py
@@ -17,7 +17,7 @@ class NcMedicaid(Medicaid):
         "YOUNG_ADULT": 512,  # * 12 = 6146,  Medicaid Expansion Adults
         "PARENT": 0,
         "SSI_RECIPIENT": 0,
-        "AGED": 1086,  # * 12 = 13035, Medicaid for the Aged 
+        "AGED": 1086,  # * 12 = 13035, Medicaid for the Aged
         "DISABLED": 1519,  # * 12 = 18227, Medicaid for the Disabled
     }
 

--- a/programs/programs/nc/pe/member.py
+++ b/programs/programs/nc/pe/member.py
@@ -17,8 +17,8 @@ class NcMedicaid(Medicaid):
         "YOUNG_ADULT": 512,  # * 12 = 6146,  Medicaid Expansion Adults
         "PARENT": 0,
         "SSI_RECIPIENT": 0,
-        "AGED": 1519,  # * 12 = 13035, Medicaid for the Aged
-        "DISABLED": 1086,  # * 12 = 18227, Medicaid for the Disabled
+        "AGED": 1086,  # * 12 = 13035, Medicaid for the Aged 
+        "DISABLED": 1519,  # * 12 = 18227, Medicaid for the Disabled
     }
 
     pe_inputs = [


### PR DESCRIPTION
What (if anything) did you refactor?
- Corrected estimated values for 'Medicaid for Aged' and 'Medicaid for Disabled' in the NC Medicaid calculator.