### PR TITLE
MFB-850: Add WA SSI PolicyEngine calculator

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_ssi_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_ssi_initial_config.json
@@ -1,0 +1,62 @@
+{
+    "white_label": {"code": "wa"},
+    "program_category": {"external_name": "wa_cash", "name": "Cash Assistance", "icon": "cash"},
+    "program": {
+        "name_abbreviated": "wa_ssi",
+        "year": "2025",
+        "legal_status_required": ["citizen", "gc_5plus"],
+        "name": "Supplemental Security Income (SSI)",
+        "description_short": "Federal cash assistance for individuals who are disabled, blind, or 65 years of age or older",
+        "description": "Federal cash assistance for individuals who are disabled, blind, or 65 years of age or older. Supplemental Security Income (SSI) is a needs-based program. SSI may give you cash to help meet your food, shelter, and personal care needs. Adults and children may qualify if they have a disability or are blind. Adults 65 years and older may also qualify.\n\nWashington does not provide a state supplement to SSI for most adults, so the benefit estimate reflects the federal SSI amount as calculated by PolicyEngine.\n\nSSI may affect your household's ability to qualify for TANF. SSI may also affect the value of other cash assistance benefits. It may take up to 6 to 12 months to receive this benefit.",
+        "learn_more_link": "https://www.ssa.gov/ssi",
+        "apply_button_link": "https://www.ssa.gov/apply/ssi",
+        "apply_button_description": "",
+        "estimated_application_time": "90 minutes",
+        "estimated_value": "",
+        "website_description": "Federal cash assistance for individuals who are disabled, blind, or 65 years of age or older"
+    },
+    "warning_messages": [
+        {
+            "external_name": "wa_ssi_ssdi_interaction",
+            "calculator": "_show",
+            "message": "If you get SSDI, the amount of your SSI payment may be lower. In some cases, you may not get SSI if you also get SSDI."
+        },
+        {
+            "external_name": "wa_ssi_approval_time",
+            "calculator": "_show",
+            "message": "It may take 6 to 8 months to get an initial decision. Your claim may be denied at first. Claims are often approved on appeal, but approval can sometimes take up to 3 years."
+        }
+    ],
+    "documents": [
+        {
+            "external_name": "wa_home",
+            "text": "Proof of home address (ex: lease, mortgage statement, utility bill)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_unearned_income",
+            "text": "Proof of unearned income (ex: child support, social security, unemployment)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_earned_income",
+            "text": "Proof of earned income (ex: pay stubs, tax returns, W-2, 1099) & employer information",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_id_proof",
+            "text": "Proof of identity (ex: driver's license, official state ID card)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "wa_us_status",
+            "text": "Proof of status in U.S. (ex: birth certificate, green card, work permit)",
+            "link_url": "",
+            "link_text": ""
+        }
+    ]
+}

--- a/programs/migrations/0149_backfill_wa_ssi_base_program.py
+++ b/programs/migrations/0149_backfill_wa_ssi_base_program.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def backfill_wa_ssi_base_program(apps, schema_editor):
+    """
+    Map wa_ssi → base_program="ssi" so it groups with other SSI programs in
+    cross-WL aggregations. Mirrors entries added in
+    0138_backfill_has_calculator_base_program.py for ssi/tx_ssi/cesn_ssi.
+
+    Idempotent: only updates rows where base_program is not already set.
+    """
+    Program = apps.get_model("programs", "Program")
+    Program.objects.filter(name_abbreviated="wa_ssi", base_program__isnull=True).update(base_program="ssi")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0148_alter_program_external_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_wa_ssi_base_program, migrations.RunPython.noop),
+    ]

