### PR TITLE
Resolved fpl calculations issue

### DIFF
--- a/programs/programs/nc/nc_crisis_intervention/calculator.py
+++ b/programs/programs/nc/nc_crisis_intervention/calculator.py
@@ -27,21 +27,25 @@ class NCCrisisIntervention(ProgramCalculator):
 
         # income
         gross_income = self.screen.calc_gross_income("yearly", ["all"])
-        income_limit = int(self.fpl_percent * self.program.year.as_dict()[household_size])
-        e.condition(gross_income < income_limit, messages.income(gross_income, income_limit))
+        income_limit = int(
+            self.fpl_percent * self.program.year.as_dict()[household_size]
+        )
+        e.condition(
+            gross_income < income_limit, messages.income(gross_income, income_limit)
+        )
 
     def household_value(self):
         household_size = self.screen.household_size
         gross_income = self.screen.calc_gross_income("yearly", ["all"])
-        income_limit = int(self.fpl_percent * self.program.year.as_dict()[household_size])
+        income_limit = int(self.program.year.as_dict()[household_size])
 
-        if household_size <= self.large_household_size:
-            if gross_income <= income_limit * self.max_value_fpl_percent:
-                return self.small_household_low_income_value
-            elif gross_income <= income_limit:
-                return self.small_household_large_income_value
-        else:
-            if gross_income <= income_limit * self.max_value_fpl_percent:
-                return self.large_household_low_income_value
-            elif gross_income <= income_limit:
-                return self.large_household_large_income_value
+        if household_size < self.large_household_size:  # 1-3 person household
+            if gross_income <= income_limit * self.max_value_fpl_percent:  # 0-50% FPL
+                return self.small_household_low_income_value  # $400/month
+            elif gross_income <= income_limit:  # 51%+ FPL
+                return self.small_household_large_income_value  # $300/month
+        else:  # 4+ person household
+            if gross_income <= income_limit * self.max_value_fpl_percent:  # 0-50% FPL
+                return self.large_household_low_income_value  # $500/month
+            elif gross_income <= income_limit:  # 51%+ FPL
+                return self.large_household_large_income_value  # $400/month

--- a/programs/programs/nc/nc_crisis_intervention/calculator.py
+++ b/programs/programs/nc/nc_crisis_intervention/calculator.py
@@ -27,12 +27,8 @@ class NCCrisisIntervention(ProgramCalculator):
 
         # income
         gross_income = self.screen.calc_gross_income("yearly", ["all"])
-        income_limit = int(
-            self.fpl_percent * self.program.year.as_dict()[household_size]
-        )
-        e.condition(
-            gross_income < income_limit, messages.income(gross_income, income_limit)
-        )
+        income_limit = int(self.fpl_percent * self.program.year.as_dict()[household_size])
+        e.condition(gross_income < income_limit, messages.income(gross_income, income_limit))
 
     def household_value(self):
         household_size = self.screen.household_size


### PR DESCRIPTION
What (if any) features are you implementing?
fixes #845 
-Resolved the fpl calculation issue. 
Monthly benefit amount depends on the # of people and income of the household:
1-3 person household and income 0-50% FPL= $400/month
1-3 person household and income 51%FPL + = $300/month
4+ person household and income 0-50% FPL = $500/month
4+person household and income 51%FPL+ = $400/month 

Example :
household_size = 1
income_limit = 15,650 * .05 (50% FPL) = 7,825
person gross income = 11,604 

Since the income of $11,604 is greater than $7,825 (50% FPL), this household should actually fall into the "1-3 person household and income 51%FPL+" category and receive $300/month not $400/month.
