### PR TITLE
Remove FPL API request because it is broken

### DIFF
--- a/programs/models.py
+++ b/programs/models.py
@@ -58,6 +58,7 @@ class FplCache(Cache):
         """
         Get FPLs for all relevant years using the official ASPE Poverty Guidelines API
         """
+        return self.default
         fpls = FederalPoveryLimit.objects.filter(fpl__isnull=False).distinct()
         fpl_dict = {}
         for fpl in fpls:


### PR DESCRIPTION
What (if anything) did you refactor?
- Just return the default FPL and don't use the API for now.