### PR TITLE
fix: black-format wa/ssdi calculator + tests for psf/black@stable

### DIFF
--- a/programs/programs/wa/ssdi/calculator.py
+++ b/programs/programs/wa/ssdi/calculator.py
@@ -50,7 +50,9 @@ class WaSsdi(ProgramCalculator):
         if birth_month is None:
             birth_month = 1
 
-        fra_date = date(birth_year + fra_years + (birth_month + fra_months - 1) // 12, (birth_month + fra_months - 1) % 12 + 1, 1)
+        fra_date = date(
+            birth_year + fra_years + (birth_month + fra_months - 1) // 12, (birth_month + fra_months - 1) % 12 + 1, 1
+        )
 
         return reference_date < fra_date
 
@@ -60,11 +62,7 @@ class WaSsdi(ProgramCalculator):
         e.condition(member.long_term_disability is True)
 
         if member.birth_year is not None:
-            e.condition(self._is_under_fra(
-                member.birth_year, 
-                member.birth_month,
-                self.screen.get_reference_date()
-            ))
+            e.condition(self._is_under_fra(member.birth_year, member.birth_month, self.screen.get_reference_date()))
 
         earned_income = int(member.calc_gross_income("monthly", ["earned"]))
         sga_limit = self.sga_blind if member.visually_impaired else self.sga_non_blind
@@ -82,7 +80,5 @@ class WaSsdi(ProgramCalculator):
             messages.must_not_have_benefit("SSDI"),
         )
 
-        has_disability = any(
-            me.eligible for me in e.eligible_members
-        )
+        has_disability = any(me.eligible for me in e.eligible_members)
         e.condition(has_disability, messages.has_disability())

--- a/programs/programs/wa/ssdi/tests/test_wa_ssdi.py
+++ b/programs/programs/wa/ssdi/tests/test_wa_ssdi.py
@@ -124,11 +124,12 @@ class TestWaSsdiMemberEligibility(TestCase):
         member = make_member(age=65, birth_year=1960, birth_month=11)
         self.assertTrue(self._run(member))
 
+
 class TestWaSsdiHouseholdEligibility(TestCase):
     def _run(self, has_ssdi=False, eligible_members=None):
         calc = make_calculator(has_ssdi=has_ssdi)
         e = Eligibility()
-        for member in (eligible_members or [make_member()]):
+        for member in eligible_members or [make_member()]:
             me = MemberEligibility(member)
             me.eligible = True
             e.add_member_eligibility(me)


### PR DESCRIPTION
## Context & Motivation

Main has been red on the `Check Formatting / black formatter` job since #1476 (MFB-757 wa ssdi) merged. Two SSDI files pass our pinned `requirements.txt: black==24.3.0` locally but fail Black-stable in CI.

**Root cause:** the `psf/black@stable` action installs the *latest stable* Black (currently 26.3.1), which is stricter than 24.3.0. The newer version flags:

- `programs/programs/wa/ssdi/calculator.py` — one >120-char line + two short multi-line calls that fit on a single line
- `programs/programs/wa/ssdi/tests/test_wa_ssdi.py` — missing PEP 8 two-blank-lines between classes + redundant parens around an `or` expression

This was masked at PR-time for both #1476 (wa ssdi) and #1484 (wa csfp) because the PR-event Black workflow only diffs against the PR's base.sha, so it didn't catch existing 26.3.1 violations on those files until the push-to-main run scanned the whole repo. (Same root cause briefly broke #1483's PR run after a stale base.sha picked them up — my rebase fixed that, and merging surfaced this main-branch-level break.)

## Changes Made

Whitespace-only changes — verified Black-clean under both `24.3.0` (our pinned version) and `26.3.1` (Black-stable).

**`programs/programs/wa/ssdi/calculator.py`**
- Wrap one >120-char `fra_date = date(...)` assignment.
- Collapse multi-line `_is_under_fra(...)` call to one line (now fits).
- Collapse multi-line `any(...)` generator to one line (now fits).

**`programs/programs/wa/ssdi/tests/test_wa_ssdi.py`**
- Add the missing second blank line between `TestWaSsdiMemberEligibility` and `TestWaSsdiHouseholdEligibility` (PEP 8).
- Remove the redundant parens around `eligible_members or [make_member()]` in the for-loop iterable.

## Testing

* Migrations to run: none.
* Configuration updates needed: none.
* Environment variables/settings to add: none.
* Manual testing steps:
  ```bash
  # Verify formatter happy under both versions
  pip install 'black==24.3.0' && python -m black --check --line-length 120 programs/programs/wa/ssdi/
  pip install 'black==26.3.1' && python -m black --check --line-length 120 programs/programs/wa/ssdi/
  # → All done! ✨ 🍰 ✨ (both)

  # Confirm tests still pass
  python manage.py test programs.programs.wa.ssdi -v 1
  # → Ran 24 tests in 0.043s — OK
  ```

## Deployment

* Post-deployment scripts needed: none.
* Production config updates: none.
* Admin updates needed: none.
* Notify team/users of: nothing user-facing changes.

## Notes for Reviewers

This is a pure CI-fix PR — no behavior change, no test changes, no migrations. The interesting follow-up is whether to **pin `psf/black@stable` to a specific tag** in `.github/workflows/format.yaml` to keep the CI Black version in sync with `requirements.txt`, so the next Black point-release upgrade doesn't surprise anyone again. Out of scope here; could be a one-line follow-up PR.

Made with [Cursor](https://cursor.com)