### PR TITLE
MFB-849: Add WIC to Washington

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_wic_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wic_initial_config.json
@@ -11,14 +11,17 @@
         "legal_status_required": ["citizen", "non_citizen", "refugee", "gc_5plus", "gc_18plus_no5", "gc_under18_no5", "otherWithWorkPermission"],
         "name": "Women, Infants, and Children (WIC) Nutrition Program",
         "description_short": "Food and nutrition help for pregnant and breastfeeding people and for families with children under 5 years of age.",
-        "description": "Food and nutrition help for pregnant and breastfeeding people and for families with children under 5 years of age.\n\nWIC provides healthy food, breastfeeding support, nutrition information, and referrals to other services. Pregnant people and children under 5 may qualify. New moms may qualify if they had a baby in the last 6 months or are breastfeeding a child under 1.\n\nWIC helps you buy fruits and vegetables, whole grains, iron-rich foods, milk, cheese, yogurt, eggs, canned fish, baby formula, and more. Your income must be at or below 185% of the federal poverty level. If you already receive SNAP, Medicaid, or TANF, you automatically meet the income requirement and do not need to provide proof of income.\n\nWashington WIC is open to all residents regardless of immigration status. To apply, contact your local WIC office. You will complete a nutrition and health assessment at your first appointment. Benefits can begin the same day in some cases.\n\nFor more information and to find your local WIC office, visit the Washington State Department of Health website.",
+        "description": "WIC provides healthy food, breastfeeding support, nutrition information, and referrals to other services for pregnant and breastfeeding people and for families with children under 5 years of age.\n\nEach month, WIC loads money onto a card you can use at grocery stores to buy specific foods like fruits and vegetables, whole grains, milk, eggs, cheese, yogurt, canned fish, peanut butter, and baby formula. The foods available to you depend on your situation — a pregnant person gets a different set than a toddler does.\n\nWIC also offers breastfeeding support (including free breast pumps), nutrition advice at regular check-in appointments, and help connecting to other programs like Medicaid or SNAP if you need them.\n\nClick \"Apply Now\" to learn more and contact your local WIC office to apply. You will complete a nutrition and health assessment at your first appointment. Benefits can begin the same day in some cases.",
         "learn_more_link": "https://doh.wa.gov/you-and-your-family/wic/wic-eligibility",
         "apply_button_link": "https://doh.wa.gov/you-and-your-family/wic/wic-eligibility",
-        "apply_button_description": "Apply for WA WIC",
+        "apply_button_description": "",
         "estimated_application_time": "60 minutes",
         "estimated_delivery_time": "Same day to 2 weeks",
