### PR TITLE
Feat/1803 central create a script to update field value for any table

### DIFF
--- a/programs/management/commands/category_icon_updates.json
+++ b/programs/management/commands/category_icon_updates.json
@@ -1,0 +1,12 @@
+{
+    "food or groceries": "food_groceries",
+    "baby supplies": "baby_supplies",
+    "managing housing costs": "managing_housing",
+    "behavioral health": "Support",
+    "child's development": "Child_development",
+    "family planning": "family_planning",
+    "job resources": "job_resources",
+    "low-cost dental care": "Dental_care",
+    "civil legal needs": "Legal_services",
+    "veterans resources": "Military"
+}

--- a/programs/management/commands/update_field_values.py
+++ b/programs/management/commands/update_field_values.py
@@ -1,0 +1,106 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.apps import apps
+import json
+import os
+
+
+class Command(BaseCommand):
+    help = "Update field values in any table based on mapping"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'model',
+            type=str,
+            help='Model name (e.g., CategoryIconName, Program, etc.)'
+        )
+        parser.add_argument(
+            'field',
+            type=str,
+            help='Field name to update'
+        )
+        parser.add_argument(
+            'mapping_file',
+            type=str,
+            help='JSON file containing old->new value mappings'
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would be updated without making changes'
+        )
+
+    def handle(self, *args, **options):
+        try:
+            # Get the model class dynamically
+            app_label = 'programs'  # Default to programs app
+            model_name = options['model']
+            Model = apps.get_model(app_label, model_name)
+            
+            # Get absolute path for the mapping file
+            mapping_file = options['mapping_file']
+            if not os.path.isabs(mapping_file):
+                base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+                mapping_file = os.path.join(base_dir, mapping_file)
+
+            # Load the mapping file
+            with open(options['mapping_file'], 'r') as f:
+                value_mapping = json.load(f)
+
+            field_name = options['field']
+            dry_run = options['dry_run']
+
+            self.stdout.write(f"Updating {model_name}.{field_name} values...")
+
+            with transaction.atomic():
+                updated_count = 0
+                for old_value, new_value in value_mapping.items():
+                    # Create filter kwargs dynamically
+                    filter_kwargs = {
+                        f"{field_name}__iexact": old_value
+                    }
+                    
+                    # Create update kwargs dynamically
+                    update_kwargs = {
+                        field_name: new_value
+                    }
+
+                    # Get matching records
+                    records = Model.objects.filter(**filter_kwargs)
+                    count = records.count()
+                    
+                    if count:
+                        if dry_run:
+                            self.stdout.write(
+                                self.style.SUCCESS(
+                                    f'Would update "{old_value}" to "{new_value}" ({count} records)'
+                                )
+                            )
+                        else:
+                            records.update(**update_kwargs)
+                            self.stdout.write(
+                                self.style.SUCCESS(
+                                    f'Updated "{old_value}" to "{new_value}" ({count} records)'
+                                )
+                            )
+                        updated_count += count
+
+                if dry_run:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f'Would update {updated_count} records (dry run)'
+                        )
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f'Successfully updated {updated_count} records'
+                        )
+                    )
+
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(
+                    f'Error updating values: {str(e)}'
+                )
+            )

--- a/programs/management/commands/update_field_values.py
+++ b/programs/management/commands/update_field_values.py
@@ -9,46 +9,30 @@ class Command(BaseCommand):
     help = "Update field values in any table based on mapping"
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            'model',
-            type=str,
-            help='Model name (e.g., CategoryIconName, Program, etc.)'
-        )
-        parser.add_argument(
-            'field',
-            type=str,
-            help='Field name to update'
-        )
-        parser.add_argument(
-            'mapping_file',
-            type=str,
-            help='JSON file containing old->new value mappings'
-        )
-        parser.add_argument(
-            '--dry-run',
-            action='store_true',
-            help='Show what would be updated without making changes'
-        )
+        parser.add_argument("model", type=str, help="Model name (e.g., CategoryIconName, Program, etc.)")
+        parser.add_argument("field", type=str, help="Field name to update")
+        parser.add_argument("mapping_file", type=str, help="JSON file containing old->new value mappings")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would be updated without making changes")
 
     def handle(self, *args, **options):
         try:
             # Get the model class dynamically
-            app_label = 'programs'  # Default to programs app
-            model_name = options['model']
+            app_label = "programs"  # Default to programs app
+            model_name = options["model"]
             Model = apps.get_model(app_label, model_name)
-            
+
             # Get absolute path for the mapping file
-            mapping_file = options['mapping_file']
+            mapping_file = options["mapping_file"]
             if not os.path.isabs(mapping_file):
                 base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
                 mapping_file = os.path.join(base_dir, mapping_file)
 
             # Load the mapping file
-            with open(options['mapping_file'], 'r') as f:
+            with open(options["mapping_file"], "r") as f:
                 value_mapping = json.load(f)
 
-            field_name = options['field']
-            dry_run = options['dry_run']
+            field_name = options["field"]
+            dry_run = options["dry_run"]
 
             self.stdout.write(f"Updating {model_name}.{field_name} values...")
 
@@ -56,51 +40,31 @@ class Command(BaseCommand):
                 updated_count = 0
                 for old_value, new_value in value_mapping.items():
                     # Create filter kwargs dynamically
-                    filter_kwargs = {
-                        f"{field_name}__iexact": old_value
-                    }
-                    
+                    filter_kwargs = {f"{field_name}__iexact": old_value}
+
                     # Create update kwargs dynamically
-                    update_kwargs = {
-                        field_name: new_value
-                    }
+                    update_kwargs = {field_name: new_value}
 
                     # Get matching records
                     records = Model.objects.filter(**filter_kwargs)
                     count = records.count()
-                    
+
                     if count:
                         if dry_run:
                             self.stdout.write(
-                                self.style.SUCCESS(
-                                    f'Would update "{old_value}" to "{new_value}" ({count} records)'
-                                )
+                                self.style.SUCCESS(f'Would update "{old_value}" to "{new_value}" ({count} records)')
                             )
                         else:
                             records.update(**update_kwargs)
                             self.stdout.write(
-                                self.style.SUCCESS(
-                                    f'Updated "{old_value}" to "{new_value}" ({count} records)'
-                                )
+                                self.style.SUCCESS(f'Updated "{old_value}" to "{new_value}" ({count} records)')
                             )
                         updated_count += count
 
                 if dry_run:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f'Would update {updated_count} records (dry run)'
-                        )
-                    )
+                    self.stdout.write(self.style.SUCCESS(f"Would update {updated_count} records (dry run)"))
                 else:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f'Successfully updated {updated_count} records'
-                        )
-                    )
+                    self.stdout.write(self.style.SUCCESS(f"Successfully updated {updated_count} records"))
 
         except Exception as e:
-            self.stdout.write(
-                self.style.ERROR(
-                    f'Error updating values: {str(e)}'
-                )
-            )
+            self.stdout.write(self.style.ERROR(f"Error updating values: {str(e)}"))


### PR DESCRIPTION
What (if any) features are you implementing?
Added the update_field_values script to update field values in any table by passing the table name, field name, and a JSON file containing the updated values.

Step to run the script:
You’ll need a JSON file containing the field values to be changed. This script allows you to update field values in any table.

For example, to update the name field in the CategoryIconName table using values from category_icon_updates.json:
```
# Dry run to preview the changes
python manage.py update_field_values CategoryIconName name category_icon_updates.json --dry-run

# Apply the updates
python manage.py update_field_values CategoryIconName name category_icon_updates.json
```
