### PR TITLE
Energy: Landing page logo link

### DIFF
--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -1773,6 +1773,7 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                 "white_header",
                 "white_multi_select_tile_icon",
                 "dont_show_category_values",
+                "logo_landing_page_link",
             ]
         },
         "noResultMessage": {


### PR DESCRIPTION
What (if any) features are you implementing?
- Add feature flag to make the header logo link go to the landing page.