### PR TITLE
Central: Fix SNAP asset test

### DIFF
--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -13,7 +13,6 @@ class Snap(PolicyEngineSpmCalulator):
         dependency.spm.HasPhoneExpenseDependency,
         dependency.spm.HasHeatingCoolingExpenseDependency,
         dependency.spm.HeatingCoolingExpenseDependency,
-        dependency.spm.MeetsSnapAssetTestDependency,
         dependency.spm.SnapDependentCareDeductionDependency,
         dependency.spm.WaterExpenseDependency,
         dependency.spm.PhoneExpenseDependency,

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -65,13 +65,6 @@ class TakesUpSnapIfEligibleDependency(SpmUnit):
         return True
 
 
-class MeetsSnapAssetTestDependency(SpmUnit):
-    field = "meets_snap_asset_test"
-
-    def value(self):
-        return True
-
-
 class HasHeatingCoolingExpenseDependency(SpmUnit):
     field = "has_heating_cooling_expense"
 

--- a/validations/management/commands/pull_validations.py
+++ b/validations/management/commands/pull_validations.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 from decouple import config
 from getpass import getpass
-
 from django.db import transaction
 from screener.models import Screen
 from screener.serializers import ScreenSerializer


### PR DESCRIPTION
What (if anything) did you refactor?
- Remove SNAP asset override.

**We don't know why this was added originally. All of the validations passed though, so it can't be that bad**