### PR TITLE
Add energyCalculatorApplianceStatus to the stepDirectory

### DIFF
--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -1718,6 +1718,7 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                     "energyCalculatorHouseholdData",
                     "energyCalculatorElectricityProvider",
                     "energyCalculatorGasProvider",
+                    "energyCalculatorApplianceStatus",
                     "hasBenefits",
                 ],
                 "renter": [

--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -1728,7 +1728,6 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                     "energyCalculatorHouseholdData",
                     "energyCalculatorElectricityProvider",
                     "energyCalculatorGasProvider",
-                    "energyCalculatorApplianceStatus",
                     "hasBenefits",
                 ],
             }

--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -1728,6 +1728,7 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                     "energyCalculatorHouseholdData",
                     "energyCalculatorElectricityProvider",
                     "energyCalculatorGasProvider",
+                    "energyCalculatorApplianceStatus",
                     "hasBenefits",
                 ],
             }


### PR DESCRIPTION
What (if any) features are you implementing?
- I added the `energyCalculatorApplianceStatus` to the `default` `stepDirectory` inside the `co_energy_calculator`.
