### PR TITLE
Energy: Add new feature flags to Energy Calulator

### DIFF
--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -1834,6 +1834,8 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                 "dont_show_category_values",
                 "logo_landing_page_link",
                 "no_lets_get_started",
+                "help_bubble_always_open",
+                "small_header_language_dropdown",
             ]
         },
         "noResultMessage": {


### PR DESCRIPTION
What (if any) features are you implementing?
- Add `help_bubble_always_open` feature flag to always have the help bubbles open.
- Add `small_header_language_dropdown` feature flag to make the language dropdown on the header smaller.