### PR TITLE
MFB-971: pass through Heroku dyno exit code in migrations action

### DIFF
--- a/.github/actions/heroku-migrations/action.yml
+++ b/.github/actions/heroku-migrations/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         echo "Running migrations..."
         set +e
-        OUTPUT=$(heroku run -a ${{ inputs.heroku-app-name }} "python manage.py migrate" 2>&1)
+        OUTPUT=$(heroku run --exit-code -a ${{ inputs.heroku-app-name }} "python manage.py migrate" 2>&1)
         STATUS=$?
         set -e
         echo "$OUTPUT"
@@ -53,7 +53,7 @@ runs:
       run: |
         echo "Syncing feature flags..."
         set +e
-        OUTPUT=$(heroku run -a ${{ inputs.heroku-app-name }} "python manage.py sync_feature_flags" 2>&1)
+        OUTPUT=$(heroku run --exit-code -a ${{ inputs.heroku-app-name }} "python manage.py sync_feature_flags" 2>&1)
         STATUS=$?
         set -e
         echo "$OUTPUT"


### PR DESCRIPTION
## Summary

- Add `--exit-code` to both `heroku run` calls in `.github/actions/heroku-migrations/action.yml` so the dyno's exit code propagates to the runner.
- Without it, `heroku run` returns 0 regardless of the inner command, so a failed `python manage.py migrate` left `STATUS=0`, the existing `if [ $STATUS -ne 0 ]` branch never fired, and the composite step exited green even when the schema didn't apply.
- Same fix applied to the `Sync feature flags` step in the same action — same latent bug.

Linear: [MFB-971](https://linear.app/myfriendben/issue/MFB-971/staging-deploy-reports-success-when-heroku-migrations-actually-fail)

## Verified locally against `cobenefits-api-staging`

| Command | Local exit code |
| --- | --- |
| `heroku run -a cobenefits-api-staging "python -c 'import sys; sys.exit(2)'"` | **0** (bug reproduced) |
| `heroku run --exit-code -a cobenefits-api-staging "python -c 'import sys; sys.exit(2)'"` | **2** (correctly propagated) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment pipeline error detection to ensure more reliable build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->