### PR TITLE
Bug/Missing NC zip code

### DIFF
--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -1576,6 +1576,9 @@ class NcConfigurationData(ConfigurationData):
             "Union County": "Union County",
             "Mecklenburg County": "Mecklenburg County",
         },
+        "28105": {
+            "Mecklenburg County": "Mecklenburg County",
+        },
         "28107": {
             "Union County": "Union County",
             "Stanly County": "Stanly County",


### PR DESCRIPTION
What (if anything) did you refactor?
- Added a missing zip code **28105** for the **Mecklenburg County** into the `nc.py` config file.