### PR TITLE
Fixed failing Medicaid Validations in staging.

### DIFF
--- a/programs/programs/nc/pe/member.py
+++ b/programs/programs/nc/pe/member.py
@@ -18,8 +18,8 @@ class NcMedicaid(Medicaid):
         "OLDER_CHILD": 372,  # * 12 = 4464,  Medicaid for Children
         "PREGNANT": 1045,  # * 12 = 12536, Medicaid for Pregnant Women
         "YOUNG_ADULT": 512,  # * 12 = 6146,  Medicaid Expansion Adults
-        "PARENT": 512,      # * 12 = 6146,  Medicaid Expansion Parents
-        "SSI_RECIPIENT": 1519, # * 12 = 18227,  Medicaid Expansion Parents
+        "PARENT": 512,  # * 12 = 6146,  Medicaid Expansion Parents
+        "SSI_RECIPIENT": 1519,  # * 12 = 18227,  Medicaid Expansion Parents
         "AGED": 1086,  # * 12 = 13035, Medicaid for the Aged
         "DISABLED": 1519,  # * 12 = 18227, Medicaid for the Disabled
     }

--- a/programs/programs/nc/pe/member.py
+++ b/programs/programs/nc/pe/member.py
@@ -18,8 +18,8 @@ class NcMedicaid(Medicaid):
         "OLDER_CHILD": 372,  # * 12 = 4464,  Medicaid for Children
         "PREGNANT": 1045,  # * 12 = 12536, Medicaid for Pregnant Women
         "YOUNG_ADULT": 512,  # * 12 = 6146,  Medicaid Expansion Adults
-        "PARENT": 0,
-        "SSI_RECIPIENT": 0,
+        "PARENT": 512,
+        "SSI_RECIPIENT": 1519,
         "AGED": 1086,  # * 12 = 13035, Medicaid for the Aged
         "DISABLED": 1519,  # * 12 = 18227, Medicaid for the Disabled
     }

--- a/programs/programs/nc/pe/member.py
+++ b/programs/programs/nc/pe/member.py
@@ -18,8 +18,8 @@ class NcMedicaid(Medicaid):
         "OLDER_CHILD": 372,  # * 12 = 4464,  Medicaid for Children
         "PREGNANT": 1045,  # * 12 = 12536, Medicaid for Pregnant Women
         "YOUNG_ADULT": 512,  # * 12 = 6146,  Medicaid Expansion Adults
-        "PARENT": 512,
-        "SSI_RECIPIENT": 1519,
+        "PARENT": 512,      # * 12 = 6146,  Medicaid Expansion Parents
+        "SSI_RECIPIENT": 1519, # * 12 = 18227,  Medicaid Expansion Parents
         "AGED": 1086,  # * 12 = 13035, Medicaid for the Aged
         "DISABLED": 1519,  # * 12 = 18227, Medicaid for the Disabled
     }


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [#MFB-860](https://linear.app/myfriendben/issue/MFB-860/nc-investigate-failed-medicaid-validations-in-staging)
- Related PR: [link if applicable]

fix: add missing PARENT and SSI_RECIPIENT income limits to NC Medicaid

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

Fixed failing Medicaid validations in staging by updating Medicaid Categories values
fix: add missing PARENT and SSI_RECIPIENT income limits to NC Medicaid

A recent change in this [Policyengine PR](https://github.com/PolicyEngine/policyengine-us/pull/7272/changes) - reordered how Medicaid eligibility categories are assigned. Two categories — PARENT and SSI_RECIPIENT — that previously had placeholder values of 0 in NC's Medicaid configuration are now actively returned by PolicyEngine for NC households, causing Medicaid benefit values to calculate as $0 and fail validation.

Root Cause: PolicyEngine category priority reorder

In PolicyEngine-us commit [793dca36](https://github.com/PolicyEngine/policyengine-us/commit/793dca36b2) ("Fix Medicaid category assignment order per federal regulations", Jan 28 2026), the medicaid_category variable was updated to evaluate eligibility categories in federally-mandated priority order (per 42 CFR Part 435). Two key changes affected NC households:

SSI_RECIPIENT :  1st postion (old : 8th position) 
effect : Disabled individuals who qualify as SSI recipients now receive this category instead of a lower-priority child/disabled category

PARENT : 5th position (old:  6th position) 
effect : Adults with dependent children now receive PARENT instead of ADULT

**Why the validation was failing**
One failing test case:
Test household: ZIP 27006, 2 people

Person 1: DOB 01/1984, $2,000/month wages (no conditions)
Person 2: DOB 01/2020 (child), disabled, no income

**Before the PolicyEngine change:**

Person 1 → ADULT category (value: 512) 
Person 2 → YOUNG_CHILD/OLDER_CHILD category (value: 372) 

**After the PolicyEngine change:**

Person 1 → PARENT category (was 0 in NC config) 
Person 2 → SSI_RECIPIENT category (was 0 in NC config) 

Because PARENT and SSI_RECIPIENT set values to 0 in NcMedicaid.medicaid_categories, so it returned $0 Medicaid eligibility value for both household members, causing the staging validation to fail.

This PR changes is align with NC Medicaid income thresholds: parents follow the same Medicaid Expansion limit as adults (138% FPL), and SSI recipients follow the same limit as the disabled category already present in the config.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:

Validated against the failing household (ZIP 27006, adult parent + disabled child) on staging after this change. Medicaid benefit values now calculate correctly for both household members.

HH 1:

[HH 1](https://screener.myfriendben.org/nc/54aa8943-7571-419f-a490-8d7290f3b732/results/benefits/182/?admin=true) = 3 people, zip code 27006, Person 1: 01/1984 No insurance/conditions, $3,000/month in wages; Person 2: Spouse, 01/1984, no insurance, disabled, no income, Person 3, child 01/2013, no insurance; no expenses/resources

Household should be eligible for $2,403/month for Medicaid (Child $372+disabled $1,519+adult $512). 

Staging results show household as eligible for $1819/month, meaning the non-disabled adult is ineligible for Medicaid ($512/month), which is wrong.


HH 2:

[HH 2](https://screener.myfriendben.org/nc/12943201-1e45-44f2-898f-d5a2cd622cda/results/benefits/182/?admin=true) = 2 people, zip code 27006, Person 1: 01/1984 No insurance/conditions, $2,000/month in wages; Person 2: child 01/2020, no insurance, disabled, no income, no expenses/resources

Household should be eligible for $2,031/month for Medicaid (disabled child $1,519+adult $512).

Staging results show household as eligible for $1519/month, meaning the non-disabled adult is ineligible for Medicaid ($512/month), which is wrong.
## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: None
- Future considerations: None
