### PR TITLE
MFB-850: fix WA SSI 500 (revert WaSsi.pe_inputs tuple → list)

### DIFF
--- a/programs/programs/wa/pe/member.py
+++ b/programs/programs/wa/pe/member.py
@@ -30,7 +30,7 @@ class WaSsi(Ssi):
     PolicyEngine variable mapping, and the 15 reference test scenarios.
     """
 
-    pe_inputs = (
+    pe_inputs = [
         *Ssi.pe_inputs,
         dependency.household.WaStateCodeDependency,
-    )
+    ]


### PR DESCRIPTION
## Summary

Restores WA screen submissions on `main`. Reverts `WaSsi.pe_inputs` back to a `list` (the form used by every other PE wrapper in the codebase). Picks up where #1471 left off — the playwright run posted to [MFB-850](https://linear.app/myfriendben/issue/MFB-850/wa-ssi#comment-dab825c1) caught a 500 on form submission for any WA screen and this is the cause.

## Root cause

Commit `2b5b91af` (`refactor(wa_ssi): convert WaSsi.pe_inputs from list to tuple`) made `WaSsi.pe_inputs` a tuple while `WaSsi.pe_outputs` (inherited from `Ssi.pe_outputs`) is still a list. `programs/programs/policyengine/policy_engine.py:137` concatenates them:

```python
for Data in program.pe_inputs + program.pe_outputs:
```

`tuple + list` raises `TypeError: can only concatenate tuple (not \"list\") to tuple` at runtime, so every WA screen that includes `WaSsi` (i.e., every WA screen) blows up in `eligibility_results` → `calc_pe_eligibility` → `pe_input`.

The original [code-review writeup](https://github.com/MyFriendBen/benefits-api/blob/main/pull-request-reviews/MFB-850.md) flagged this exact risk:

> 3. CodeRabbit's nitpick (subjective). The bot suggested converting `pe_inputs = [...]` to a tuple for immutability. The whole codebase uses lists (`Ssi.pe_inputs`, `TxSsi`-style wrappers, etc.) and there's no precedent for tuples. **Recommend dismissing.**

…and then dismissed its own recommendation. This PR re-applies the original recommendation.

## What changes

```diff
-    pe_inputs = (
+    pe_inputs = [
         *Ssi.pe_inputs,
         dependency.household.WaStateCodeDependency,
-    )
+    ]
```

Two characters. Net diff `+2 / −2`, one file.

## Reproduction

Locally against `benefits-api` (this branch's parent at `2c6dc16b`) + `benefits-calculator main`, walked through the funnel as the playwright persona in [`benefits-calculator/tests/mfb-850-wa-ssi-staging.spec.ts`](https://github.com/Gary-Community-Ventures/benefits-calculator/blob/main/tests/mfb-850-wa-ssi-staging.spec.ts):

| State | Result |
|---|---|
| Pre-fix | `GET /api/eligibility/<uuid>` → **500** with `TypeError: can only concatenate tuple (not \"list\") to tuple` (full stack trace in `programs/programs/policyengine/policy_engine.py:137`); SPA renders \"Oops! Looks like something went wrong\" page. |
| Post-fix | `GET /api/eligibility/<uuid>` → **200**; results page renders **\"1 Programs Found · Supplemental Security Income (SSI) · \$994/month\"**, matching `spec.md` Scenario 1's expected value (full FBR for an aged-only persona). |

## Test plan

- [x] All 9 unit tests in `programs/programs/wa/pe/tests/test_member.py` still pass — assertions are type-agnostic (`assertIn`, `assertEqual`, `len()`, `for x in pe_inputs`) and behave identically against a list.
- [x] End-to-end reproduction in cursor browser using local backend + frontend dev servers, against the playwright persona's screen path.
- [ ] Re-run the failing playwright spec [`mfb-850-wa-ssi-staging.spec.ts`](https://github.com/Gary-Community-Ventures/benefits-calculator/blob/main/tests/mfb-850-wa-ssi-staging.spec.ts) on staging once this is deployed.

## Optional follow-ups (not in this PR)

- Harden `pe_input()` to coerce both sides via `list(program.pe_inputs) + list(program.pe_outputs)` so any future tuple drop-in for `pe_inputs`/`pe_outputs` cannot recreate this class of bug.
- Add a single `Screen.has_benefit(\"wa_ssi\") == True when has_ssi=True` unit test for the `_build_benefit_map` mapping (suggested in the original review).


Made with [Cursor](https://cursor.com)