### PR TITLE
Chore/Add `django-simple-history` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ django-parler==2.3
 django-parler-rest==2.2
 django-phonenumber-field==6.3.0
 django-sesame==3.1
+django-simple-history==3.10.1
 django-unfold==0.62.0
 djangorestframework==3.15.2
 drf-yasg==1.21.7


### PR DESCRIPTION
What (if anything) did you refactor?
- Added `django-simple-history` to requirements.txt.

Parent PR [#1054](https://github.com/Gary-Community-Ventures/benefits-api/pull/1054).