### PR TITLE
Fix don't send to HubSpot for test screens

### DIFF
--- a/integrations/services/cms_integration.py
+++ b/integrations/services/cms_integration.py
@@ -56,7 +56,6 @@ class HubSpotIntegration(CmsIntegration):
         self._update_contact(self.user.external_id, data)
 
     def should_add(self):
-        return True
         if settings.DEBUG:
             return False
         if self.user is None or self.screen.is_test_data is None:


### PR DESCRIPTION
What (if anything) did you refactor?
- Restore the functionality of not sending test users to HubSpot.