--- a/programs/migrations/0150_show_wa_ssi_in_has_benefits_step.py
+++ b/programs/migrations/0150_show_wa_ssi_in_has_benefits_step.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def forward(apps, schema_editor):
+    """
+    Flag wa_ssi for the WA white label as selectable on the has-benefits step.
+    Matches the pattern from 0142_audit_show_in_has_benefits_step.py for ssi
+    in other white labels.
+    """
+    Program = apps.get_model("programs", "Program")
+    Program.objects.filter(white_label__code="wa", name_abbreviated="wa_ssi").update(
+        show_in_has_benefits_step=True,
+        active=True,
+    )
+
+
+def reverse(apps, schema_editor):
+    Program = apps.get_model("programs", "Program")
+    Program.objects.filter(white_label__code="wa", name_abbreviated="wa_ssi").update(
+        show_in_has_benefits_step=False,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0149_backfill_wa_ssi_base_program"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/programs/programs/policyengine/calculators/registry.py
+++ b/programs/programs/policyengine/calculators/registry.py
@@ -41,6 +41,11 @@ from programs.programs.tx.pe import (
     tx_spm_calculators,
     tx_tax_unit_calculators,
 )
+from programs.programs.wa.pe import (
+    wa_member_calculators,
+    wa_spm_calculators,
+    wa_tax_unit_calculators,
+)
 
 all_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
     **co_member_calculators,
@@ -49,6 +54,7 @@ all_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
     **ma_member_calculators,
     **nc_member_calculators,
     **tx_member_calculators,
+    **wa_member_calculators,
 }
 
 all_spm_unit_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {
@@ -58,6 +64,7 @@ all_spm_unit_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {
     **ma_spm_calculators,
     **nc_spm_calculators,
     **tx_spm_calculators,
+    **wa_spm_calculators,
 }
 
 all_tax_unit_calculators: dict[str, type[PolicyEngineTaxUnitCalulator]] = {
@@ -66,6 +73,7 @@ all_tax_unit_calculators: dict[str, type[PolicyEngineTaxUnitCalulator]] = {
     **il_tax_unit_calculators,
     **ma_tax_unit_calculators,
     **tx_tax_unit_calculators,
+    **wa_tax_unit_calculators,
 }
 
 all_calculators: dict[str, type[PolicyEngineCalulator]] = {

--- a/programs/programs/wa/pe/__init__.py
+++ b/programs/programs/wa/pe/__init__.py
@@ -1,3 +1,21 @@
-from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
+import programs.programs.wa.pe.member as member
+from programs.programs.policyengine.calculators.base import (
+    PolicyEngineCalulator,
+    PolicyEngineMembersCalculator,
+    PolicyEngineSpmCalulator,
+    PolicyEngineTaxUnitCalulator,
+)
 
-wa_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {}
+wa_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
+    "wa_ssi": member.WaSsi,
+}
+
+wa_tax_unit_calculators: dict[str, type[PolicyEngineTaxUnitCalulator]] = {}
+
+wa_spm_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {}
+
+wa_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {
+    **wa_member_calculators,
+    **wa_tax_unit_calculators,
+    **wa_spm_calculators,
+}

--- a/programs/programs/wa/pe/member.py
+++ b/programs/programs/wa/pe/member.py
@@ -1,0 +1,16 @@
+from programs.programs.federal.pe.member import Ssi
+import programs.programs.policyengine.calculators.dependencies as dependency
+
+
+class WaSsi(Ssi):
+    """
+    Washington SSI calculator that uses PolicyEngine's calculated benefit amounts.
+    Extends the federal SSI calculator with Washington state code dependency so
+    PolicyEngine evaluates SSI eligibility against WA-specific rules
+    (e.g. WA's optional state supplement).
+    """
+
+    pe_inputs = [
+        *Ssi.pe_inputs,
+        dependency.household.WaStateCodeDependency,
+    ]

--- a/programs/programs/wa/pe/tests/test_member.py
+++ b/programs/programs/wa/pe/tests/test_member.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for WA member-level PolicyEngine calculator classes.
+
+Mirrors the TX SSI tests in programs/programs/tx/pe/tests/test_member.py and
+verifies WA-specific calculator wiring (state code dependency, registration,
+inheritance from the federal Ssi calculator).
+"""
+
+from django.test import TestCase
+
+from programs.programs.federal.pe.member import Ssi
+from programs.programs.policyengine.calculators.dependencies import household
+from programs.programs.policyengine.calculators.dependencies.household import WaStateCodeDependency
+from programs.programs.wa.pe import wa_pe_calculators, wa_member_calculators
+from programs.programs.wa.pe.member import WaSsi
+
+
+class TestWaSsi(TestCase):
+    """Tests for WaSsi calculator class."""
+
+    def test_exists_and_is_subclass_of_ssi(self):
+        """
+        Test that WaSsi calculator class exists and is a subclass of the
+        federal Ssi calculator (which sets pe_name="ssi").
+        """
+        self.assertTrue(issubclass(WaSsi, Ssi))
+        self.assertEqual(WaSsi.pe_name, "ssi")
+        self.assertIsNotNone(WaSsi.pe_inputs)
+        self.assertGreater(len(WaSsi.pe_inputs), 0)
+
+    def test_is_registered_in_wa_pe_calculators(self):
+        """Test that WA SSI is registered under name_abbreviated 'wa_ssi'."""
+        self.assertIn("wa_ssi", wa_member_calculators)
+        self.assertIn("wa_ssi", wa_pe_calculators)
+        self.assertEqual(wa_pe_calculators["wa_ssi"], WaSsi)
+
+    def test_is_registered_in_global_registry(self):
+        """Test that WA SSI is exposed via the cross-state PolicyEngine registry."""
+        from programs.programs.policyengine.calculators.registry import (
+            all_calculators,
+            all_member_calculators,
+        )
+
+        self.assertIn("wa_ssi", all_member_calculators)
+        self.assertIn("wa_ssi", all_calculators)
+        self.assertEqual(all_member_calculators["wa_ssi"], WaSsi)
+
+    def test_pe_inputs_includes_all_parent_inputs_plus_wa_specific(self):
+        """
+        WaSsi should inherit all inputs from parent Ssi class plus add
+        WaStateCodeDependency.
+        """
+        self.assertGreater(len(WaSsi.pe_inputs), len(Ssi.pe_inputs))
+        self.assertIn(household.WaStateCodeDependency, WaSsi.pe_inputs)
+        for parent_input in Ssi.pe_inputs:
+            self.assertIn(parent_input, WaSsi.pe_inputs)
+
+    def test_pe_inputs_includes_wa_state_code_dependency(self):
+        """
+        WaStateCodeDependency must be in pe_inputs and configured with
+        state="WA" so PolicyEngine evaluates SSI under Washington rules.
+        """
+        self.assertIn(WaStateCodeDependency, WaSsi.pe_inputs)
+        self.assertEqual(WaStateCodeDependency.state, "WA")
+        self.assertEqual(WaStateCodeDependency.field, "state_code")
+
+    def test_pe_inputs_includes_ssi_member_dependencies(self):
+        """Spot-check that key SSI member dependencies are inherited."""
+        from programs.programs.policyengine.calculators.dependencies.member import (
+            AgeDependency,
+            IsBlindDependency,
+            IsDisabledDependency,
+            SsiCountableResourcesDependency,
+            SsiEarnedIncomeDependency,
+            SsiReportedDependency,
+            SsiUnearnedIncomeDependency,
+        )
+
+        for dep in (
+            SsiCountableResourcesDependency,
+            SsiReportedDependency,
+            IsBlindDependency,
+            IsDisabledDependency,
+            SsiEarnedIncomeDependency,
+            SsiUnearnedIncomeDependency,
+            AgeDependency,
+        ):
+            self.assertIn(dep, WaSsi.pe_inputs)
+
+    def test_has_same_pe_outputs_as_parent(self):
+        """WaSsi keeps the federal Ssi outputs (PolicyEngine returns the SSI amount)."""
+        self.assertEqual(WaSsi.pe_outputs, Ssi.pe_outputs)

--- a/screener/models.py
+++ b/screener/models.py
@@ -428,6 +428,7 @@ class Screen(models.Model):
             "mydenver": self.has_mydenver,
             "ssi": has_ssi_or_ssi_income,
             "tx_ssi": has_ssi_or_ssi_income,
+            "wa_ssi": has_ssi_or_ssi_income,
             "tx_csfp": self.has_csfp,
             "tx_harris_rides": self.has_harris_county_rides,
             "andcs": self.has_andcs,


### PR DESCRIPTION
## Summary

Adds a Washington-specific SSI program (`wa_ssi`) backed by PolicyEngine, mirroring the existing TX SSI pattern. PolicyEngine evaluates SSI under WA rules via a `WaStateCodeDependency` so the benefit estimate reflects Washington's state-code context (federal SSI amount; WA does not provide a state supplement to most adults).

This is the first PolicyEngine calculator wired up for WA, so it also adds the WA → global PE registry plumbing.

## Changes

- **Calculator**
  - `programs/programs/wa/pe/member.py` — `WaSsi(Ssi)` with `pe_inputs = [*Ssi.pe_inputs, WaStateCodeDependency]`
  - `programs/programs/wa/pe/__init__.py` — registers `wa_ssi` and exposes `wa_member_calculators` / `wa_tax_unit_calculators` / `wa_spm_calculators` / `wa_pe_calculators`
- **Cross-state PolicyEngine registry**
  - `programs/programs/policyengine/calculators/registry.py` — imports and merges WA calculators into `all_member_calculators` / `all_spm_unit_calculators` / `all_tax_unit_calculators`
- **Screener "current benefits" wiring**
  - `screener/models.py` — maps `wa_ssi` to `has_ssi_or_ssi_income` so a user-declared SSI flows through to the WA program
- **Migrations**
  - `programs/migrations/0149_backfill_wa_ssi_base_program.py` — backfill `base_program="ssi"` for existing `wa_ssi` rows (idempotent; mirrors the SSI entries in `0138_backfill_has_calculator_base_program.py`)
  - `programs/migrations/0150_show_wa_ssi_in_has_benefits_step.py` — flag `wa_ssi` as `show_in_has_benefits_step=True` for the WA white label (mirrors `0142_audit_show_in_has_benefits_step.py`)
- **Program config seed**
  - `programs/management/commands/import_program_config_data/data/wa_ssi_initial_config.json` — category, copy, warnings, and document checklist (parallels `tx_ssi_initial_config.json`, with WA-specific copy noting no state supplement)
- **Tests**
  - `programs/programs/wa/pe/tests/test_member.py` — 7 unit tests covering subclass relationship, `pe_name`, registration in WA + global registries, `WaStateCodeDependency` configuration, inherited SSI member dependencies, and `pe_outputs` parity



<img width="1320" height="1170" alt="Screenshot 2026-04-27 at 10 00 54 AM" src="https://github.com/user-attachments/assets/750a33fa-0d6c-43dd-97a4-7cd129d4a964" />



<img width="1023" height="296" alt="Screenshot 2026-04-27 at 10 10 49 AM" src="https://github.com/user-attachments/assets/79f09ecc-c839-4189-9040-17b85fb3c416" />


<img width="1213" height="1010" alt="Screenshot 2026-04-27 at 10 22 04 AM" src="https://github.com/user-attachments/assets/ca749ebe-e556-4007-afd4-3004c982e046" />


<img width="1204" height="1201" alt="Screenshot 2026-04-27 at 10 23 09 AM" src="https://github.com/user-attachments/assets/994e7d54-ddcd-46ca-8c83-dde21d53ea56" />

