### PR TITLE
MFB-977: add CESN heat pump journey feature flag

### DIFF
--- a/screener/feature_flags.py
+++ b/screener/feature_flags.py
@@ -52,7 +52,11 @@ WHITELABEL_FEATURE_FLAGS: dict[str, FeatureFlagConfig] = {
     ),
     "cesn_heat_pump_journey": FeatureFlagConfig(
         label="CESN Heat Pump Journey",
-        description="Enable the Colorado Energy Savings Network (CESN) heat pump results journey in the screener.",
+        description=(
+            "Show the 3-card heat pump journey section "
+            "(Why get a heat pump? / Will it impact my bills? / Whom should I hire?) "
+            "on the water heater results page."
+        ),
         scope="frontend",
     ),
 }

--- a/screener/feature_flags.py
+++ b/screener/feature_flags.py
@@ -50,4 +50,9 @@ WHITELABEL_FEATURE_FLAGS: dict[str, FeatureFlagConfig] = {
         description="Show a popup in results that lets users share MyFriendBen with friends via email, SMS, or link.",
         scope="frontend",
     ),
+    "cesn_heat_pump_journey": FeatureFlagConfig(
+        label="CESN Heat Pump Journey",
+        description="Enable the Colorado Energy Savings Network (CESN) heat pump results journey in the screener.",
+        scope="frontend",
+    ),
 }


### PR DESCRIPTION
## Context

Step 1 of [MFB-977 — CESN heat pump journey (feature flag)](https://linear.app/myfriendben/issue/MFB-977/step-1-add-cesn-heat-pump-journey-feature-flag): register a white-label **feature flag** so the benefits-calculator can gate the CESN heat pump results journey behind `config.feature_flags`, and admins can toggle it under **General Settings → Feature Flags** after deploy (with `sync_feature_flags`).

## What changed

- Added **`cesn_heat_pump_journey`** to `WHITELABEL_FEATURE_FLAGS` in `screener/feature_flags.py`.
- **Scope:** `frontend` (surfaced via `ConfigurationSerializer` → `/api/config`).
- **Default:** `false` (explicit safe rollout).

## Follow-ups (not in this PR)

- Frontend: read `config.feature_flags.cesn_heat_pump_journey` and wire journey UI (later MFB steps).
- After merge + deploy: run `python manage.py sync_feature_flags` (or rely on automated deploy hook) so existing `WhiteLabel` rows receive the new key with default `false`.

## Testing

`ENABLE_GOOGLE_INTEGRATIONS=False python manage.py test configuration.tests.TestConfigurationSerializerFeatureFlags screener.management.commands.tests.test_sync_feature_flags.SyncFeatureFlagsCommandTest screener.tests.test_models.TestWhiteLabelFeatureFlags`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added feature flag infrastructure to control a heat pump journey section on the water heater results page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->