### PR TITLE
Fix wa_snap initial config: include category creation fields

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_snap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_snap_initial_config.json
@@ -3,7 +3,9 @@
     "code": "wa"
   },
   "program_category": {
-    "external_name": "wa_food"
+    "external_name": "wa_food",
+    "name": "Food and Nutrition",
+    "icon": "food"
   },
   "program": {
     "name_abbreviated": "wa_snap",


### PR DESCRIPTION
## Summary

- `wa_snap_initial_config.json`'s `program_category` block only specified `external_name`, which works only when the category already exists. Since `wa_snap` is the first WA program config, fresh local DBs fail during import with: `CommandError: Program category 'wa_food' does not exist. To create a new category, provide: icon, name` (raised from `import_program_config.py:_import_program_category`).
- Added `"name": "Food and Nutrition"` and `"icon": "food"` so the import command can create the category instead of erroring out.
- Values match the cross-white-label convention: every other white label's food category uses the same name (`configuration/white_labels/{wa,tx,ma,il,nc,co,cesn}.py`) and the same icon (`programs/migrations/0114_alter_categoryiconname_name.py`). Same pattern as `tx_csfp_initial_config.json`.

## Test plan

- [ ] On a local DB without an existing `wa_food` ProgramCategory, run `python manage.py import_program_config programs/management/commands/import_program_config_data/data/wa_snap_initial_config.json` — expect `[Category]\n  Created: wa_food (ID: <n>)` followed by the `wa_snap` program import succeeding.
- [ ] Verify in Django admin (`/admin/programs/programcategory/`) that `[Washington] Food and Nutrition` exists with `external_name=wa_food`, `icon=food`, linked to the Washington white label.
- [ ] Re-run the same import command — expect `Using existing: wa_food` instead of an error (idempotency).
- [ ] Confirm no other `wa_*` config in `import_program_config_data/data/` is affected (this is currently the only one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Program categories now display with user-friendly names and visual icons for improved organization and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->