### PR TITLE
Revert SSI member change

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -108,9 +108,6 @@ class Medicaid(Member):
 class Ssi(Member):
     field = "ssi"
 
-    def value(self):
-        return self.member.calc_gross_income("yearly", ["sSI"])
-
 
 class IsDisabledDependency(Member):
     field = "is_disabled"


### PR DESCRIPTION
## Context & Motivation

```
"ssi": {
  "2025": null
}

# to...
"ssi": {
  "2025": 0.0
}
```

[The NC Work First change](https://github.com/MyFriendBen/benefits-api/pull/1119) caused an unexpected issue with SSI. When we send a `null` value we get back SSI from PE. However, if we send `0.0`, which from a human standpoint is the same, Policy Engine sees this as someone receiving the benefit and therefore returns nothing for SSI.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- revert the change

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: 

## Deployment

<!-- Steps needed AFTER merging to get this live -->

- Run script:
- Update production config:
- Admin updates needed:
- Notify team/users of:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Illinois Eviction Help urgent-need checker; eligible when the household reports rent expenses.

- Refactor
  - Standardized presumptive eligibility checks across IL transportation-related programs.
  - IL Benefit Access: eligibility now considers households up to size 3 and updated income limits by household size (values unchanged).
  - IL Transit Reduced Fare: eligibility now requires residence in Cook, DuPage, Kane, Lake, McHenry, or Will counties, plus meeting presumptive or income criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->