### PR TITLE
Updated NC WIC estimated saving value

### DIFF
--- a/programs/programs/nc/pe/member.py
+++ b/programs/programs/nc/pe/member.py
@@ -27,11 +27,11 @@ class NcMedicaid(Medicaid):
 class NcWic(Wic):
     wic_categories = {
         "NONE": 0,
-        "INFANT": 130,
-        "CHILD": 26,
-        "PREGNANT": 47,
-        "POSTPARTUM": 47,
-        "BREASTFEEDING": 52,
+        "INFANT": 60,
+        "CHILD": 60,
+        "PREGNANT": 60,
+        "POSTPARTUM": 60,
+        "BREASTFEEDING": 60,
     }
     pe_inputs = [
         *Wic.pe_inputs,


### PR DESCRIPTION
Fixes issue #928 
What (if any) features are you implementing?
-changed estimated savings values in code for NC WIC to be $60/per person per month or all eligible children.
