### PR TITLE
Chore/Add defaultLanguage to white label configurations

### DIFF
--- a/configuration/white_labels/_default.py
+++ b/configuration/white_labels/_default.py
@@ -43,6 +43,7 @@ class DefaultConfigurationData(ConfigurationData):
                 "_default_message": "It looks like you may not qualify for benefits included in MyFriendBen at this time. If you indicated need for an immediate resource, please click on the “Near-Term Benefits” tab. For additional resources, please click the 'More Help' button below to get the resources you’re looking for.",
             },
         },
+        "defaultLanguage": {"default": "en-us"},
     }
 
     footer_data = {

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -436,6 +436,7 @@ class ConfigurationData:
             "[REPLACE_ME]": [],
         },
         "featureFlags": {"default": []},
+        "defaultLanguage": {"default": "en-us", "[REPLACE_ME]": ""},
     }
 
     footer_data = {

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -2346,6 +2346,7 @@ class CoConfigurationData(ConfigurationData):
                 "_default_message": "It looks like you may not qualify for benefits included in MyFriendBen at this time. If you indicated need for an immediate resource, please click on the \"Near-Term Benefits\" tab. For additional resources, please click the 'More Help' button below to get the resources you're looking for.",
             },
         },
+        "defaultLanguage": {"default": "en-us"},
     }
 
     footer_data = {

--- a/configuration/white_labels/co_energy_calculator.py
+++ b/configuration/white_labels/co_energy_calculator.py
@@ -2301,6 +2301,7 @@ class CoEnergyCalculatorConfigurationData(ConfigurationData):
                 "_default_message": 'It looks like you may not qualify for programs in this tool at this time. To see other resources, click the "More Help" link below.',
             },
         },
+        "defaultLanguage": {"default": "en-us"},
     }
 
     footer_data = {

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -2356,6 +2356,7 @@ class IlConfigurationData(ConfigurationData):
                 "_default_message": "It looks like you may not qualify for benefits included in MyFriendBen at this time. If you indicated need for an immediate resource, please click on the \"Near-Term Benefits\" tab. For additional resources, please click the 'More Help' button below to get the resources you're looking for.",
             },
         },
+        "defaultLanguage": {"default": "en-us"},
     }
 
     footer_data = {

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -1416,6 +1416,7 @@ class MaConfigurationData(ConfigurationData):
                 "_default_message": "It looks like you may not qualify for benefits included in MyFriendBen at this time. If you indicated need for an immediate resource, please click on the “Near-Term Benefits” tab. For additional resources, please click the 'More Help' button below to get the resources you’re looking for.",
             },
         },
+        "defaultLanguage": {"default": "en-us"},
     }
 
     footer_data = {

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -2885,6 +2885,10 @@ class NcConfigurationData(ConfigurationData):
                 "_default_message": "It looks like you may not qualify for benefits included in MyFriendBen at this time. If you indicated need for an immediate resource, please click on the “Near-Term Benefits” tab.",
             }
         },
+        "defaultLanguage": {
+            "default": "en-us",
+            "hfed": "es",
+        },
     }
 
     footer_data = {


### PR DESCRIPTION
Related frontend PR [#1889](https://github.com/Gary-Community-Ventures/benefits-calculator/pull/1889).

What (if anything) did you refactor?
- Added a `defaultLanguage` in all whitelabel config files.
- Added `es` for `hfed` cobrand/referrer. This will set the default language of Hispanic Federation cobrand to Spanish.

Any other comments, questions, or concerns?
Please run the following to update all config records:
```
python manage.py add_config --all
```