### PR TITLE
Add friend to the referral_options

### DIFF
--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -165,6 +165,7 @@ class CoConfigurationData(ConfigurationData):
         "ccig": "Colorado Design Insight Group",
         "searchEngine": {"_label": "referralOptions.searchEngine", "_default_message": "Google or other search engine"},
         "socialMedia": {"_label": "referralOptions.socialMedia", "_default_message": "Social Media"},
+        "friend": {"_label": "referralOptions.friend", "_default_message": "Friend / Family / Word of Mouth"},
         "other": {"_label": "referralOptions.other", "_default_message": "Other"},
         "testOrProspect": {
             "_label": "referralOptions.testOrProspect",


### PR DESCRIPTION
What (if any) features are you implementing?
- I added `friend` to the `referral_options`. 

`Desktop`:
<img width="1728" alt="Screenshot 2025-02-28 at 2 07 43 PM" src="https://github.com/user-attachments/assets/ed376bd2-685d-4dbc-8c3d-5867dd371efc" />

`Mobile`: 
<img width="624" alt="Screenshot 2025-02-28 at 2 07 56 PM" src="https://github.com/user-attachments/assets/d6e17cb9-c2c3-46db-aff3-b3bc0733c584" />
