### PR TITLE
Exclude cash assistance from certain programs

### DIFF
--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -202,7 +202,10 @@ class CoConfigurationData(ConfigurationData):
             "_label": "incomeOptions.sSDependent",
             "_default_message": "Social Security Dependent Benefits (retirement, disability, or survivors)",
         },
-        "cashAssistance": {"_label": "incomeOptions.cashAssistance", "_default_message": "Cash Assistance Grant"},
+        "cashAssistance": {
+            "_label": "incomeOptions.cashAssistance",
+            "_default_message": "Government Cash Assistance (including Colorado Works/TANF)",
+        },
         "gifts": {"_label": "incomeOptions.gifts", "_default_message": "Gifts/Contributions (Received)"},
         "investment": {
             "_label": "incomeOptions.investment",

--- a/programs/programs/co/child_care_assistance/calculator.py
+++ b/programs/programs/co/child_care_assistance/calculator.py
@@ -43,7 +43,7 @@ class ChildCareAssistance(ProgramCalculator):
 
         # income
         frequency = "yearly"
-        gross_income = self.screen.calc_gross_income(frequency, ["all"])
+        gross_income = self.screen.calc_gross_income(frequency, ["all"], ["cashAssistance"])
         deductions = self.screen.calc_expenses(frequency, ["childSupport"])
         net_income = gross_income - deductions
         fpl_percent = cccap_county_limits[county_name] / 100

--- a/programs/programs/co/connect_for_health/calculator.py
+++ b/programs/programs/co/connect_for_health/calculator.py
@@ -35,7 +35,7 @@ class ConnectForHealth(ProgramCalculator):
         # Income
         fpl = self.program.fpl.as_dict()
         income_band = int(fpl[self.screen.household_size] * ConnectForHealth.percent_of_fpl)
-        gross_income = int(self.screen.calc_gross_income("yearly", ("all",)))
+        gross_income = int(self.screen.calc_gross_income("yearly", ["all"], exclude=["cashAssistance"]))
         e.condition(gross_income < income_band, messages.income(gross_income, income_band))
 
     def member_eligible(self, e: MemberEligibility):

--- a/programs/programs/co/medicaid/family_planning_services/calculator.py
+++ b/programs/programs/co/medicaid/family_planning_services/calculator.py
@@ -24,7 +24,7 @@ class FamilyPlanningServices(ProgramCalculator):
         income_limit = int(
             FamilyPlanningServices.fpl_percent * fpl.get_limit(self.screen.household_size + len(e.eligible_members))
         )
-        gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
+        gross_income = int(self.screen.calc_gross_income("yearly", ["all"], exclude=["cashAssistance"]))
 
         e.condition(gross_income < income_limit, messages.income(gross_income, income_limit))
 

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -202,7 +202,7 @@ class CoTanfCountableGrossUnearnedIncomeDependency(SpmUnit):
     )
 
     def value(self):
-        return int(self.screen.calc_gross_income("yearly", ["unearned"]))
+        return int(self.screen.calc_gross_income("yearly", ["unearned"], exclude=["cashAssistance"]))
 
 
 class NcTanfCountableEarnedIncomeDependency(SpmUnit):

--- a/screener/models.py
+++ b/screener/models.py
@@ -105,12 +105,12 @@ class Screen(models.Model):
     def frozen(self):
         return self.validations.count() > 0
 
-    def calc_gross_income(self, frequency, types):
+    def calc_gross_income(self, frequency, types, exclude=[]):
         household_members = self.household_members.all()
         gross_income = 0
 
         for household_member in household_members:
-            gross_income += household_member.calc_gross_income(frequency, types)
+            gross_income += household_member.calc_gross_income(frequency, types, exclude)
         return float(gross_income)
 
     def calc_expenses(self, frequency, types):
@@ -413,12 +413,15 @@ class HouseholdMember(models.Model):
     has_income = models.BooleanField(blank=True, null=True)
     has_expenses = models.BooleanField(blank=True, null=True)
 
-    def calc_gross_income(self, frequency, types):
+    def calc_gross_income(self, frequency, types, exclude=[]):
         gross_income = 0
         earned_income_types = ["wages", "selfEmployment"]
 
         income_streams = self.income_streams.all()
         for income_stream in income_streams:
+            if income_stream.type in exclude:
+                continue
+
             include_all = "all" in types
             specific_match = income_stream.type in types
             earned_income_match = "earned" in types and income_stream.type in earned_income_types


### PR DESCRIPTION
What (if any) features are you implementing?
- Add `exclude` param to `calc_gross_income` method.

What (if anything) did you refactor?
- Refactor some programs to exclude cash assistance income.
- Rename the cash assistance income.

@msrezaie FYI, in case y'all want to do the same for some of the NC programs. The tax credits and Medicaid programs already had it excluded.