### PR TITLE
Energy: Use urgent need category

### DIFF
--- a/configuration/management/commands/add_config.py
+++ b/configuration/management/commands/add_config.py
@@ -23,6 +23,15 @@ class Command(BaseCommand):
     @transaction.atomic
     def handle(self, *args, **options):
         white_labels_to_update = white_label_config.keys() if options["all"] else options["white_labels"]
+
+        if len(white_labels_to_update) == 0:
+            self.stdout.write(
+                self.style.ERROR(
+                    "No white labels selected. Use --all to select all white labels, or list them individually"
+                )
+            )
+            return
+
         for white_label_code in white_labels_to_update:
             if white_label_code not in white_label_config:
                 self.stdout.write(self.style.WARNING(f'White label for "{white_label_code}" does not exist'))

--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -1768,6 +1768,7 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                 "no_confirmation_return_zipcode",
                 "white_header",
                 "white_multi_select_tile_icon",
+                "dont_show_category_values",
             ]
         },
         "noResultMessage": {


### PR DESCRIPTION
What (if anything) did you refactor?
- Add feature flag `dont_show_category_values` to default to not showing the category values.
- Also, I finally got annoyed enough at the `--all` flag that I created a message if you don't select any white labels for the `add_config` command.