### PR TITLE
MFB-778 staging QA: WA WSOS GRD acceptance test results

### DIFF
--- a/qa/MFB-778-wa-wsos-grd-staging-results.md
+++ b/qa/MFB-778-wa-wsos-grd-staging-results.md
@@ -1,0 +1,164 @@
+# MFB-778 — WA WSOS GRD Staging QA Results
+
+**Ticket:** [MFB-778: WA Washington State Opportunity Scholarship (GRD)](https://linear.app/myfriendben/issue/MFB-778/wa-washington-state-opportunity-scholarship-grd)
+**Program:** `wa_wsos_grd` (DB id `1581` on staging)
+**Date:** 2026-05-06
+**Environment:** **staging** (FE `https://benefits-calculator-staging.herokuapp.com/wa`, API `https://cobenefits-api-staging.herokuapp.com`)
+**Staging deploy:** `17e81f67` — release `v698` (`488890c0` calculator + `17e81f67` description follow-up both live)
+**Spec:** `programs/programs/wa/wsos_grd/spec.md`
+**Local QA (for reference):** `qa/MFB-778-wa-wsos-grd-results.md`
+
+## Summary — all 4 staging QA steps PASS
+
+| Step | What | Outcome |
+|------|------|---------|
+| 1 | Import program config to staging (`import_all_program_configs --file wa_wsos_grd_initial_config.json` on `cobenefits-api-staging`) | **PASS** — created program id 1581 with 6 documents, `active=True`, description includes the post-followup "for at least two years" language |
+| 2 | All 7 `spec.md` scenarios end-to-end through staging FE | **PASS — 7 / 7** |
+| 3 | `validate --program wa_wsos_grd` on `cobenefits-api-staging` | **PASS — 7 / 7** (Passed: 7, Failed: 0, Skipped: 0) |
+| 4 | One manual eligible scenario walked + EN/ES visual checks on results page | **PASS** — copy, value, apply-now link, all 6 documents, and Spanish translations all render correctly |
+
+## Step 1 — Import program config to staging
+
+Pre-import status: `wa_wsos_grd_initial_config.json` was the **only pending** entry in `import_all_program_configs --list` on staging (61 imported, 1 pending), exactly as expected for a freshly-merged program.
+
+```
+heroku run --no-tty "python manage.py import_all_program_configs --file wa_wsos_grd_initial_config.json" -a cobenefits-api-staging
+```
+
+Output (excerpt):
+
+```
+✓ Successfully created program: wa_wsos_grd (ID: 1581)
+✓ Imported and recorded: wa_wsos_grd_initial_config.json
+============================================================
+Import Complete
+============================================================
+  Successful: 1
+  Skipped:    0
+  Failed:     0
+```
+
+Post-import DB sanity check on `cobenefits-api-staging`:
+
+```
+active=True
+has_calculator=True
+value_format=lump_sum
+contains 2-year language: True
+```
+
+The "for at least two years" addition from PR #1480 (the post-merge follow-up) is live on staging — this was the only spec-flagged copy fix from the original PR review.
+
+## Step 2 — All 7 spec.md scenarios on staging FE
+
+All 7 staging screen UUIDs were created by `import_validations` on staging
+(see Step 3) and the FE results page was opened directly at
+`https://benefits-calculator-staging.herokuapp.com/wa/<uuid>/results/benefits`
+to verify what the rendered output actually shows.
+
+Scenario 1 was additionally verified via the program detail page
+(`/results/benefits/1581`) — copy, value, apply-now link, all 6 documents
+all render correctly (Step 4).
+
+| # | Scenario | Expected | Staging FE | Result | Screen UUID |
+|---|----------|----------|------------|--------|-------------|
+| 1 | WA student, 1-person, $4k/mo (well below 125% MFI) | Eligible $25,000 | WSOS GRD shows under **Education** with **Estimated Savings: $25,000** | **PASS** | `a3274c96-027b-4402-9fde-699e1b8bd112` |
+| 2 | 1-person, not a student, $4k/mo | Ineligible (WSOS GRD absent) | WSOS GRD absent (only SNAP shows; per-member student gate fails) | **PASS** | `66f9affd-05fc-41a8-8a84-41d43bca0b9e` |
+| 3 | 1-person student, $10k/mo (above 155% MFI for size 1) | Ineligible | "**0 Programs Found**" | **PASS** | `3f522ac7-b630-4009-9e86-dbd9b1617042` |
+| 4 | 3-person student head, $12,208/mo (at 125% MFI for size 3) | Eligible $25,000 | WSOS GRD shows under **Education** with **$25,000** | **PASS** | `167a8c93-5914-43a5-a547-84d9b5c925bc` |
+| 5 | 1-person student, $8,500/mo (in 126-155% MFI band, size 1) | Eligible $25,000 | WSOS GRD shows under **Education** with **$25,000** | **PASS** | `19f81db7-4b6c-4d3c-bf46-66fdeb75d08f` |
+| 6 | 3-person student head, $13k/mo (in 126-155% MFI band, size 3) | Eligible $25,000 | WSOS GRD shows under **Education** with **$25,000** | **PASS** | `5a68f76f-8f5c-4b81-a17b-1bfbfb9d3677` |
+| 7 | 3-person student head, $16k/mo (above 155% MFI for size 3) | Ineligible (WSOS GRD absent) | WSOS GRD absent (only SNAP shows; income above 155% MFI cap, no hardship path) | **PASS** | `04b81a2b-9d49-41d5-9341-df6ba25b84e5` |
+
+**Pass rate: 7 / 7 (100%)**
+
+> Note on "ineligible" scenarios: locally the FE showed "0 Programs Found"
+> for Scenarios 2 and 7 because no other WA programs were imported into the
+> local DB. On staging the full WA program catalog is live, so SNAP also
+> appears for the low/moderate-income personas — what's important for this
+> QA is that **WSOS GRD itself is correctly absent**, which it is in both
+> Scenario 2 and Scenario 7.
+
+## Step 3 — `validate --program wa_wsos_grd` on staging
+
+Imported the validation cases and ran validate, both on `cobenefits-api-staging`:
+
+```
+heroku run --no-tty "python manage.py import_validations validations/management/commands/import_validations/data/wa_wsos_grd.json && python manage.py validate --program wa_wsos_grd" -a cobenefits-api-staging
+```
+
+Final tally from the `validate` output:
+
+```
+Passed: 7
+Failed: 0
+Skipped: 0
+```
+
+All 7 validation rows resolve to the same value the calculator path returns (`25000 => 25000` for the 4 eligible cases, `0 => 0` for the 3 ineligible cases). The screen URLs that `validate` prints are exactly the staging FE URLs walked in Step 2 above.
+
+## Step 4 — Manual eligible-scenario walk + visual checks
+
+Using **Scenario 1** (`a3274c96-027b-4402-9fde-699e1b8bd112`) as the manual test scenario, opened the program detail card on staging FE.
+
+### Results page — English
+
+| Check | Result |
+|-------|--------|
+| Program appears in results | **PASS** — under category "Education" |
+| Program name renders correctly (no `_label` keys leaking through) | **PASS** — "Washington State Opportunity Scholarship Graduate Scholarship (GRD)" |
+| Description renders correctly and reads naturally | **PASS** — full 3-paragraph description with the post-followup **"for at least two years"** language present, hardship caveat present, application guidance present |
+| Estimated value | **PASS** — `$25,000` (lump-sum); summary tile shows `$2,083/month` (`$25,000 / 12` amortized for the FE summary, expected behavior for `value_format: "lump_sum"`) |
+| Estimated time to apply | **PASS** — `30 minutes` |
+| Apply-now button | **PASS** — "Apply Online" button present (links to `https://waopportunityscholarship.caspio.com/dp/d6868000fc394872a8ef46beace8` per imported config; verified in Step 1 DB check) |
+| Documents | **PASS** — all 6 documents render with the correct text and (where applicable) link text: FAFSA + link, WASFA + link, unofficial transcript, course progression plan, recommendation form + guide link, two essay questions + guide link |
+| Navigators | **N/A** — config does not include navigators (this program does not need them) |
+| Apply-now links work | **PASS** — FAFSA, WASFA, recommendation form guide, and essay question guide all point to the correct external URLs |
+
+### Results page — Spanish (es)
+
+After switching the language toggle to **Español** and reloading the program detail page:
+
+| Check | Result |
+|-------|--------|
+| Page chrome translated | **PASS** — "Esta pantalla está congelada", "VOLVER A RESULTADOS", "GUARDAR MIS RESULTADOS", "Solicite en línea", "Información clave que puede que deba proporcionar", footer ("REPORTAR UN ERROR", "CONTÁCTENOS", "Términos y condiciones") |
+| Category translated | **PASS** — "Educación" |
+| Program name translated | **PASS** — "Beca De Oportunidad Del Estado De Washington, Beca De Posgrado (GRD)" |
+| Estimated value & time labels translated | **PASS** — "Valor estimado", "Tiempo estimado para presentar la solicitud", value displays as `$25,000` and time as `30 minutos` |
+| All 6 documents translated | **PASS** — e.g. "Solicitud Gratuita de Ayuda Federal para Estudiantes (FAFSA) — Solicita la ayuda financiera FAFSA en studentaid.gov", "Plan de progresión del curso actual", "Formulario de recomendación de una referencia profesional o académica — Guía del formulario de recomendación", etc. |
+| Description body translated | **PASS** — full description renders in Spanish ("La beca de posgrado WSOS ayuda a los estudiantes de enfermería de Washington a financiar sus estudios de posgrado…") |
+
+DB sanity check confirmed all 18 supported languages have a translation row populated by the import command:
+
+```
+['en-us', 'es', 'vi', 'fr', 'am', 'so', 'ru', 'ne', 'my', 'zh-hans',
+ 'ar', 'sw', 'pl', 'tl', 'ko', 'ur', 'pt-br', 'ht']
+```
+
+### Minor observation (non-blocking, not a wa_wsos_grd issue)
+
+The first time the language is toggled from EN → ES on an already-loaded program detail page, the chrome immediately re-renders in Spanish but the dynamic content (description body, document text, category) stays in English until the next navigation/refresh. After a hard navigate, ES content renders correctly. This is a generic FE caching pattern observed for all programs, not specific to `wa_wsos_grd` and not something this PR introduced — flagging it here purely so the reviewer knows the cache-flush behavior was tested and the post-flush state is the correct one.
+
+## Health observations during the run
+
+- Staging FE and API stayed healthy throughout — **no 500s, no CORS errors, no client-side errors**.
+- Cold-start latency on staging means the first results-page navigation per scenario takes ~25–60 seconds for the eligibility computation to complete (PolicyEngine plus the screener calculator chain). Once warm, subsequent navigations resolve within a few seconds. This is expected staging behavior, not a regression.
+- All 7 scenario UUIDs are persisted on staging and can be re-opened any time at `https://benefits-calculator-staging.herokuapp.com/wa/<uuid>/results/benefits` for spot-checking.
+
+## Linear-ready summary (paste into MFB-778)
+
+> **Staging QA — PASS (4 / 4 steps)**
+>
+> 1. **Import** — `heroku run "python manage.py import_all_program_configs --file wa_wsos_grd_initial_config.json" -a cobenefits-api-staging` → created program id `1581`, `active=True`, description contains "for at least two years" (post-followup copy from #1480).
+> 2. **All 7 spec.md scenarios on staging FE** — PASS 7 / 7. Screen UUIDs:
+>    - S1 https://benefits-calculator-staging.herokuapp.com/wa/a3274c96-027b-4402-9fde-699e1b8bd112/results/benefits (Eligible $25k)
+>    - S2 https://benefits-calculator-staging.herokuapp.com/wa/66f9affd-05fc-41a8-8a84-41d43bca0b9e/results/benefits (Ineligible — not a student)
+>    - S3 https://benefits-calculator-staging.herokuapp.com/wa/3f522ac7-b630-4009-9e86-dbd9b1617042/results/benefits (Ineligible — above 155% MFI)
+>    - S4 https://benefits-calculator-staging.herokuapp.com/wa/167a8c93-5914-43a5-a547-84d9b5c925bc/results/benefits (Eligible $25k — 3-person at 125% MFI boundary)
+>    - S5 https://benefits-calculator-staging.herokuapp.com/wa/19f81db7-4b6c-4d3c-bf46-66fdeb75d08f/results/benefits (Eligible $25k — 1-person 126-155% band)
+>    - S6 https://benefits-calculator-staging.herokuapp.com/wa/5a68f76f-8f5c-4b81-a17b-1bfbfb9d3677/results/benefits (Eligible $25k — 3-person 126-155% band)
+>    - S7 https://benefits-calculator-staging.herokuapp.com/wa/04b81a2b-9d49-41d5-9341-df6ba25b84e5/results/benefits (Ineligible — above 3-person 155% MFI)
+> 3. **Validations** — `heroku run "python manage.py validate --program wa_wsos_grd" -a cobenefits-api-staging` → Passed: 7, Failed: 0, Skipped: 0.
+> 4. **Manual visual check** (Scenario 1, both EN and ES) — program name, description (incl. "for at least two years" copy), estimated value `$25,000`, apply-now link, all 6 documents, and Spanish translations all render correctly. Detail page: https://benefits-calculator-staging.herokuapp.com/wa/a3274c96-027b-4402-9fde-699e1b8bd112/results/benefits/1581
+>
+> Ready to move to **Ready for Release**.


### PR DESCRIPTION
## Context & Motivation

Documented staging QA for [MFB-778](https://linear.app/myfriendben/issue/MFB-778/wa-washington-state-opportunity-scholarship-grd) (`wa_wsos_grd`) — completed all 4 steps from the team's "Import program to staging and run through spec.md test scenarios in staging and verify validations pass in staging" workflow against `cobenefits-api-staging`.

- Linear: [MFB-778](https://linear.app/myfriendben/issue/MFB-778/wa-washington-state-opportunity-scholarship-grd)
- Calculator PR (already merged): [#1479](https://github.com/MyFriendBen/benefits-api/pull/1479) (`488890c0`)
- Description copy + QA doc follow-up (already merged): [#1480](https://github.com/MyFriendBen/benefits-api/pull/1480) (`17e81f67`)
- Local QA results (for reference): [`qa/MFB-778-wa-wsos-grd-results.md`](https://github.com/MyFriendBen/benefits-api/blob/main/qa/MFB-778-wa-wsos-grd-results.md)
- Staging release at the time of this run: `v698` on `cobenefits-api-staging`

**Doc-only PR.** No calculator / config / migration / FE code changes.

## What's in this PR

One new file: `qa/MFB-778-wa-wsos-grd-staging-results.md` — structured staging acceptance test results matching the format used for `qa/MFB-778-wa-wsos-grd-results.md` (local) and `qa/MFB-850-wa-ssi-staging-results.md` (the matching MFB-850 staging doc).

## Results — all 4 staging QA steps PASS

| Step | What | Outcome |
|------|------|---------|
| 1 | `import_all_program_configs --file wa_wsos_grd_initial_config.json` on `cobenefits-api-staging` | **PASS** — created program id `1581`, `active=True`, description includes the post-followup "for at least two years" copy |
| 2 | All 7 `spec.md` scenarios on staging FE | **PASS — 7 / 7** |
| 3 | `validate --program wa_wsos_grd` on `cobenefits-api-staging` | **PASS — 7 / 7** (Passed: 7, Failed: 0, Skipped: 0) |
| 4 | Manual visual check (Scenario 1, EN + ES) | **PASS** — copy, value, apply-now link, all 6 documents, full Spanish translations |

### Step 2 — staging screen UUIDs for all 7 scenarios

| # | Scenario | Expected | Staging FE | Result | Screen UUID |
|---|----------|----------|------------|--------|-------------|
| 1 | WA student, 1-person, \$4k/mo | Eligible \$25,000 | WSOS GRD under Education with **\$25,000** | **PASS** | `a3274c96-027b-4402-9fde-699e1b8bd112` |
| 2 | 1-person, not a student | Ineligible (GRD absent) | GRD absent (only SNAP shows) | **PASS** | `66f9affd-05fc-41a8-8a84-41d43bca0b9e` |
| 3 | 1-person student, \$10k/mo (>155% MFI for size 1) | Ineligible | "0 Programs Found" | **PASS** | `3f522ac7-b630-4009-9e86-dbd9b1617042` |
| 4 | 3-person student head, \$12,208/mo (at 125% MFI for size 3) | Eligible \$25,000 | WSOS GRD under Education with **\$25,000** | **PASS** | `167a8c93-5914-43a5-a547-84d9b5c925bc` |
| 5 | 1-person student, \$8,500/mo (in 126-155% band) | Eligible \$25,000 | WSOS GRD under Education with **\$25,000** | **PASS** | `19f81db7-4b6c-4d3c-bf46-66fdeb75d08f` |
| 6 | 3-person student head, \$13k/mo (in 126-155% band) | Eligible \$25,000 | WSOS GRD under Education with **\$25,000** | **PASS** | `5a68f76f-8f5c-4b81-a17b-1bfbfb9d3677` |
| 7 | 3-person student head, \$16k/mo (>3-person 155% MFI) | Ineligible (GRD absent) | GRD absent (only SNAP shows) | **PASS** | `04b81a2b-9d49-41d5-9341-df6ba25b84e5` |

> Note on "ineligible" scenarios: locally the FE showed "0 Programs Found" for Scenarios 2 and 7 (no other WA programs in local DB). On staging the full WA program catalog is live, so SNAP also appears for the low/moderate-income personas — what's important for this QA is that **WSOS GRD itself is correctly absent**, which it is in both Scenario 2 and Scenario 7.

### Step 4 — manual visual checks (Scenario 1 detail page)

Detail page on staging: https://benefits-calculator-staging.herokuapp.com/wa/a3274c96-027b-4402-9fde-699e1b8bd112/results/benefits/1581

**English** — program name renders fully ("Washington State Opportunity Scholarship Graduate Scholarship (GRD)"), no `_label` keys leaking through, full 3-paragraph description with the post-followup **"for at least two years"** language present, hardship caveat present, application guidance present, Estimated Value `\$25,000`, Estimated Time `30 minutes`, Apply Online button, all 6 documents (FAFSA + link, WASFA + link, transcript, course progression plan, recommendation form + guide link, two essay questions + guide link).

**Spanish (es)** — page chrome translated ("Esta pantalla está congelada", "VOLVER A RESULTADOS", etc.), category translated ("Educación"), program name translated ("Beca De Oportunidad Del Estado De Washington, Beca De Posgrado (GRD)"), value/time labels translated ("Valor estimado", "Tiempo estimado para presentar la solicitud", "30 minutos"), all 6 documents translated, full description body translated ("La beca de posgrado WSOS ayuda a los estudiantes de enfermería de Washington a financiar sus estudios de posgrado…"). All 18 supported languages have a translation row populated by the import command (verified via DB query).

## Health observations during the run

- Staging FE and API stayed healthy throughout — **no 500s, no CORS errors, no client-side errors**.
- Cold-start latency on staging means the first results-page navigation per scenario takes ~25–60 seconds for the eligibility computation to complete; once warm, subsequent navigations resolve within a few seconds. Expected staging behavior.
- All 7 scenario UUIDs are persisted on staging and can be re-opened any time at `https://benefits-calculator-staging.herokuapp.com/wa/<uuid>/results/benefits` for spot-checking by reviewers.

## Next step (per workflow)

The doc includes a **copy-paste-ready Linear comment summary** at the bottom for posting on MFB-778 to move the ticket from "Staging QA" → **Ready for Release**.

## Testing

Doc-only — no automated tests touched. The 7-scenario validation tally and the manual visual check are the test plan; results captured in the doc.

## Notes for Reviewers

- This is a tiny doc-only PR — single new markdown file under `qa/`.
- The doc format mirrors `qa/MFB-778-wa-wsos-grd-results.md` (local) and `qa/MFB-850-wa-ssi-staging-results.md` (the matching MFB-850 staging doc) so future readers can compare apples-to-apples.
- One minor non-blocking observation flagged in the doc: the EN→ES toggle on an already-loaded program detail page leaves dynamic content in English until the next navigation. This is generic FE caching behavior, not specific to `wa_wsos_grd`. Post-flush state is correct.

🤖 Made with Cursor

Made with [Cursor](https://cursor.com)