### PR TITLE
Ignore frozen when pulling validations

### DIFF
--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -198,7 +198,7 @@ class ScreenSerializer(serializers.ModelSerializer):
         create_only_fields = ("external_id", "is_test", "referrer_code", "white_label")
 
     def __init__(self, *args, **kwargs):
-        self.force = kwargs.pop('force', False)
+        self.force = kwargs.pop("force", False)
         super().__init__(*args, **kwargs)
 
     def validate(self, attrs):

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -197,6 +197,10 @@ class ScreenSerializer(serializers.ModelSerializer):
         )
         create_only_fields = ("external_id", "is_test", "referrer_code", "white_label")
 
+    def __init__(self, *args, **kwargs):
+        self.force = kwargs.pop('force', False)
+        super().__init__(*args, **kwargs)
+
     def validate(self, attrs):
         white_label_code = attrs.pop("white_label")["code"]
         white_label = WhiteLabel.objects.get(code=white_label_code)

--- a/validations/management/commands/pull_validations.py
+++ b/validations/management/commands/pull_validations.py
@@ -1,11 +1,12 @@
 from django.core.management.base import BaseCommand
 from getpass import getpass
-import requests
 
+from django.db import transaction
 from screener.models import Screen
 from screener.serializers import ScreenSerializer
 from validations.models import Validation
 from validations.serializers import ValidationSerializer
+import requests
 
 
 class Command(BaseCommand):
@@ -18,6 +19,7 @@ class Command(BaseCommand):
             help="Domain of the environment to pull from",
         )
 
+    @transaction.atomic
     def handle(self, *args, **options):
         domain = options["domain"]
         api_key = getpass("API key: ")
@@ -42,7 +44,7 @@ class Command(BaseCommand):
         try:
             # update
             screen = Screen.objects.get(uuid=uuid)
-            serializer = ScreenSerializer(screen, data=remote_screen)
+            serializer = ScreenSerializer(screen, data=remote_screen, force=True)
         except Screen.DoesNotExist:
             # create
             serializer = ScreenSerializer(data=remote_screen)


### PR DESCRIPTION
What (if anything) did you refactor?
- Add a `force` kwarg to the screen serializer that lets you choose to ignore the frozen.
- Use the `force` kwarg to force update the screen when using `pull_validations`