-        "estimated_value": "Varies; typically $50 - $165 per person per month",
-        "website_description": "Free healthy food and nutrition support for pregnant women, babies, and children under 5"
+        "estimated_value": "",
+        "website_description": "Free healthy food and nutrition support for pregnant women, babies, and children under 5",
+        "has_calculator": true,
+        "show_in_has_benefits_step": true,
+        "show_on_current_benefits": true
     },
     "documents": [
         {

--- a/programs/management/commands/import_program_config_data/data/wa_wic_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wic_initial_config.json
@@ -1,0 +1,56 @@
+{
+    "white_label": {"code": "wa"},
+    "program_category": {
+        "external_name": "wa_food",
+        "name": "Food and Nutrition",
+        "icon": "food"
+    },
+    "program": {
+        "name_abbreviated": "wa_wic",
+        "year": "2025",
+        "legal_status_required": ["citizen", "non_citizen", "refugee", "gc_5plus", "gc_18plus_no5", "gc_under18_no5", "otherWithWorkPermission"],
+        "name": "Women, Infants, and Children (WIC) Nutrition Program",
+        "description_short": "Food and nutrition help for pregnant and breastfeeding people and for families with children under 5 years of age.",
+        "description": "Food and nutrition help for pregnant and breastfeeding people and for families with children under 5 years of age.\n\nWIC provides healthy food, breastfeeding support, nutrition information, and referrals to other services. Pregnant people and children under 5 may qualify. New moms may qualify if they had a baby in the last 6 months or are breastfeeding a child under 1.\n\nWIC helps you buy fruits and vegetables, whole grains, iron-rich foods, milk, cheese, yogurt, eggs, canned fish, baby formula, and more. Your income must be at or below 185% of the federal poverty level. If you already receive SNAP, Medicaid, or TANF, you automatically meet the income requirement and do not need to provide proof of income.\n\nWashington WIC is open to all residents regardless of immigration status. To apply, contact your local WIC office. You will complete a nutrition and health assessment at your first appointment. Benefits can begin the same day in some cases.\n\nFor more information and to find your local WIC office, visit the Washington State Department of Health website.",
+        "learn_more_link": "https://doh.wa.gov/you-and-your-family/wic/wic-eligibility",
+        "apply_button_link": "https://doh.wa.gov/you-and-your-family/wic/wic-eligibility",
+        "apply_button_description": "Apply for WA WIC",
+        "estimated_application_time": "60 minutes",
+        "estimated_delivery_time": "Same day to 2 weeks",
+        "estimated_value": "Varies; typically $50 - $165 per person per month",
+        "website_description": "Free healthy food and nutrition support for pregnant women, babies, and children under 5"
+    },
+    "documents": [
+        {
+            "external_name": "wa_home",
+            "text": "Proof of Washington home address (ex: lease, utility bill, official mail)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_id_proof",
+            "text": "Proof of identity (ex: driver's license, official state ID, passport)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_earned_income",
+            "text": "Proof of earned income (ex: pay stubs, tax returns, W-2, 1099)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_unearned_income",
+            "text": "Proof of unearned income (ex: child support, social security, unemployment)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_other_program",
+            "text": "Evidence of participation in SNAP, Medicaid, or TANF (if applicable — waives income verification)",
+            "link_url": "",
+            "link_text": ""
+        }
+    ],
+    "navigators": []
+}

--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -1,32 +1,7 @@
 from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
+from programs.programs.federal.pe.spm import Snap
 import programs.programs.policyengine.calculators.dependencies as dependency
 from screener.models import HouseholdMember
-
-
-class Wic(PolicyEngineMembersCalculator):
-    wic_categories = {
-        "NONE": 0,
-        "INFANT": 0,
-        "CHILD": 0,
-        "PREGNANT": 0,
-        "POSTPARTUM": 0,
-        "BREASTFEEDING": 0,
-    }
-    pe_name = "wic"
-    pe_inputs = [
-        dependency.member.PregnancyDependency,
-        dependency.member.ExpectedChildrenPregnancyDependency,
-        dependency.member.AgeDependency,
-        dependency.spm.SchoolMealCountableIncomeDependency,
-    ]
-    pe_outputs = [dependency.member.Wic, dependency.member.WicCategory]
-
-    def member_value(self, member: HouseholdMember):
-        if self.get_member_variable(member.id) <= 0:
-            return 0
-
-        wic_category = self.get_member_dependency_value(dependency.member.WicCategory, member.id)
-        return self.wic_categories[wic_category] * 12
 
 
 class Medicaid(PolicyEngineMembersCalculator):
@@ -93,6 +68,36 @@ class Medicaid(PolicyEngineMembersCalculator):
         medicaid_category = self.get_member_dependency_value(dependency.member.MedicaidCategory, member.id)
 
         return self.medicaid_categories[medicaid_category] * 12
+
+
+class Wic(PolicyEngineMembersCalculator):
+    wic_categories = {
+        "NONE": 0,
+        "INFANT": 0,
+        "CHILD": 0,
+        "PREGNANT": 0,
+        "POSTPARTUM": 0,
+        "BREASTFEEDING": 0,
+    }
+    pe_name = "wic"
+    pe_inputs = [
+        dependency.member.PregnancyDependency,
+        dependency.member.ExpectedChildrenPregnancyDependency,
+        dependency.member.AgeDependency,
+        dependency.spm.SchoolMealCountableIncomeDependency,
+        *Snap.pe_inputs,  # categorical eligibility
+        *Medicaid.pe_inputs,  # categorical eligibility
+        # NOTE: TANF changes by state, so we can't capture categorical
+        # eligibility for it here like we do for SNAP and Medicaid
+    ]
+    pe_outputs = [dependency.member.Wic, dependency.member.WicCategory]
+
+    def member_value(self, member: HouseholdMember):
+        if self.get_member_variable(member.id) <= 0:
+            return 0
+
+        wic_category = self.get_member_dependency_value(dependency.member.WicCategory, member.id)
+        return self.wic_categories[wic_category] * 12
 
 
 class Chip(PolicyEngineMembersCalculator):

--- a/programs/programs/policyengine/calculators/registry.py
+++ b/programs/programs/policyengine/calculators/registry.py
@@ -41,6 +41,7 @@ from programs.programs.tx.pe import (
     tx_spm_calculators,
     tx_tax_unit_calculators,
 )
+from programs.programs.wa.pe import wa_member_calculators
 
 all_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
     **co_member_calculators,
@@ -49,6 +50,7 @@ all_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
     **ma_member_calculators,
     **nc_member_calculators,
     **tx_member_calculators,
+    **wa_member_calculators,
 }
 
 all_spm_unit_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {

--- a/programs/programs/wa/pe/__init__.py
+++ b/programs/programs/wa/pe/__init__.py
@@ -1,3 +1,10 @@
+import programs.programs.wa.pe.member as member
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
 
-wa_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {}
+wa_member_calculators = {
+    "wa_wic": member.WaWic,
+}
+
+wa_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {
+    **wa_member_calculators,
+}

--- a/programs/programs/wa/pe/member.py
+++ b/programs/programs/wa/pe/member.py
@@ -1,0 +1,27 @@
+from programs.programs.federal.pe.member import Wic
+import programs.programs.policyengine.calculators.dependencies as dependency
+
+
+class WaWic(Wic):
+    # WIC uses a hybrid model: fixed Cash Value Benefit (CVB) for produce + quantity-based
+    # food credits (milk, eggs, cereal, formula, etc.) estimated at local WA retail prices.
+    # Total = CVB + estimated retail cost of food quantities. FY 2025/2026 values.
+    #
+    # INFANT ($135): No CVB; entire value is infant formula (~9 cans/mo) + jarred foods.
+    # BREASTFEEDING ($114): Highest adult package — max CVB ($52) + expanded food (canned
+    #   fish, extra cheese, double eggs).
+    # PREGNANT ($92): $47 CVB + $45 food (larger dairy/grain package than postpartum).
+    # POSTPARTUM ($78): $47 CVB + $31 food (reduced dairy/grains vs. pregnant).
+    # CHILD ($68): $26 CVB + $42 food.
+    wic_categories = {
+        "NONE": 0,
+        "INFANT": 135,
+        "CHILD": 68,
+        "PREGNANT": 92,
+        "POSTPARTUM": 78,
+        "BREASTFEEDING": 114,
+    }
+    pe_inputs = [
+        *Wic.pe_inputs,
+        dependency.household.NcStateCodeDependency,
+    ]

--- a/programs/programs/wa/pe/member.py
+++ b/programs/programs/wa/pe/member.py
@@ -3,16 +3,19 @@ import programs.programs.policyengine.calculators.dependencies as dependency
 
 
 class WaWic(Wic):
-    # WIC uses a hybrid model: fixed Cash Value Benefit (CVB) for produce + quantity-based
-    # food credits (milk, eggs, cereal, formula, etc.) estimated at local WA retail prices.
-    # Total = CVB + estimated retail cost of food quantities. FY 2025/2026 values.
-    #
-    # INFANT ($135): No CVB; entire value is infant formula (~9 cans/mo) + jarred foods.
-    # BREASTFEEDING ($114): Highest adult package — max CVB ($52) + expanded food (canned
-    #   fish, extra cheese, double eggs).
-    # PREGNANT ($92): $47 CVB + $45 food (larger dairy/grain package than postpartum).
-    # POSTPARTUM ($78): $47 CVB + $31 food (reduced dairy/grains vs. pregnant).
-    # CHILD ($68): $26 CVB + $42 food.
+    class NotTanfEligibility(dependency.spm.SpmUnit):
+        # TODO: remove this when we add calculation for WaTanf
+        # the issue is that we can't add tanf to the base class
+        # like we did for SNAP because TANF differs by state
+        field = "wa_tanf"
+
+        def value(self):
+            return 0
+
+    # Monthly values per participant category. Hybrid model: fixed Cash Value
+    # Benefit (CVB) for produce + estimated retail cost of the quantity-based
+    # food package (milk, eggs, cereal, formula, etc.). See spec.md "Benefit
+    # Value" section for the CVB/food split and citations.
     wic_categories = {
         "NONE": 0,
         "INFANT": 135,
@@ -23,5 +26,6 @@ class WaWic(Wic):
     }
     pe_inputs = [
         *Wic.pe_inputs,
-        dependency.household.NcStateCodeDependency,
+        NotTanfEligibility,
+        dependency.household.WaStateCodeDependency,
     ]

--- a/programs/programs/wa/wic/spec.md
+++ b/programs/programs/wa/wic/spec.md
@@ -85,17 +85,32 @@
 
 ## Benefit Value
 
-- **Estimated value**: $50–$165 per eligible household member per month
+WIC uses a hybrid benefit model: a fixed federal **Cash Value Benefit (CVB)** that can be spent only on fruits and vegetables, plus a **quantity-based food package** (milk, eggs, cheese, cereal, beans, infant formula, etc.) where participants receive credits for specific maximum quantities rather than cash. The value assigned in the calculator sums both: the fixed CVB cash amount plus an estimate of the retail cost of the food package quantities at WA grocery stores.
 
-**Methodology**: WIC provides food benefits that vary by participant category (pregnant/breastfeeding women, infants, and children each receive different monthly food packages). The national average WIC benefit was **$81.51 per participant per month in FY2024**. King County WA specifically reports approximately **$150/month for a family of two**.
+**Formula**: `total_monthly_value = CVB_cash + estimated_retail_cost_of_food_quantities`
 
-For calculator purposes: multiply the number of WIC-eligible household members by $80, expressed as a range of $50–$165 per eligible person per month.
+**Monthly values per participant category (FY 2025/2026)**:
 
-Note: the initial config estimated "$50–$75/month per participant" — this is too low and should be updated to $50–$165 per eligible person per month.
+| Participant Category | CVB (Produce Cash) | Food Portion (Retail Est.) | Total Monthly Value |
+| :---- | :---- | :---- | :---- |
+| **INFANT** | $0 | $135 | **$135** |
+| **CHILD** | $26 | $42 | **$68** |
+| **POSTPARTUM** | $47 | $31 | **$78** |
+| **PREGNANT** | $47 | $45 | **$92** |
+| **BREASTFEEDING** | $52 | $62 | **$114** |
 
-**Value Estimate Sources**:
-- [CBPP — WIC average $81.51/participant/month in FY2024](https://www.cbpp.org/research/food-assistance/special-supplemental-nutrition-program-for-women-infants-and-children)
-- [King County WA WIC (~$150/month for a family of two)](https://kingcounty.gov/en/dept/dph/health-safety/health-centers-programs-services/maternity-support-wic/wic-supplemental-nutrition-program)
+**Why the values differ by category**:
+- **Infants ($135)**: No CVB for infants; value is driven by infant formula (up to 9 cans/month) and jarred baby food.
+- **Breastfeeding ($114)**: Highest adult package — max CVB ($52) plus an expanded food allowance (canned fish, extra cheese, double eggs).
+- **Pregnant ($92) vs. Postpartum ($78)**: Non-breastfeeding postpartum women receive a reduced dairy/grain package ($31) vs. pregnancy ($45).
+- **Child ($68)**: Smallest total — lower CVB ($26) and smaller food package ($42).
+
+CVB amounts are set federally by USDA FNS and are the same across states. Food package quantities are also federally mandated (7 CFR Part 246); the retail cost estimates are specific to WA.
+
+**Sources**:
+- [USDA FNS — WIC Food Packages](https://www.fns.usda.gov/wic/food-packages) — federal CVB amounts and food package composition
+- [7 CFR § 246.10 — Supplemental foods](https://www.ecfr.gov/current/title-7/subtitle-B/chapter-II/subchapter-A/part-246/subpart-C/section-246.10) — maximum monthly quantities by participant category
+- [Washington State Department of Health — WIC Food List](https://doh.wa.gov/you-and-your-family/wic/wic-foods) — WA-specific approved foods used for retail estimates
 
 ## Implementation Coverage
 
@@ -138,7 +153,7 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 
 ## Test Scenarios
 
-> ⚠️ **Income threshold note**: Scenarios involving income at or near the 185% FPL boundary use 2026 estimates derived from the 2026 HHS poverty guidelines (HH of 4 confirmed at $5,088/month per WA DOH). Verify all boundary thresholds against [https://doh.wa.gov/you-and-your-family/wic/wic-eligibility](https://doh.wa.gov/you-and-your-family/wic/wic-eligibility) before running threshold-sensitive tests. Approximate 2026 185% FPL monthly values: HH of 1 ≈ $2,503, HH of 2 ≈ $3,364, HH of 3 ≈ $4,226, HH of 4 = $5,088.
+> ⚠️ **Income threshold note**: Scenarios involving income at or near the 185% FPL boundary use the **2025 HHS poverty guidelines** (the set in effect for the WIC program year this config targets; `year: "2025"` in the initial config). 2025 185% FPL monthly values: HH of 1 = $2,413, HH of 2 = $3,261, HH of 3 = $4,109, HH of 4 = $4,956. Verify all boundary thresholds against [https://doh.wa.gov/you-and-your-family/wic/wic-eligibility](https://doh.wa.gov/you-and-your-family/wic/wic-eligibility) before running threshold-sensitive tests.
 
 ---
 
@@ -149,7 +164,7 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 **Steps**:
 - **Location**: Enter ZIP code `98101`, Select county `King`
 - **Household**: Number of people: `2`
-- **Person 1**: Birth month/year: `June 1996` (age 29), Relationship: Head of Household, Pregnant: `Yes`, Employment income: `$1,800` per month (well below 185% FPL for HH of 2: ~$3,364/month)
+- **Person 1**: Birth month/year: `June 1996` (age 29), Relationship: Head of Household, Pregnant: `Yes`, Employment income: `$1,800` per month (well below 185% FPL for HH of 2: ~$3,261/month)
 - **Person 2**: Birth month/year: `March 2019` (age 7), Relationship: Child, No income
 - **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
 
@@ -164,11 +179,11 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 **Steps**:
 - **Location**: Enter ZIP code `98001`, Select county `King`
 - **Household**: Number of people: `2`
-- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$3,364` per month (approximately 185% FPL for HH of 2 in 2026 — verify against WA DOH income limits page before running)
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$3,261` per month (exactly 185% FPL for HH of 2 in 2025 — verify against WA DOH income limits page before running)
 - **Person 2**: Birth month/year: `May 2021` (age 4 years 11 months — will turn 5 in May 2026), Relationship: Child, No income
 - **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
 
-**Why this matters**: Tests two boundaries simultaneously: the child's age (just under 5) and the income ceiling (exactly at 185% FPL). Both should be inclusive. If either gate is misconfigured as strictly less than, this scenario will catch it.
+**Why this matters**: Tests two boundaries simultaneously: the child's age (just under 5) and the income ceiling (exactly at 185% FPL for 2025, $3,261/month for HH of 2). Both should be inclusive. If either gate is misconfigured as strictly less than, this scenario will catch it.
 
 ---
 
@@ -179,7 +194,7 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 **Steps**:
 - **Location**: Enter ZIP code `98103`, Select county `King`
 - **Household**: Number of people: `3`
-- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,225` per month (approximately $1 below 185% FPL for HH of 3 in 2026 — verify against WA DOH income limits page)
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,108` per month ($1 below 185% FPL for HH of 3 in 2025: $4,109/month)
 - **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
 - **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
 - **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
@@ -195,13 +210,13 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 **Steps**:
 - **Location**: Enter ZIP code `98101`, Select county `King`
 - **Household**: Number of people: `4`
-- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$5,088` per month (exactly 185% FPL for HH of 4 in 2026 — confirmed per WA DOH)
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,956` per month (exactly 185% FPL for HH of 4 in 2025)
 - **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
 - **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
 - **Person 4**: Birth month/year: `March 2025` (age 1), Relationship: Child, No income
 - **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
 
-**Why this matters**: Validates the income threshold is evaluated as ≤ 185% FPL (not strictly <). At exactly $5,088/month for a 4-person household, this is the confirmed 2026 WIC income ceiling.
+**Why this matters**: Validates the income threshold is evaluated as ≤ 185% FPL (not strictly <). At exactly $4,956/month for a 4-person household, this is the 2025 WIC income ceiling.
 
 ---
 
@@ -212,7 +227,7 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 **Steps**:
 - **Location**: Enter ZIP code `98101`, Select county `King`
 - **Household**: Number of people: `2`
-- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$3,365` per month (approximately $1 above 185% FPL for HH of 2 in 2026 — verify against WA DOH income limits page)
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$3,262` per month ($1 above 185% FPL for HH of 2 in 2025: $3,261/month)
 - **Person 2**: Birth month/year: `May 2021` (age 4), Relationship: Child, No income
 - **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
 
@@ -378,7 +393,7 @@ Note: the initial config estimated "$50–$75/month per participant" — this is
 **Steps**:
 - **Location**: Enter ZIP code `98101`, Select county `King`
 - **Household**: Number of people: `3`
-- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,500` per month (above 185% FPL for HH of 3: ~$4,226/month)
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,500` per month (above 185% FPL for HH of 3: $4,109/month in 2025)
 - **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
 - **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
 - **Current Benefits**: Select `SNAP` — do NOT select Medicaid or TANF

--- a/programs/programs/wa/wic/spec.md
+++ b/programs/programs/wa/wic/spec.md
@@ -1,0 +1,429 @@
+# Implement Women, Infants, and Children (WIC) Nutrition Program (WA)
+
+## Program Details
+
+- **Program**: Women, Infants, and Children (WIC) Nutrition Program
+- **State**: WA
+- **White Label**: wa
+- **Research Date**: 2026-03-19
+- **Spec Last Updated**: 2026-04-07 (revised per patmanson review)
+
+## Eligibility Criteria
+
+1. **Categorical requirement: Must be a pregnant woman, postpartum woman (up to 6 months after end of pregnancy), breastfeeding woman (up to 12 months), infant (under 1 year), or child (ages 1–4, up to but not including 5th birthday)**
+   - Screener fields:
+     - `age`
+     - `pregnant`
+     - `birth_year_month`
+     - `relationship`
+   - Source: 7 CFR 246.7(c)(1); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+2. **Income eligibility: Household gross income at or below 185% of the Federal Poverty Level (FPL)**
+   - Note: **Income is NOT used as a disqualifying criterion when any household member is enrolled in SNAP, Medicaid, or TANF** (see Criterion 3). The income check must be bypassed entirely when adjunctive eligibility applies — do not fail eligibility based on income in those cases.
+   - Screener fields:
+     - `household_size`
+     - `income_streams`
+   - Source: 7 CFR 246.7(d)(1); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+3. **Adjunctive income eligibility: Participants in SNAP, Medicaid, or TANF are automatically income-eligible for WIC**
+   - Note: When any of these programs is active for the household, income is not evaluated as a disqualifying criterion.
+   - Screener fields:
+     - `has_snap`
+     - `has_medicaid`
+     - `has_tanf`
+   - Source: 7 CFR 246.7(d)(2)(iv); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+4. **Residency: Must reside in the state of Washington**
+   - Screener fields:
+     - `zipcode`
+     - `county`
+   - Source: 7 CFR 246.7(c)(1)(i); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+5. **Age requirement for children: Child must be under 5 years of age (before their 5th birthday)**
+   - Screener fields:
+     - `age`
+     - `birth_year_month`
+   - Source: 7 CFR 246.2; https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+6. **Household must contain at least one categorically eligible member**
+   - Note: WIC eligibility attaches to the categorically eligible individual. A household with no pregnant/postpartum women, infants, or children under 5 is not eligible even if it has adjunctive benefits.
+   - Screener fields:
+     - `age`
+     - `pregnant`
+     - `birth_year_month`
+   - Source: 7 CFR 246.7(c)(1); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+7. **Nutritional risk determination: Must be found at nutritional risk by a WIC health professional** ⚠️ *data gap*
+   - Note: In-person clinical assessment at WIC clinic; cannot be pre-screened. Rarely a barrier for otherwise eligible individuals.
+   - Impact: Low
+   - Source: 7 CFR 246.7(c)(4); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+8. **Postpartum/breastfeeding window** ⚠️ *data gap*
+   - Note: Non-breastfeeding postpartum women are eligible up to 6 months after end of pregnancy; breastfeeding women up to 12 months. No postpartum or breastfeeding status field exists in the screener. Can be approximated from infant age if an infant under 1 year is present in the household.
+   - Impact: Medium
+   - Source: 7 CFR 246.7(c)(1)(ii)–(iii); https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+9. **Must not be currently receiving WIC benefits (no duplicate participation)** ⚠️ *data gap*
+   - Note: `has_wic` field exists but duplicate enrollment is better surfaced as informational rather than a hard eligibility exclusion in the screener.
+   - Impact: Low
+   - Source: https://www.law.cornell.edu/cfr/text/7/246.2
+
+10. **Citizenship/immigration status: None required — all residents eligible regardless of status** ⚠️ *data gap*
+    - Note: WIC has no citizenship or immigration requirement. No citizenship check should be applied in screening logic.
+    - Impact: Low
+    - Source: https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+11. **Physical presence at WIC clinic for certification** ⚠️ *data gap*
+    - Note: Procedural/administrative requirement; not a pre-screening criterion. Some telehealth exceptions available post-COVID.
+    - Impact: Low
+    - Source: https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+12. **Homelessness/housing status: Homeless individuals are eligible; no permanent address required** ⚠️ *data gap*
+    - Note: Non-restrictive; this is an affirmative inclusion. No action needed in screener logic.
+    - Impact: Low
+    - Source: https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+
+## Benefit Value
+
+- **Estimated value**: $50–$165 per eligible household member per month
+
+**Methodology**: WIC provides food benefits that vary by participant category (pregnant/breastfeeding women, infants, and children each receive different monthly food packages). The national average WIC benefit was **$81.51 per participant per month in FY2024**. King County WA specifically reports approximately **$150/month for a family of two**.
+
+For calculator purposes: multiply the number of WIC-eligible household members by $80, expressed as a range of $50–$165 per eligible person per month.
+
+Note: the initial config estimated "$50–$75/month per participant" — this is too low and should be updated to $50–$165 per eligible person per month.
+
+**Value Estimate Sources**:
+- [CBPP — WIC average $81.51/participant/month in FY2024](https://www.cbpp.org/research/food-assistance/special-supplemental-nutrition-program-for-women-infants-and-children)
+- [King County WA WIC (~$150/month for a family of two)](https://kingcounty.gov/en/dept/dph/health-safety/health-centers-programs-services/maternity-support-wic/wic-supplemental-nutrition-program)
+
+## Implementation Coverage
+
+- ✅ Evaluable criteria: 6
+- ⚠️ Data gaps: 6
+
+6 of 12 criteria can be evaluated with current screener fields. The core requirements — categorical status (pregnant/postpartum/infant/child under 5), income at or below 185% FPL, adjunctive eligibility via SNAP/Medicaid/TANF, Washington residency, age, and household composition — are all well-covered. The 6 data gaps are low/medium impact: nutritional risk assessment and physical clinic presence are procedural; citizenship/immigration and homelessness are non-restrictions (affirmative inclusions); postpartum window can be approximated from infant age; duplicate WIC participation is better handled as informational.
+
+**Critical implementation note**: The income check must be bypassed entirely when adjunctive eligibility (SNAP, Medicaid, or TANF) is present. Applying the income test to adjunctive-eligible households would incorrectly exclude them.
+
+## Research Sources
+
+- [WA DOH WIC Eligibility and Income Limits](https://doh.wa.gov/you-and-your-family/wic/wic-eligibility)
+- [USDA WIC Regulations — 7 CFR Part 246](https://www.ecfr.gov/current/title-7/subtitle-B/chapter-II/subchapter-A/part-246)
+- [Cornell LII — 7 CFR 246.2 (Definitions: "child," "infant," "postpartum woman")](https://www.law.cornell.edu/cfr/text/7/246.2)
+- [Cornell LII — 7 CFR 246.7 (Certification of participants)](https://www.law.cornell.edu/cfr/text/7/246.7)
+- [CBPP WIC Research (FY2024 average benefit)](https://www.cbpp.org/research/food-assistance/special-supplemental-nutrition-program-for-women-infants-and-children)
+- [King County WA WIC Supplemental Nutrition Program](https://kingcounty.gov/en/dept/dph/health-safety/health-centers-programs-services/maternity-support-wic/wic-supplemental-nutrition-program)
+
+## Acceptance Criteria
+
+[ ] Scenario 1 (Pregnant Woman, Low Income — Clearly Eligible): User should be **eligible**
+[ ] Scenario 2 (Child at 4 Years 11 Months, Income Exactly at 185% FPL): User should be **eligible**
+[ ] Scenario 3 (Household of 3, Income $1 Below 185% FPL): User should be **eligible**
+[ ] Scenario 4 (Household of 4, Income Exactly at 185% FPL): User should be **eligible**
+[ ] Scenario 5 (Household of 2, Income $1 Above 185% FPL, No Adjunctive): User should be **ineligible**
+[ ] Scenario 6 (Infant Exactly Age 1 — Eligible as Child): User should be **eligible**
+[ ] Scenario 7 (Infant Under 1 Year Old — Eligible as WIC Infant): User should be **eligible**
+[ ] Scenario 8 (3-Year-Old Child — Clearly Eligible): User should be **eligible**
+[ ] Scenario 9a (Pregnant Woman, Valid WA ZIP Code): User should be **eligible**
+[ ] Scenario 9b (Pregnant Woman, Non-WA ZIP Code): User should be **ineligible**
+[ ] Scenario 10 (Household Already Receiving WIC): User should be **ineligible**
+[ ] Scenario 11 (Adults Only, No Pregnancy — No Categorically Eligible Members): User should be **ineligible**
+[ ] Scenario 12 (Mixed Household — Eligible Toddler, Ineligible 6-Year-Old): User should be **eligible**
+[ ] Scenario 13 (Pregnant Woman, Infant, and Toddler — All Categorically Eligible): User should be **eligible**
+[ ] Scenario 14 (Child at 4 Years 11 Months — Near Age Cutoff): User should be **eligible**
+[ ] Scenario 15a (SNAP Recipient, Child Under 5 — Adjunctive Auto-Qualify): User should be **eligible**
+[ ] Scenario 15b (Medicaid Recipient, Child Under 5 — Adjunctive Auto-Qualify): User should be **eligible**
+[ ] Scenario 15c (TANF Recipient, Child Under 5 — Adjunctive Auto-Qualify): User should be **eligible**
+
+## Test Scenarios
+
+> ⚠️ **Income threshold note**: Scenarios involving income at or near the 185% FPL boundary use 2026 estimates derived from the 2026 HHS poverty guidelines (HH of 4 confirmed at $5,088/month per WA DOH). Verify all boundary thresholds against [https://doh.wa.gov/you-and-your-family/wic/wic-eligibility](https://doh.wa.gov/you-and-your-family/wic/wic-eligibility) before running threshold-sensitive tests. Approximate 2026 185% FPL monthly values: HH of 1 ≈ $2,503, HH of 2 ≈ $3,364, HH of 3 ≈ $4,226, HH of 4 = $5,088.
+
+---
+
+### Scenario 1: Pregnant Woman with Low Income — Clearly Eligible ⭐ Priority QA
+**What we're checking**: Pregnant woman in a 2-person household with income well below 185% FPL — validates the most common WIC eligibility pathway
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1996` (age 29), Relationship: Head of Household, Pregnant: `Yes`, Employment income: `$1,800` per month (well below 185% FPL for HH of 2: ~$3,364/month)
+- **Person 2**: Birth month/year: `March 2019` (age 7), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Validates the core categorical + income eligibility pathway. Pregnancy is the most straightforward categorical qualifier. With income well below the threshold, this confirms both criteria work in combination.
+
+---
+
+### Scenario 2: Child at 4 Years 11 Months, Income at Exactly 185% FPL — Minimally Eligible
+**What we're checking**: Child just under the age-5 cutoff with household income at the exact 185% FPL boundary — validates both the age upper boundary and the income ceiling (inclusive ≤)
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98001`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$3,364` per month (approximately 185% FPL for HH of 2 in 2026 — verify against WA DOH income limits page before running)
+- **Person 2**: Birth month/year: `May 2021` (age 4 years 11 months — will turn 5 in May 2026), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Tests two boundaries simultaneously: the child's age (just under 5) and the income ceiling (exactly at 185% FPL). Both should be inclusive. If either gate is misconfigured as strictly less than, this scenario will catch it.
+
+---
+
+### Scenario 3: Household of 3 with Income $1 Below 185% FPL — Just Under Threshold
+**What we're checking**: A household of 3 with income just below the 185% FPL ceiling — validates the income threshold is correctly applied and inclusive
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98103`, Select county `King`
+- **Household**: Number of people: `3`
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,225` per month (approximately $1 below 185% FPL for HH of 3 in 2026 — verify against WA DOH income limits page)
+- **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
+- **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Confirms the income ceiling is applied correctly for a 3-person household. The $1 buffer ensures we're testing the threshold itself, not just a comfortably-below value.
+
+---
+
+### Scenario 4: Household of 4 at Exactly 185% FPL — Boundary Eligible
+**What we're checking**: 4-person household with income exactly equal to 185% FPL — confirms the threshold is inclusive (≤, not <)
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `4`
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$5,088` per month (exactly 185% FPL for HH of 4 in 2026 — confirmed per WA DOH)
+- **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
+- **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
+- **Person 4**: Birth month/year: `March 2025` (age 1), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Validates the income threshold is evaluated as ≤ 185% FPL (not strictly <). At exactly $5,088/month for a 4-person household, this is the confirmed 2026 WIC income ceiling.
+
+---
+
+### Scenario 5: Household of 2 with Income $1 Above 185% FPL — Just Over Threshold ⭐ Priority QA
+**What we're checking**: 2-person household with income just above the 185% FPL ceiling and no adjunctive benefits — confirms the income ceiling is enforced when no bypass applies
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$3,365` per month (approximately $1 above 185% FPL for HH of 2 in 2026 — verify against WA DOH income limits page)
+- **Person 2**: Birth month/year: `May 2021` (age 4), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Confirms the income ceiling is a hard gate. With no adjunctive benefits, a household $1 over the limit must be denied. This pairs with Scenario 2 to confirm the boundary is enforced correctly in both directions.
+
+---
+
+### Scenario 6: Infant Exactly Age 1 — Eligible as Child
+**What we're checking**: Infant who has just turned exactly 1 year old — confirms the age-1 minimum for the "child" category and that the infant-to-child transition contains no eligibility gap
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1993` (age 32), Relationship: Head of Household, Employment income: `$2,000` per month
+- **Person 2**: Birth month/year: `April 2025` (age exactly 1 year — born this month last year), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Children ages 1–4 are categorically eligible for WIC. Infants under 1 are also eligible but counted separately. A child turning exactly 1 transitions from the "infant" to "child" WIC category — both are eligible, and this confirms the age-1 boundary is not treated as a gap or exclusion.
+
+---
+
+### Scenario 7: Infant Under 1 Year Old — Eligible as WIC Infant
+**What we're checking**: Infant clearly under 1 year old — validates the infant eligibility pathway
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1993` (age 32), Relationship: Head of Household, Employment income: `$2,000` per month
+- **Person 2**: Birth month/year: `January 2026` (age ~3 months), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Infants under 1 year are a core WIC categorical group. Validates the infant pathway works independently of the child pathway.
+
+---
+
+### Scenario 8: 3-Year-Old Child — Clearly Eligible
+**What we're checking**: Child at age 3, well within the child eligibility range — straightforward mid-range eligibility check
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$2,500` per month
+- **Person 2**: Birth month/year: `January 2023` (age 3), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: A non-boundary check for the child age range. Avoids edge cases to confirm basic child eligibility functions as expected.
+
+---
+
+### Scenario 9a: Pregnant Woman in Valid WA ZIP Code — Eligible Location ⭐ Priority QA
+**What we're checking**: Confirms the residency check passes for a valid Washington ZIP code
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `March 1993` (age 33), Relationship: Head of Household, Pregnant: `Yes`, Employment income: `$1,800` per month
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Confirms the WA residency check passes for a valid in-state ZIP. Run alongside Scenario 9b for a paired location test.
+
+---
+
+### Scenario 9b: Pregnant Woman in Non-WA ZIP Code — Location Invalid
+**What we're checking**: Confirms the residency check correctly denies eligibility for an out-of-state address
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `97201` (Portland, OR), Select county `Multnomah`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `March 1993` (age 33), Relationship: Head of Household, Pregnant: `Yes`, Employment income: `$1,800` per month
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: WA WIC is state-administered. A user with an Oregon address must not receive a WA WIC eligibility result. This is the natural counterpart to Scenario 9a.
+
+---
+
+### Scenario 10: Household Already Receiving WIC — Exclusion Check
+**What we're checking**: Household with `has_wic` indicated — validates that existing WIC participants are not shown as newly eligible
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1993` (age 32), Relationship: Head of Household, Employment income: `$1,800` per month
+- **Person 2**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
+- **Current Benefits**: Select `WIC`
+
+**Why this matters**: Confirms that households already receiving WIC are correctly handled and not shown as newly eligible.
+
+---
+
+### Scenario 11: Adults Only, No Pregnancy — No Categorically Eligible Members
+**What we're checking**: Household with no pregnant women, infants, or children under 5 — confirms WIC does not appear even when adjunctive benefits are present
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1985` (age 40), Relationship: Head of Household, Employment income: `$1,800` per month
+- **Person 2**: Birth month/year: `March 1988` (age 38), Relationship: Spouse, No income
+- **Current Benefits**: Select `SNAP`
+
+**Why this matters**: Even SNAP adjunctive eligibility does not override the categorical requirement. A household with no pregnant/postpartum women, infants, or children under 5 is not eligible for WIC regardless of income or benefit status. This is an important counterpart to the adjunctive scenarios.
+
+---
+
+### Scenario 12: Mixed Household — Eligible Toddler, Ineligible 6-Year-Old ⭐ Priority QA
+**What we're checking**: Household with both an age-eligible child (under 5) and an age-ineligible older child — confirms the presence of an ineligible member does not disqualify the eligible one
+**Expected**: Eligible (toddler qualifies; 6-year-old does not)
+
+**Steps**:
+- **Location**: Enter ZIP code `98103`, Select county `King`
+- **Household**: Number of people: `3`
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$2,800` per month
+- **Person 2**: Birth month/year: `January 2023` (age 3), Relationship: Child, No income
+- **Person 3**: Birth month/year: `February 2020` (age 6), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Tests that WIC eligibility is assessed per eligible household member, not per household unit. A 6-year-old aging out of WIC should not cause the 3-year-old to lose eligibility.
+
+---
+
+### Scenario 13: Pregnant Woman, Infant, and Toddler — All Categorically Eligible
+**What we're checking**: Household where all child/maternal members are categorically eligible — confirms multi-member categorical eligibility works
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `4`
+- **Person 1**: Birth month/year: `June 1993` (age 32), Relationship: Head of Household, Pregnant: `Yes`, Employment income: `$2,500` per month
+- **Person 2**: Birth month/year: `March 1995` (age 31), Relationship: Spouse, No income
+- **Person 3**: Birth month/year: `March 2025` (age ~13 months), Relationship: Child, No income
+- **Person 4**: Birth month/year: `January 2023` (age 3), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Validates that a household with multiple categorically eligible members (pregnant woman + infant + toddler) is correctly identified as eligible.
+
+---
+
+### Scenario 14: Child at 4 Years 11 Months — Near Age Cutoff
+**What we're checking**: Child at 4 years 11 months (1 month before turning 5) — validates the age-5 cutoff is enforced correctly and that children just before the cutoff remain eligible
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `June 1990` (age 35), Relationship: Head of Household, Employment income: `$2,500` per month
+- **Person 2**: Birth month/year: `May 2021` (age 4 years 11 months — will turn 5 in May 2026), Relationship: Child, No income
+- **Current Benefits**: Do NOT select SNAP, Medicaid, or TANF
+
+**Why this matters**: Since the screener collects birth month/year (not exact day), a child born in May 2021 is currently 4 years 11 months old and is still eligible. This tests the upper age boundary without requiring an exact birth date. (Note: an original scenario tested "child turns 5 tomorrow" — that is impractical given we only collect birth month. "4 years 11 months" is the correct proxy.)
+
+---
+
+### Scenario 15a: SNAP Recipient with Child Under 5 — Adjunctive Auto-Qualify ⭐ Priority QA
+**What we're checking**: Household with income above 185% FPL but receiving SNAP — validates adjunctive eligibility bypasses the income check
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `3`
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,500` per month (above 185% FPL for HH of 3: ~$4,226/month)
+- **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
+- **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
+- **Current Benefits**: Select `SNAP` — do NOT select Medicaid or TANF
+- **Note**: SNAP may not yet be programmed for the WA white label. This scenario documents the expected behavior for when adjunctive eligibility is implemented.
+
+**Why this matters**: Adjunctive eligibility via SNAP is one of the most critical pathways in WIC. A household over the income threshold must still qualify if they receive SNAP. This is the primary test of the income bypass logic.
+
+---
+
+### Scenario 15b: Medicaid Recipient with Child Under 5 — Adjunctive Auto-Qualify
+**What we're checking**: Same income-over-threshold household as 15a, but qualifying via Medicaid alone — validates Medicaid independently triggers the income bypass
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `3`
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,500` per month (above 185% FPL for HH of 3)
+- **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
+- **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
+- **Current Benefits**: Select `Medicaid` — do NOT select SNAP or TANF
+
+**Why this matters**: Validates Medicaid is independently recognized as an adjunctive eligibility trigger per 7 CFR 246.7(d)(2)(iv), separate from SNAP.
+
+---
+
+### Scenario 15c: TANF Recipient with Child Under 5 — Adjunctive Auto-Qualify
+**What we're checking**: Same income-over-threshold household as 15a, but qualifying via TANF alone — validates TANF independently triggers the income bypass
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `98101`, Select county `King`
+- **Household**: Number of people: `3`
+- **Person 1**: Birth month/year: `June 1988` (age 37), Relationship: Head of Household, Employment income: `$4,500` per month (above 185% FPL for HH of 3)
+- **Person 2**: Birth month/year: `September 1990` (age 35), Relationship: Spouse, No income
+- **Person 3**: Birth month/year: `January 2024` (age 2), Relationship: Child, No income
+- **Current Benefits**: Select `TANF` — do NOT select SNAP or Medicaid
+
+**Why this matters**: Validates TANF is independently recognized as an adjunctive eligibility trigger. All three adjunctive programs (SNAP, Medicaid, TANF) must be tested individually to confirm each one bypasses the income check on its own.
+
+---
+
+## Source Documentation
+
+- https://doh.wa.gov/you-and-your-family/wic/wic-eligibility
+- https://www.cbpp.org/research/food-assistance/special-supplemental-nutrition-program-for-women-infants-and-children
+- https://kingcounty.gov/en/dept/dph/health-safety/health-centers-programs-services/maternity-support-wic/wic-supplemental-nutrition-program
+- https://www.law.cornell.edu/cfr/text/7/246.2
+- https://www.law.cornell.edu/cfr/text/7/246.7

--- a/screener/models.py
+++ b/screener/models.py
@@ -398,6 +398,7 @@ class Screen(models.Model):
             "il_wic": self.has_wic,
             "nc_wic": self.has_wic,
             "tx_wic": self.has_wic,
+            "wa_wic": self.has_wic,
             "snap": self.has_snap,
             "sunbucks": self.has_sunbucks,
             "co_snap": self.has_snap,

--- a/validations/management/commands/import_validations/data/wa_wic.json
+++ b/validations/management/commands/import_validations/data/wa_wic.json
@@ -56,11 +56,11 @@
     "expected_results": {
       "program_name": "wa_wic",
       "eligible": true,
-      "value": 509
+      "value": 816
     }
   },
   {
-    "notes": "WA WIC - Household of 2, Income $1 Above 185% FPL, No Adjunctive - Should NOT Be Eligible (2026 threshold: $3,261/mo for HH of 2)",
+    "notes": "WA WIC - Household of 2, Income Above Child Medicaid Cap, No Adjunctive - Should NOT Be Eligible ($5,500/mo exceeds both WIC 185% FPL and the child's WA Apple Health for Kids Medicaid threshold of ~312% FPL for HH of 2)",
     "household": {
       "white_label": "wa",
       "household_size": 2,
@@ -79,7 +79,7 @@
           "income_streams": [
             {
               "type": "wages",
-              "amount": 3262.0,
+              "amount": 5500.0,
               "frequency": "monthly"
             }
           ],
@@ -193,7 +193,7 @@
     "expected_results": {
       "program_name": "wa_wic",
       "eligible": true,
-      "value": 509
+      "value": 816
     }
   }
 ]

--- a/validations/management/commands/import_validations/data/wa_wic.json
+++ b/validations/management/commands/import_validations/data/wa_wic.json
@@ -60,7 +60,7 @@
     }
   },
   {
-    "notes": "WA WIC - Household of 2, Income Above Child Medicaid Cap, No Adjunctive - Should NOT Be Eligible ($5,500/mo exceeds both WIC 185% FPL and the child's WA Apple Health for Kids Medicaid threshold of ~312% FPL for HH of 2)",
+    "notes": "WA WIC - Household of 2, Income Above 185% FPL and Above Child Medicaid Cap - Should NOT Be Eligible. Income must exceed both WIC's 185% FPL and WA's Apple Health for Kids Medicaid cap (~312% FPL) to avoid presumptive (adjunctive) eligibility via the child.",
     "household": {
       "white_label": "wa",
       "household_size": 2,

--- a/validations/management/commands/import_validations/data/wa_wic.json
+++ b/validations/management/commands/import_validations/data/wa_wic.json
@@ -1,0 +1,199 @@
+[
+  {
+    "notes": "WA WIC - Pregnant Woman with Child Under 5, Income Below 185% FPL - Clearly Eligible",
+    "household": {
+      "white_label": "wa",
+      "household_size": 2,
+      "zipcode": "98101",
+      "county": "King",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1996,
+          "age": 29,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 1800.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 9,
+          "birth_year": 2023,
+          "age": 2,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_wic",
+      "eligible": true,
+      "value": 509
+    }
+  },
+  {
+    "notes": "WA WIC - Household of 2, Income $1 Above 185% FPL, No Adjunctive - Should NOT Be Eligible (2026 threshold: $3,261/mo for HH of 2)",
+    "household": {
+      "white_label": "wa",
+      "household_size": 2,
+      "zipcode": "98101",
+      "county": "King",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1996,
+          "age": 29,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 3262.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 9,
+          "birth_year": 2023,
+          "age": 2,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_wic",
+      "eligible": false
+    }
+  },
+  {
+    "notes": "WA WIC - SNAP Recipient with Child Under 5, Income Above 185% FPL - Adjunctive Auto-Qualify (income check bypassed)",
+    "household": {
+      "white_label": "wa",
+      "household_size": 3,
+      "zipcode": "98103",
+      "county": "King",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "has_snap": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1992,
+          "age": 33,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 4500.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 1,
+          "birth_year": 1993,
+          "age": 33,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 5,
+          "birth_year": 2023,
+          "age": 2,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_wic",
+      "eligible": true,
+      "value": 509
+    }
+  }
+]

--- a/validations/management/commands/import_validations/test_case_schema.json
+++ b/validations/management/commands/import_validations/test_case_schema.json
@@ -17,8 +17,8 @@
       "properties": {
         "white_label": {
           "type": "string",
-          "description": "White label code (e.g., 'co', 'tx', 'nc', 'ma', 'il')",
-          "enum": ["co", "tx", "nc", "ma", "il"]
+          "description": "White label code (e.g., 'co', 'tx', 'nc', 'ma', 'il', 'wa')",
+          "enum": ["co", "tx", "nc", "ma", "il", "wa"]
         },
         "completed": {
           "type": "boolean",


### PR DESCRIPTION
## Context & Motivation

Add WA WIC (Women, Infants, and Children) program to the Washington white label screener. This allows WA users to be screened for WIC eligibility and see estimated benefit values based on participant category (infant, child, pregnant, postpartum, breastfeeding).

## Changes Made

- Added `WaWic` calculator with WA-specific benefit values per participant category (FY 2025/2026 retail estimates: infant $135, child $68, pregnant $92, postpartum $78, breastfeeding $114)
- Registered `wa_member_calculators` in `wa/pe/__init__.py` and imported into `policyengine/calculators/registry.py`
- Added `"wa_wic": self.has_wic` to the benefit map in `screener/models.py`
- Added program config: `wa_wic_initial_config.json`
- Added validation test cases: `wa_wic.json`
- Added spec: `wa/wic/spec.md`

## Testing

- Migrations to run: None
- Configuration updates needed: `python manage.py import_program_config_data wa_wic_initial_config` (imports the WA WIC program record)
- Environment variables/settings to add: None
- Manual testing steps:
  - Run the screener for the WA white label
  - Verify WIC appears in the "Do you already receive these benefits?" step
  - Submit a screen with a household that includes a pregnant woman, child under 5, or infant and confirm WIC eligibility result with correct estimated value
  - Submit a screen with a household that has no categorically eligible members (e.g., single adult male, no children) and confirm WIC is not eligible

## Deployment

- Post-deployment scripts needed: `python manage.py import_program_config_data wa_wic_initial_config`
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: WA WIC is now live for screening

## Notes for Reviewers

- Known limitations: WIC benefit values for the food portion are retail estimates based on WA grocery prices, not exact amounts — actual value varies by store and region
- Future considerations: Values should be updated when USDA FNS revises CVB amounts or WA food package quantities change (typically annually at FY start)