### PR TITLE
Central: Add pull screen command

### DIFF
--- a/screener/management/commands/pull_screen.py
+++ b/screener/management/commands/pull_screen.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from decouple import config
 from getpass import getpass
 
 from django.db import transaction
@@ -26,7 +27,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         domain = options["domain"]
         uuid = options["uuid"]
-        api_key = getpass("API key: ")
+
+        api_key = config("DEV_API_KEY", "")
+        if not api_key:
+            api_key = getpass("API key: ")
 
         remote_screen = self._get_screen_from_remote(uuid, domain, api_key)
 

--- a/screener/management/commands/pull_screen.py
+++ b/screener/management/commands/pull_screen.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         screen.save()
 
         white_label = remote_screen.get("white_label", screen.white_label)
-        results_url = f"http://localhost:3000/{white_label}/{uuid}/step-3"
+        results_url = f"http://localhost:3000/{white_label}/{uuid}/results/benefits"
 
         self.stdout.write(f"Screen pulled successfully. Results: {results_url}")
 

--- a/screener/management/commands/pull_screen.py
+++ b/screener/management/commands/pull_screen.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand
+from getpass import getpass
+
+from django.db import transaction
+from screener.models import Screen
+from screener.serializers import ScreenSerializer
+import requests
+
+
+class Command(BaseCommand):
+    help = "Pull a single screen from a remote environment into the local database"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "domain",
+            nargs=None,
+            help="Domain of the environment to pull from",
+        )
+        parser.add_argument(
+            "uuid",
+            nargs=None,
+            help="UUID of the screen to pull",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        domain = options["domain"]
+        uuid = options["uuid"]
+        api_key = getpass("API key: ")
+
+        remote_screen = self._get_screen_from_remote(uuid, domain, api_key)
+
+        remote_screen.pop("user", None)
+
+        self._upsert_screen(uuid, remote_screen)
+
+    def _upsert_screen(self, uuid: str, remote_screen: dict):
+        try:
+            # update
+            screen = Screen.objects.get(uuid=uuid)
+            serializer = ScreenSerializer(screen, data=remote_screen, force=True)
+        except Screen.DoesNotExist:
+            # create
+            serializer = ScreenSerializer(data=remote_screen)
+
+        serializer.is_valid(raise_exception=True)
+
+        screen = serializer.save()
+
+        screen.uuid = uuid
+        screen.save()
+
+        self.stdout.write(f"Successfully pulled screen with UUID {uuid} into the local database.")
+
+    def _get_screen_from_remote(self, uuid: str, domain: str, api_key: str):
+        header = {
+            "Authorization": f"Token {api_key}",
+        }
+        response = requests.get(f"{domain}/api/screens/{uuid}", headers=header)
+
+        if response.status_code != 200:
+            self.stderr.write(f"Failed to fetch screen with UUID {uuid} from {domain}.")
+            self.stderr.write(f"Response: {response.status_code} - {response.text}")
+
+        return response.json()

--- a/validations/management/commands/pull_validations.py
+++ b/validations/management/commands/pull_validations.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from decouple import config
 from getpass import getpass
 
 from django.db import transaction
@@ -18,11 +19,21 @@ class Command(BaseCommand):
             nargs=None,
             help="Domain of the environment to pull from",
         )
+        parser.add_argument(
+            "--no-bypass",
+            action="store_true",
+            help="Do not use the environment variable for the API key; prompt for it instead.",
+        )
 
     @transaction.atomic
     def handle(self, *args, **options):
         domain = options["domain"]
-        api_key = getpass("API key: ")
+        if options["no_bypass"]:
+            api_key = getpass("API key: ")
+        else:
+            api_key = config("DEV_API_KEY", "")
+            if not api_key:
+                api_key = getpass("API key: ")
 
         response = requests.get(f"{domain}/api/validations")
 


### PR DESCRIPTION
What (if any) features are you implementing?
- Add `pull_screen` command to pull a screen from another environment to the current environment, given the uuid.

Any other comments, questions, or concerns?

- I tried removing the API key by setting `permission_classes = []` in `ScreenViewSet` and also setting `"DEFAULT_AUTHENTICATION_CLASSES" = []` in `settings.py`, after removing the API key prompt from the command. But I kept getting a 403 error: "Authentication credentials were not provided." Please let me know if there's anything I missed. Thanks.