### PR TITLE
Central:  Fix SSI recipient household size bug in NC work first

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -107,10 +107,15 @@ class Medicaid(Member):
 
 class Ssi(Member):
     field = "ssi"
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
 
     def value(self):
-        sSi = self.member.calc_gross_income("yearly", ["sSI"])
-        return None if sSi == 0 else sSi
+        ssi = self.member.calc_gross_income("yearly", ["sSI"])
+        return None if ssi == 0 else ssi
 
 
 class IsDisabledDependency(Member):


### PR DESCRIPTION
## Context & Motivation

We previously applied [a fix](https://github.com/MyFriendBen/benefits-api/pull/1119) for the incorrect household size issue by sending the SSI value to PE. However, for members without an SSI value, we sent `0.0` instead of `None`, which caused PE to return incorrect responses.

With this update, if the SSI value is `0`, we will now send `None` instead.

I’ve tested this locally using the [two failed co ssi](https://docs.google.com/spreadsheets/d/1JRsCKm9KeeatVoW3wjsT2YqSy63js53Ib3vivK5NFYY/edit?gid=1044361438#gid=1044361438&range=A56) household scenarios logged on 8/29/2025. 

- Fixes https://linear.app/myfriendben/issue/MFB-79/nc-fix-ssi-recipienthousehold-size-bug-in-nc-work-first
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1119

## Testing

<!-- Steps needed to test this PR locally -->

- Manual testing steps:
    - Enter or retrieve the household data mentioned above, then verify on the results page that the SSI value displays correctly.
    - Retest the two households from [the original ticket](https://linear.app/myfriendben/issue/MFB-79/nc-fix-ssi-recipienthousehold-size-bug-in-nc-work-first) and verify the returned NC Work First value is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SSI for members is now automatically computed from yearly income, reducing manual data entry and improving consistency across calculations and reports.
- **Bug Fixes**
  - Members with no SSI are no longer shown with a zero amount; they are treated as not applicable, improving accuracy in summaries and eligibility outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->