### PR TITLE
MFB-966: WA WSOS — Baccalaureate (BaS) calculator

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json
@@ -1,0 +1,70 @@
+{
+  "white_label": {
+    "code": "wa"
+  },
+  "program_category": {
+    "external_name": "wa_education",
+    "name": "Education",
+    "icon": "education"
+  },
+  "program": {
+    "name_abbreviated": "wa_wsos_bas",
+    "legal_status_required": [
+      "citizen",
+      "non_citizen",
+      "refugee",
+      "gc_5plus",
+      "gc_5less",
+      "otherWithWorkPermission"
+    ],
+    "name": "Washington State Opportunity Scholarship Baccalaureate Scholarship (BaS)",
+    "description_short": "Scholarship for Washington undergraduates in STEM or health care",
+    "description": "The WSOS Baccalaureate Scholarship helps Washington students pay for a bachelor's degree. The scholarship gives up to $22,500 over your degree.\n\nThe money goes to your school. It can help pay for tuition, housing, transportation, food, and other school costs. You can use it with other financial aid.\n\nYou must plan to study a STEM or health care major at an approved Washington college or university. You must have a Washington high school credential, or earn one by June of the application year. The scholarship is for students who do not already have a bachelor's degree. You also need to meet WSOS academic requirements or have passing GED scores. You need to plan to take at least three credits in each fall, winter, and spring term while using the scholarship. WSOS welcomes undocumented students who meet the program’s education and residency rules.\n\nBefore you apply, you will need to complete a FAFSA or WASFA — these are free forms that show your financial need. Click How to Apply to see the steps. You will write short essays and upload a recent unofficial transcript. You don't need references or recommendation forms.",
+    "learn_more_link": "https://waopportunityscholarship.org/applicants/baccalaureate/",
+    "apply_button_link": "https://waopportunityscholarship.org/applicants/baccalaureate/#apply",
+    "apply_button_description": "How to Apply",
+    "estimated_application_time": "60 to 90 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": "lump_sum",
+    "value_type": "benefit",
+    "website_description": "Scholarship for Washington undergraduates in STEM or health care",
+    "base_program": null,
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "documents": [
+    {
+      "external_name": "wa_wsos_bas_fafsa",
+      "text": "Free Application for Federal Student Aid (FAFSA)",
+      "link_url": "https://studentaid.gov/h/apply-for-aid/fafsa",
+      "link_text": "Apply for FAFSA at studentaid.gov"
+    },
+    {
+      "external_name": "wa_wsos_bas_wasfa",
+      "text": "Washington Application for State Financial Aid (WASFA)",
+      "link_url": "https://wsac.wa.gov/wasfa",
+      "link_text": "Apply for WASFA at wsac.wa.gov"
+    },
+    {
+      "external_name": "wa_wsos_bas_unofficial_transcript",
+      "text": "High school or college transcript, or passing GED scores",
+      "link_url": "https://waopportunityscholarship.org/transcript-tips/",
+      "link_text": "Transcript tips"
+    },
+    {
+      "external_name": "wa_wsos_bas_essay_question",
+      "text": "Short essay answers",
+      "link_url": "https://waopportunityscholarship.org/bas-short-answer-guide/",
+      "link_text": "BaS short answer guide"
+    }
+  ],
+  "warning_message": {
+    "external_name": "wa_wsos_bas_warning",
+    "calculator": "_show",
+    "message": "The 2026 BaS application deadline was February 26, 2026. Accepted students must respond by May 6, 2026, at 9 p.m. PST. Check the program page for future application dates."
+  }
+}

--- a/programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json
@@ -29,7 +29,6 @@
     "value_format": "lump_sum",
     "value_type": "benefit",
     "website_description": "Scholarship for Washington undergraduates in STEM or health care",
-    "base_program": null,
     "active": true,
     "low_confidence": false,
     "show_on_current_benefits": true,

--- a/programs/programs/wa/__init__.py
+++ b/programs/programs/wa/__init__.py
@@ -1,4 +1,5 @@
 from .csfp.calculator import WaCsfp
+from .wsos_bas.calculator import WaWsosBas
 from .wsos_grd.calculator import WaWsosGrd
 from ..calc import ProgramCalculator
 from .seattle_fresh_bucks.calculator import WaSeattleFreshBucks
@@ -7,6 +8,7 @@ from .ssdi.calculator import WaSsdi
 wa_calculators: dict[str, type[ProgramCalculator]] = {
     "wa_csfp": WaCsfp,
     "wa_ssdi": WaSsdi,
+    "wa_wsos_bas": WaWsosBas,
     "wa_wsos_grd": WaWsosGrd,
     "wa_seattle_fresh_bucks": WaSeattleFreshBucks,
 }

--- a/programs/programs/wa/wsos_bas/calculator.py
+++ b/programs/programs/wa/wsos_bas/calculator.py
@@ -94,26 +94,40 @@ class WaWsosBas(ProgramCalculator):
         return self.MFI_125_BY_SIZE[6] + (size - 6) * self.MFI_125_PER_EXTRA_PERSON_ABOVE_TABLE
 
     def household_eligible(self, e: Eligibility):
-        # `calc_gross_income` returns a float; compare against the limit at
-        # full precision so a household whose annual income is fractionally
-        # above the 125% MFI cap (e.g. $174,500.50 for a 4-person household)
-        # is correctly screened out instead of being floored down onto the
-        # boundary. `messages.income` rounds for display, so passing a float
-        # is fine. Same approach as WaWsosGrd.
+        """
+        Apply the 125% MFI income gate against household annual gross income.
+
+        `calc_gross_income` returns a float; compare against the limit at full
+        precision so a household whose annual income is fractionally above the
+        125% MFI cap (e.g. $174,500.50 for a 4-person household) is correctly
+        screened out instead of being floored down onto the boundary.
+        `messages.income` rounds for display, so passing a float is fine.
+        Same approach as `WaWsosGrd`.
+        """
         gross_income = self.screen.calc_gross_income("yearly", ["all"])
         income_limit = self.income_limit_125()
         e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
 
     def member_eligible(self, e: MemberEligibility):
-        # Any student counts as the BaS applicant. The base ProgramCalculator
-        # auto-fails the household if no member is eligible, which is what we
-        # want when nobody in the household is a student.
+        """
+        Apply the per-member student gate.
+
+        Any member with `student == True` is treated as a potential BaS applicant.
+        `bool(...)` collapses the BooleanField's three states (`True`, `False`,
+        `None`) to a single eligibility decision: only `True` qualifies. The base
+        `ProgramCalculator` auto-fails the household when no member is eligible,
+        which is the behavior we want when nobody in the household is a student.
+        """
         e.condition(bool(e.member.student))
 
     def household_value(self) -> int:
+        """Lump-sum scholarship is awarded once at the household level."""
         return self.amount
 
     def member_value(self, member):
-        # The scholarship is a single lump-sum award per household; all of
-        # the value is reported at the household level via household_value().
+        """
+        Per-member value is always 0; the entire BaS award is reported via
+        `household_value()`. Returning 0 here prevents multi-student households
+        from multiplying the lifetime cap.
+        """
         return 0

--- a/programs/programs/wa/wsos_bas/calculator.py
+++ b/programs/programs/wa/wsos_bas/calculator.py
@@ -1,0 +1,119 @@
+import programs.programs.messages as messages
+from programs.programs.calc import Eligibility, MemberEligibility, ProgramCalculator
+
+
+class WaWsosBas(ProgramCalculator):
+    """
+    Washington State Opportunity Scholarship — Baccalaureate (BaS) track.
+
+    Up to $22,500 lump-sum scholarship over the program duration, applied to
+    Cost of Attendance after other financial aid (Pell, Washington College
+    Grant, etc.). Funds are intended for Washington undergraduates pursuing
+    a first bachelor's degree in an eligible STEM or health care major at an
+    eligible Washington college or university.
+
+    Screener-checkable criteria (what this calculator actually screens):
+      - Washington residency: implicit via the `wa` white label
+      - At least one household member is a student (`member.student == True`).
+        Note: BaS also accepts applicants who plan to enroll but do not yet
+        consider themselves a student. The screener cannot disambiguate, so
+        this gate is necessarily an underestimate.
+      - Household annual income at or below 125% Washington State Median
+        Family Income (MFI) for the household size
+
+    Inclusivity assumptions (per spec.md — fields the screener does not
+    collect; we assume met for any student respondent and surface the
+    caveats in `description`):
+      - Has not yet earned a bachelor's degree (BaS funds the *first*
+        bachelor's only)
+      - Has earned, or will earn by June of the application year, a
+        Washington high school credential or passing GED scores
+      - Cumulative GPA >= 2.75 on a 4.0 scale (or passing GED score)
+      - Has not earned more than 90 quarter / 60 semester credits since
+        high school graduation (Running Start / dual-credit excluded).
+        Per spec direction this constraint is intentionally NOT surfaced
+        in the user-facing description.
+      - Plans to enroll in at least three credits every fall, winter, and
+        spring term while using the scholarship
+      - Enrolled (or planning to enroll) in an eligible STEM or health
+        care major at an eligible Washington institution
+
+    Income test: BaS uses a single 125% MFI threshold by household size —
+    no expanded / hardship-band like the GRD track. We compare current
+    pre-tax household gross income to the 2026 published 125% MFI table.
+
+    Note on the family-of-11 typo: the official 2026 BaS MFI Chart
+    publishes $156,500 for a family of 11, which is out of sequence with
+    surrounding values and identical to the same typo in the GRD chart.
+    Per spec direction, we do not silently "correct" this in code; the
+    typo is worth flagging to WSOS once across all WSOS programs rather
+    than per-program. This calculator's table contains only the
+    monotonic published values for sizes 1-6 plus a documented linear
+    extension for sizes 7+.
+
+    Sources:
+      - https://waopportunityscholarship.org/applicants/baccalaureate/
+        (Eligibility, Education plan, Financial Need)
+      - https://waopportunityscholarship.org/wp-content/uploads/2025/10/
+        Baccalaureate-C15-MFI-Chart.pdf (Official 2026 BaS MFI Chart)
+    """
+
+    # 2026 WSOS BaS 125% MFI thresholds in dollars per year. Per-household-
+    # size lookup table sourced from the official BaS MFI Chart linked
+    # above. BaS has only this single tier (unlike GRD which also has a
+    # 155% expanded band).
+    MFI_125_BY_SIZE = {
+        1: 90_500,
+        2: 118_000,
+        3: 146_500,
+        4: 174_500,
+        5: 202_000,
+        6: 230_000,
+    }
+
+    # Spec only publishes sizes 1-6 (and a typo at size 11). For larger
+    # households, extend by the average increment observed in the
+    # published table (~$28,000 per additional person at 125% MFI):
+    # 1->2: +27.5K, 2->3: +28.5K, 3->4: +28K, 4->5: +27.5K, 5->6: +28K.
+    # Validations only cover sizes 1 and 4 today; this fallback exists so
+    # a 7+ person household is not silently denied or crashed.
+    MFI_125_PER_EXTRA_PERSON_ABOVE_TABLE = 28_000
+
+    amount = 22_500  # lump-sum scholarship per household, per the program page
+
+    dependencies = ["income_amount", "income_frequency", "household_size"]
+
+    def income_limit_125(self) -> int:
+        """
+        Annual 125% MFI income cap for the household's size, with linear
+        extension for sizes larger than the published table.
+        """
+        size = self.screen.household_size
+        if size in self.MFI_125_BY_SIZE:
+            return self.MFI_125_BY_SIZE[size]
+        return self.MFI_125_BY_SIZE[6] + (size - 6) * self.MFI_125_PER_EXTRA_PERSON_ABOVE_TABLE
+
+    def household_eligible(self, e: Eligibility):
+        # `calc_gross_income` returns a float; compare against the limit at
+        # full precision so a household whose annual income is fractionally
+        # above the 125% MFI cap (e.g. $174,500.50 for a 4-person household)
+        # is correctly screened out instead of being floored down onto the
+        # boundary. `messages.income` rounds for display, so passing a float
+        # is fine. Same approach as WaWsosGrd.
+        gross_income = self.screen.calc_gross_income("yearly", ["all"])
+        income_limit = self.income_limit_125()
+        e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+
+    def member_eligible(self, e: MemberEligibility):
+        # Any student counts as the BaS applicant. The base ProgramCalculator
+        # auto-fails the household if no member is eligible, which is what we
+        # want when nobody in the household is a student.
+        e.condition(bool(e.member.student))
+
+    def household_value(self) -> int:
+        return self.amount
+
+    def member_value(self, member):
+        # The scholarship is a single lump-sum award per household; all of
+        # the value is reported at the household level via household_value().
+        return 0

--- a/programs/programs/wa/wsos_bas/spec.md
+++ b/programs/programs/wa/wsos_bas/spec.md
@@ -1,0 +1,208 @@
+# Washington State Opportunity Scholarship (WSOS) — BaS Track Implementation Spec
+
+**Program:** `wa_wsos_bas`  
+**State:** Washington  
+**White Label:** `wa`  
+**Research Date:** 2026-05-05  
+**Self-review update:** 2026-05-06
+
+---
+
+## Eligibility Criteria
+
+1. **Applicant is a Washington state resident** ⚠️ *partial data gap*
+   - Screener fields:
+     - `zipcode`
+     - `county`
+   - Note: BaS requires Washington residency, and the screener can verify current Washington location through ZIP code and county. The screener cannot verify any residency-duration requirement, such as living in Washington for one year before starting college.
+     - **Proxy assumption:** Use current Washington ZIP/county as the calculator proxy for residency.
+     - **Application-stage verification:** Any longer residency-duration requirement is verified during the WSOS application process.
+     - WSOS explicitly accepts undocumented applicants — no immigration status restriction applies.
+     - **Suggested screener refinement:** Only ask this as a BaS-specific follow-up after the user indicates they are pursuing or planning to pursue a STEM or health care program at a Washington college or university.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Residency)
+
+2. **Household income is at or below 125% of Washington State Median Family Income (MFI) for household size** ⚠️ *partial data gap*
+   - Screener fields:
+     - `income_streams` (amount and frequency across all household members)
+     - `household_size`
+   - Note: BaS uses a single income threshold of 125% MFI — no expanded/hardship-based tier like the GRD track.
+   - The official MFI chart is based on 2024 family income for the 2026 cycle. The screener uses current pre-tax household income as a proxy for this income test.
+   - **Proxy assumption:** Use current MFB household income as an approximate proxy for WSOS family income. This may over- or under-estimate eligibility if the applicant’s 2024 family income differs from their current income.
+     - **Implementation note:** Use the official WSOS MFI chart for all household sizes published in the chart. Do not silently extrapolate or “correct” the family-of-11 value without WSOS confirmation.
+     - 2026 MFI thresholds (verified against official WSOS Baccalaureate MFI Chart, applies to 2024 family income):
+       - Family of 1: $90,500
+       - Family of 2: $118,000
+       - Family of 3: $146,500
+       - Family of 4: $174,500
+       - Family of 5: $202,000
+       - Family of 6: $230,000
+     - ⚠️ **Note:** Family of 11 shows $156,500 in the official table — this appears to be a typo (out of sequence with surrounding values). Same typo appears in the GRD MFI chart. Worth flagging to WSOS once across all WSOS programs rather than per-program.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Financial Need); https://waopportunityscholarship.org/wp-content/uploads/2025/10/Baccalaureate-C15-MFI-Chart.pdf (Official 2026 WSOS Baccalaureate MFI Chart)
+
+3. **Applicant is currently a student or planning to enroll as a student in an eligible STEM or health care major at an eligible Washington college/university** ⚠️ *partial data gap*
+   - Screener fields:
+     - `student` (screener asks whether someone is a student — use as a proxy for current/intended enrollment)
+   - Note: BaS is limited to specific STEM and health care majors at eligible WA institutions. The screener captures student status but not intended enrollment, major, or institution.
+     - Eligible majors list: https://waopportunityscholarship.org/baccalaureate-eligible-majors-list/
+     - Eligible institutions list: https://waopportunityscholarship.org/baccalaureate-eligible-institutions-list/
+     - **Inclusivity assumption:** Assume any student respondent is enrolled in (or planning to enroll in) an eligible major at an eligible institution.
+     - BaS is open to applicants who have not yet started college, so `student` alone is an imperfect proxy. A student who plans to enroll but does not currently consider themselves a student could be missed.
+     - **Suggested screener refinement:** Add education-plan questions for scholarship programs:
+       - “Are you currently enrolled, admitted, or planning to enroll in college?”
+       - “Which college or university do you attend or plan to attend?” using the BaS eligible-institutions list.
+       - “What is your intended or declared major / field of study?” using the BaS eligible-majors list.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Education plan)
+
+4. **Applicant has not yet earned a bachelor's degree** ⚠️ *data gap*
+   - Screener fields: none
+   - Note: BaS funds students working toward their *first* bachelor's degree. Not captured in screener.
+     - **Inclusivity assumption:** Assume requirement is met for all student respondents. Devs should add a comment in the calculator noting this assumption.
+     - **Suggested screener refinement:** Add a “highest education level completed” dropdown with options such as “high school credential/GED,” “some college, no degree,” “associate degree,” and “bachelor's degree or higher.” This would also help CTS/BaS-style scholarship programs.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Previous education)
+
+5. **Applicant has earned, or will earn by June of the application year, a Washington state high school credential (or passing GED scores)** ⚠️ *data gap*
+   - Screener fields: none
+   - Note: BaS requires a Washington HS credential or passing GED. Not captured in screener — and importantly stricter than CTS, which does not require the credential to be from a Washington institution.
+     - Passing GED scores: 45 (1988 series), 450 (2002 series), or 145 (2014 series).
+     - **Inclusivity assumption:** Assume requirement is met for all student respondents who indicate WA residency. Devs should add a comment in the calculator noting this assumption.
+     - **Suggested screener refinement:** Add a student/education follow-up asking whether the applicant has earned, or will earn by June of the application year, a high school diploma or GED, and whether it was earned in Washington State.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Previous education)
+
+6. **Cumulative GPA of at least 2.75 (on a 4.0 scale) or passing GED score** ⚠️ *data gap*
+   - Screener fields: none
+   - Note: Verified via transcript at application. Not captured in screener.
+     - **Inclusivity assumption:** Assume requirement is met for all student respondents. Devs should add a comment in the calculator noting this assumption.
+     - **Suggested screener refinement:** Add an optional scholarship follow-up asking for most recent cumulative GPA, with an option like “I do not have a GPA / GED path.” This may add friction, so use only if scholarship screening becomes a priority.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Previous education)
+
+7. **Applicant has not earned more than 90 quarter or 60 semester credits since high school graduation (Running Start and other dual-credit high school program credits do NOT count)** ⚠️ *data gap*
+   - Screener fields: none
+   - Note: BaS is intended for students relatively early in their college path. Credits earned through Running Start or other dual-credit programs are excluded from this count. Not captured in screener.
+     - **Inclusivity assumption (silent):** Assume requirement is met for all student respondents. Devs should add a comment in the calculator noting this assumption.
+     - Per user direction: this constraint is NOT surfaced in the user-facing description. Applicants who have already exceeded the credit ceiling will be incorrectly shown the program; this is acceptable given the dev-only handling pattern chosen here.
+     - **Suggested screener refinement:** If MFB later supports education-specific screening, add a credits-completed question that separates college credits earned after high school from Running Start / dual-credit credits earned during high school.
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Previous education)
+
+8. **Applicant plans to enroll in at least three credits every fall, winter, and spring term** ⚠️ *data gap*
+   - Screener fields: none
+   - Note: Minimum enrollment for BaS funding. Not captured in screener.
+     - **Inclusivity assumption:** Assume requirement is met for all student respondents. Devs should add a comment in the calculator noting this assumption.
+     - **Suggested screener refinement:** Add a scholarship-program follow-up asking expected credits per fall/winter/spring term, or a simpler yes/no question: “Do you plan to take at least 3 credits each fall, winter, and spring term?”
+   - Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Education plan)
+
+---
+
+## Non-Eligibility Items (Administrative / Application Requirements)
+
+These items appear in the program rules but are application requirements, not eligibility criteria. They should be surfaced in the program description, documents list, or application guidance rather than used in eligibility logic:
+
+- **FAFSA or WASFA submission:** Required application step. Already captured in documents list.
+- **Federal Education Tax Credits:** Apply if eligible — compliance requirement, not an eligibility factor.
+- **Application materials** (essays, unofficial transcript): Application requirements. Already captured in documents list. BaS notably does NOT require recommendation forms or references.
+- **Application deadlines:** Timing factor, not eligibility. Should be shown in application guidance or results page. (2026 cycle: opens Jan 14, deadline Feb 26 at 9 p.m. PST; acceptance deadline May 6 at 9 p.m. PST.)
+
+---
+
+## Priority Criteria
+
+These factors affect selection priority but not eligibility:
+
+- The Board of Directors determines final selection criteria, which include factors such as financial need, commitment to STEM or health care, and academic achievement.
+- Selection criteria can vary year to year.
+
+---
+
+## Benefit Value
+
+**Award structure (citable figures from program page):**
+- Up to **$22,500** total in scholarship dollars (lifetime maximum across the program).
+- Funding is applied to the applicant's Cost of Attendance (COA) *after* all other financial aid (e.g., Pell Grant, Washington College Grant).
+- Can cover tuition, housing, transportation, food, and other eligible costs beyond tuition.
+- Per-term/year cap is not specified on the program page (unlike GRD's $6,250 per-term cap).
+- If other financial aid covers part or all of COA, some or all of the scholarship funding may be returned to WSOS.
+
+**Recommended methodology:**
+- Return **$22,500** as a lump sum value (`value_format: "lump_sum"`).
+- This is a citable figure directly from the program page.
+- Actual award depends on cost of attendance, remaining program duration, and other financial aid already applied.
+- Source: https://waopportunityscholarship.org/applicants/baccalaureate/ (Baccalaureate Scholarship 101; “This program provides up to a total of $22,500 in scholarship dollars...”)
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Clearly Eligible — WA Student Below 125% MFI
+**What's being tested:** Baseline eligibility — WA student with income well below the 125% MFI threshold for 1 person ($90,500/year). All screener-checkable criteria met.
+**Expected:** Eligible, value: $22,500
+
+**Steps:**
+- **Location:** Enter ZIP code `98101`, Select county `King`
+- **Household:** Number of people: `1`
+- **Person 1 (Head of Household):** Relationship: `Head of Household`, Birth month/year: `January 2006` (age 20), Student: `Yes`, Has income: `Yes`, Income type: `Wages`, Income amount: `$2,000`, Income frequency: `Monthly`, Insurance: `None`
+- **Current Benefits:** Select `None`
+
+**Why this matters:** Primary regression test confirming the standard eligible case for an undergraduate.
+
+---
+
+### Scenario 2: Clearly Ineligible — Income Above 125% MFI (Single Person)
+**What's being tested:** Single-person household with income above the 125% MFI cutoff ($90,500/year ≈ $7,541/month). Should be screened out — BaS has no expanded/hardship path.
+**Expected:** Ineligible
+
+**Steps:**
+- **Location:** Enter ZIP code `98101`, Select county `King`
+- **Household:** Number of people: `1`
+- **Person 1 (Head of Household):** Relationship: `Head of Household`, Birth month/year: `March 2005` (age 21), Student: `Yes`, Has income: `Yes`, Income type: `Wages`, Income amount: `$8,000`, Income frequency: `Monthly`, Insurance: `None`
+- **Current Benefits:** Select `None`
+
+**Why this matters:** Confirms applicants above the 125% MFI cutoff are correctly screened out. This is a stronger validation scenario than a “not a student” case because BaS also covers students planning to enroll.
+
+---
+
+### Scenario 3: Edge Case — 4-Person Household Just Below the 125% MFI Boundary Due to Monthly Rounding
+**What's being tested:** 4-person household with income just below the 4-person 125% MFI threshold ($174,500/year). The validation uses `$14,541/month`, which annualizes to `$174,492/year`. This tests household-size scaling and near-boundary eligibility, but not exact equality.
+**Expected:** Eligible, value: $22,500
+
+**Steps:**
+- **Location:** Enter ZIP code `98501`, Select county `Thurston`
+- **Household:** Number of people: `4`
+- **Person 1 (Head of Household):** Relationship: `Head of Household`, Birth month/year: `January 1980` (age 46, parent), Has income: `Yes`, Income type: `Wages`, Income amount: `$14,541`, Income frequency: `Monthly`, Insurance: `None`
+- **Person 2 (Spouse):** Relationship: `Spouse`, Birth month/year: `March 1982` (age 44, parent), Has income: `No`, Insurance: `None`
+- **Person 3 (Child — applicant):** Relationship: `Child`, Birth month/year: `September 2008` (age 17), Student: `Yes`, Has income: `No`, Insurance: `None`
+- **Person 4 (Child):** Relationship: `Child`, Birth month/year: `June 2012` (age 13), Student: `No`, Has income: `No`, Insurance: `None`
+- **Current Benefits:** Select `None`
+
+**Why this matters:** Confirms the 125% MFI threshold scales correctly with household size and reflects a typical BaS applicant scenario (high school senior in a family of 4). If the validation system supports annual income frequency, a separate exact-boundary test could use `$174,500/year`.
+
+---
+
+### Scenario 4: Clearly Ineligible — Large Household, Income Above Scaled 125% MFI
+**What's being tested:** 4-person household with income above the 4-person 125% MFI threshold ($174,500/year = about $14,541.67/month). `$16,000/month` exceeds this threshold.
+**Expected:** Ineligible
+
+**Steps:**
+- **Location:** Enter ZIP code `98501`, Select county `Thurston`
+- **Household:** Number of people: `4`
+- **Person 1 (Head of Household):** Relationship: `Head of Household`, Birth month/year: `January 1980` (age 46, parent), Has income: `Yes`, Income type: `Wages`, Income amount: `$16,000`, Income frequency: `Monthly`, Insurance: `None`
+- **Person 2 (Spouse):** Relationship: `Spouse`, Birth month/year: `March 1982` (age 44, parent), Has income: `No`, Insurance: `None`
+- **Person 3 (Child — applicant):** Relationship: `Child`, Birth month/year: `September 2008` (age 17), Student: `Yes`, Has income: `No`, Insurance: `None`
+- **Person 4 (Child):** Relationship: `Child`, Birth month/year: `June 2012` (age 13), Student: `No`, Has income: `No`, Insurance: `None`
+- **Current Benefits:** Select `None`
+
+**Why this matters:** Confirms a multi-member household above its scaled 125% threshold is correctly screened out.
+
+---
+
+### Scenario 5: Eligible — Mixed Household, Student-as-Head with Non-Student Spouse and Child
+**What's being tested:** Returning adult learner (age 28) is the head of household and the BaS applicant. Non-student spouse and young child still count toward household size and income but are not evaluated as the applicant. Income `$4,000/month` (`$48,000/year`) is well below the 3-person 125% MFI cap of `$146,500/year`.
+**Expected:** Eligible, value: $22,500
+
+**Steps:**
+- **Location:** Enter ZIP code `99201`, Select county `Spokane`
+- **Household:** Number of people: `3`
+- **Person 1 (Head of Household — applicant):** Relationship: `Head of Household`, Birth month/year: `May 1998` (age 28), Student: `Yes`, Has income: `Yes`, Income type: `Wages`, Income amount: `$4,000`, Income frequency: `Monthly`, Insurance: `None`
+- **Person 2 (Spouse):** Relationship: `Spouse`, Birth month/year: `February 1996` (age 30), Student: `No`, Has income: `No`, Insurance: `None`
+- **Person 3 (Child):** Relationship: `Child`, Birth month/year: `October 2021` (age 4), Student: `No`, Has income: `No`, Insurance: `None`
+- **Current Benefits:** Select `None`
+
+**Why this matters:** Tests household logic — only the student-as-HoH should be evaluated as the BaS applicant, while the non-student spouse and child still count toward household size and income. Reflects a realistic returning-adult-learner persona pursuing a first bachelor's degree.

--- a/programs/programs/wa/wsos_bas/tests.py
+++ b/programs/programs/wa/wsos_bas/tests.py
@@ -1,0 +1,277 @@
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from programs.programs.wa.wsos_bas.calculator import WaWsosBas
+from programs.util import Dependencies
+from screener.models import HouseholdMember, IncomeStream, Screen, WhiteLabel
+
+
+class TestWaWsosBas(TestCase):
+    """
+    Unit tests for the WA WSOS Baccalaureate (BaS) Scholarship calculator.
+
+    Covers the two screener-checkable gates (at least one student, household
+    annual income <= 125% MFI for size), the 2026 published table boundaries,
+    the linear extension for households above the table, and the lump-sum
+    value contract.
+
+    Maps to spec.md scenarios but calls the calculator directly. The full
+    end-to-end browser flow is exercised separately via Playwright; the
+    persisted validation suite (`wa_wsos_bas.json`) covers Scenarios 1, 2,
+    and 3 against the live screener layer.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Washington", code="wa", state_code="WA")
+        self.mock_program = Mock()
+
+    def _make_screen(self, household_size=1, zipcode="98101", county="King"):
+        return Screen.objects.create(
+            white_label=self.white_label,
+            agree_to_tos=True,
+            zipcode=zipcode,
+            county=county,
+            household_size=household_size,
+            completed=False,
+        )
+
+    def _add_member(self, screen, *, age=20, relationship="headOfHousehold", student=False, monthly_wages=0):
+        member = HouseholdMember.objects.create(
+            screen=screen,
+            relationship=relationship,
+            age=age,
+            student=student,
+        )
+        if monthly_wages:
+            IncomeStream.objects.create(
+                screen=screen,
+                household_member=member,
+                type="wages",
+                amount=monthly_wages,
+                frequency="monthly",
+            )
+        return member
+
+    def _calc(self, screen):
+        return WaWsosBas(screen, self.mock_program, {}, Dependencies())
+
+    # --- Class wiring --------------------------------------------------------
+
+    def test_registered_in_wa_calculators(self):
+        """Calculator is registered in the WA program registry under wa_wsos_bas."""
+        from programs.programs.wa import wa_calculators
+
+        self.assertIn("wa_wsos_bas", wa_calculators)
+        self.assertIs(wa_calculators["wa_wsos_bas"], WaWsosBas)
+
+    def test_amount_is_22500_lump_sum(self):
+        """The published BaS lump-sum award is $22,500."""
+        self.assertEqual(WaWsosBas.amount, 22_500)
+
+    def test_dependencies_cover_income_and_household_size(self):
+        """The calculator declares the screener fields it actually reads."""
+        self.assertIn("income_amount", WaWsosBas.dependencies)
+        self.assertIn("income_frequency", WaWsosBas.dependencies)
+        self.assertIn("household_size", WaWsosBas.dependencies)
+
+    # --- Eligibility (spec scenarios) ----------------------------------------
+
+    def test_eligible_single_student_well_below_125_pct_mfi(self):
+        """
+        spec.md Scenario 1: WA student, 1-person household, $2k/mo wages
+        ($24k/yr) — well below the 1-person 125% MFI cap of $90,500/yr.
+        """
+        screen = self._make_screen()
+        self._add_member(screen, student=True, monthly_wages=2000)
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertTrue(eligibility.eligible)
+
+    def test_ineligible_single_student_above_125_pct_mfi(self):
+        """
+        spec.md Scenario 2: WA student, 1-person household, $8k/mo
+        ($96k/yr) — above the 1-person 125% MFI cap of $90,500/yr.
+        BaS has no expanded / hardship band, so this fails income.
+        """
+        screen = self._make_screen()
+        self._add_member(screen, student=True, monthly_wages=8000)
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertFalse(eligibility.eligible)
+
+    def test_eligible_four_person_household_just_below_125_pct_mfi(self):
+        """
+        spec.md Scenario 3: 4-person family, HS-senior student applicant,
+        $14,541/mo wages ($174,492/yr) -- just under the 4-person 125%
+        MFI cap of $174,500/yr (monthly rounding edge).
+        """
+        screen = self._make_screen(household_size=4, zipcode="98501", county="Thurston")
+        self._add_member(screen, age=46, monthly_wages=14541)
+        self._add_member(screen, relationship="spouse", age=44, student=False)
+        self._add_member(screen, relationship="child", age=17, student=True)
+        self._add_member(screen, relationship="child", age=13, student=False)
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertTrue(eligibility.eligible)
+
+    def test_ineligible_four_person_household_above_125_pct_mfi(self):
+        """
+        spec.md Scenario 4: same 4-person family, but $16k/mo
+        ($192k/yr) -- well above the 4-person 125% MFI cap of $174,500/yr.
+        """
+        screen = self._make_screen(household_size=4, zipcode="98501", county="Thurston")
+        self._add_member(screen, age=46, monthly_wages=16000)
+        self._add_member(screen, relationship="spouse", age=44, student=False)
+        self._add_member(screen, relationship="child", age=17, student=True)
+        self._add_member(screen, relationship="child", age=13, student=False)
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertFalse(eligibility.eligible)
+
+    def test_eligible_returning_adult_student_as_head_with_dependents(self):
+        """
+        spec.md Scenario 5: Returning adult student (age 28) is HoH and BaS
+        applicant; non-student spouse + young child still count toward
+        household size and income. $4k/mo wages ($48k/yr) -- well under
+        the 3-person 125% MFI cap of $146,500/yr.
+        """
+        screen = self._make_screen(household_size=3, zipcode="99201", county="Spokane")
+        self._add_member(screen, age=28, student=True, monthly_wages=4000)
+        self._add_member(screen, relationship="spouse", age=30, student=False)
+        self._add_member(screen, relationship="child", age=4, student=False)
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertTrue(eligibility.eligible)
+
+    # --- Eligibility (extra coverage beyond the spec scenarios) --------------
+
+    def test_ineligible_no_student_in_household(self):
+        """
+        Household with no student fails the per-member gate; the base
+        ProgramCalculator auto-marks the household ineligible when no
+        member passes member_eligible().
+        """
+        screen = self._make_screen()
+        self._add_member(screen, age=46, student=False, monthly_wages=2000)
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertFalse(eligibility.eligible)
+
+    def test_eligible_at_exact_125_pct_mfi_boundary(self):
+        """`<=` boundary: income exactly equal to the 125% MFI cap is eligible."""
+        # 1-person cap is $90,500/yr -> use a yearly stream to hit it exactly.
+        screen = self._make_screen()
+        member = self._add_member(screen, student=True)
+        IncomeStream.objects.create(
+            screen=screen,
+            household_member=member,
+            type="wages",
+            amount=90_500,
+            frequency="yearly",
+        )
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertTrue(eligibility.eligible)
+
+    def test_ineligible_one_dollar_above_125_pct_mfi_boundary(self):
+        """`<=` boundary: $1 above the 125% MFI cap is ineligible."""
+        screen = self._make_screen()
+        member = self._add_member(screen, student=True)
+        IncomeStream.objects.create(
+            screen=screen,
+            household_member=member,
+            type="wages",
+            amount=90_501,
+            frequency="yearly",
+        )
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertFalse(eligibility.eligible)
+
+    # --- Value ---------------------------------------------------------------
+
+    def test_value_is_22500_lump_sum_when_eligible(self):
+        """Eligible household returns the published $22,500 lump-sum scholarship."""
+        screen = self._make_screen()
+        self._add_member(screen, student=True, monthly_wages=2000)
+
+        calc = self._calc(screen)
+        eligibility = calc.eligible()
+        calc.value(eligibility)
+
+        self.assertEqual(eligibility.value, 22_500)
+
+    def test_value_is_0_when_ineligible(self):
+        """Ineligible household reports value 0 (the base class skips value() when not eligible)."""
+        screen = self._make_screen()
+        self._add_member(screen, student=True, monthly_wages=8000)
+
+        calc = self._calc(screen)
+        eligibility = calc.eligible()
+        calc.value(eligibility)
+
+        self.assertEqual(eligibility.value, 0)
+
+    def test_value_is_household_level_not_per_member(self):
+        """
+        Every member returns 0 from member_value; all of the lump-sum
+        award is reported at the household level. Confirms the scholarship
+        does not multiply across multiple students in the same household.
+        """
+        screen = self._make_screen(household_size=2)
+        self._add_member(screen, student=True, monthly_wages=2000)
+        self._add_member(screen, relationship="spouse", age=21, student=True)
+
+        calc = self._calc(screen)
+        eligibility = calc.eligible()
+        calc.value(eligibility)
+
+        self.assertEqual(eligibility.value, 22_500)
+        for member_eligibility in eligibility.eligible_members:
+            self.assertEqual(member_eligibility.value, 0)
+
+    # --- MFI table boundaries ------------------------------------------------
+
+    def test_income_limit_table_lookup(self):
+        """All 6 published table sizes return the documented 125% MFI value verbatim."""
+        for size, expected in WaWsosBas.MFI_125_BY_SIZE.items():
+            screen = self._make_screen(household_size=size)
+            self.assertEqual(self._calc(screen).income_limit_125(), expected)
+
+    def test_income_limit_extension_above_table(self):
+        """
+        Sizes above the published table (1-6) extend by the documented
+        per-person increment so a 7+ person household is not silently
+        denied or crashed.
+        """
+        screen = self._make_screen(household_size=8)
+        expected = WaWsosBas.MFI_125_BY_SIZE[6] + 2 * WaWsosBas.MFI_125_PER_EXTRA_PERSON_ABOVE_TABLE
+        self.assertEqual(self._calc(screen).income_limit_125(), expected)
+
+    def test_mfi_table_values_match_spec(self):
+        """
+        Pin the 2026 published 125% MFI values to the spec table so any
+        accidental edit to the lookup is caught here. Verified against
+        https://waopportunityscholarship.org/wp-content/uploads/2025/10/
+        Baccalaureate-C15-MFI-Chart.pdf
+        """
+        self.assertEqual(
+            WaWsosBas.MFI_125_BY_SIZE,
+            {
+                1: 90_500,
+                2: 118_000,
+                3: 146_500,
+                4: 174_500,
+                5: 202_000,
+                6: 230_000,
+            },
+        )

--- a/programs/programs/wa/wsos_bas/tests.py
+++ b/programs/programs/wa/wsos_bas/tests.py
@@ -23,10 +23,12 @@ class TestWaWsosBas(TestCase):
     """
 
     def setUp(self):
+        """Create a WA white label and a mock Program for each test."""
         self.white_label = WhiteLabel.objects.create(name="Washington", code="wa", state_code="WA")
         self.mock_program = Mock()
 
     def _make_screen(self, household_size=1, zipcode="98101", county="King"):
+        """Build an in-memory `Screen` for the WA white label with the given size."""
         return Screen.objects.create(
             white_label=self.white_label,
             agree_to_tos=True,
@@ -37,6 +39,7 @@ class TestWaWsosBas(TestCase):
         )
 
     def _add_member(self, screen, *, age=20, relationship="headOfHousehold", student=False, monthly_wages=0):
+        """Add a `HouseholdMember` (and optional monthly wages) to the screen."""
         member = HouseholdMember.objects.create(
             screen=screen,
             relationship=relationship,
@@ -54,6 +57,7 @@ class TestWaWsosBas(TestCase):
         return member
 
     def _calc(self, screen):
+        """Construct a `WaWsosBas` calculator bound to the given screen."""
         return WaWsosBas(screen, self.mock_program, {}, Dependencies())
 
     # --- Class wiring --------------------------------------------------------
@@ -163,6 +167,45 @@ class TestWaWsosBas(TestCase):
         eligibility = self._calc(screen).eligible()
 
         self.assertFalse(eligibility.eligible)
+
+    def test_ineligible_when_student_field_is_unanswered(self):
+        """
+        `Screen.student` is BooleanField(null=True), so an unanswered field
+        comes through as None. `bool(None) -> False -> ineligible`. Pinning
+        this explicitly catches a future refactor that might confuse `is False`
+        with a generic falsy check.
+        """
+        screen = self._make_screen()
+        member = HouseholdMember.objects.create(
+            screen=screen,
+            relationship="headOfHousehold",
+            age=20,
+            student=None,
+        )
+        IncomeStream.objects.create(
+            screen=screen,
+            household_member=member,
+            type="wages",
+            amount=2000,
+            frequency="monthly",
+        )
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertFalse(eligibility.eligible)
+
+    def test_eligible_zero_income_student(self):
+        """
+        Common BaS persona: unemployed student (e.g. HS senior pre-application)
+        with zero household income. Lower-side income boundary, complementing
+        `test_eligible_at_exact_125_pct_mfi_boundary` on the upper side.
+        """
+        screen = self._make_screen()
+        self._add_member(screen, age=18, student=True)  # no income stream
+
+        eligibility = self._calc(screen).eligible()
+
+        self.assertTrue(eligibility.eligible)
 
     def test_eligible_at_exact_125_pct_mfi_boundary(self):
         """`<=` boundary: income exactly equal to the 125% MFI cap is eligible."""

--- a/validations/management/commands/import_validations/data/wa_wsos_bas.json
+++ b/validations/management/commands/import_validations/data/wa_wsos_bas.json
@@ -1,0 +1,154 @@
+[
+  {
+    "notes": "Scenario 1: Clearly eligible — WA student with income well below the 2026 1-person 125% MFI cap ($90,500/year). Student status confirmed, income $2,000/month. Baseline BaS golden path: residency + student + income all clearly satisfied.",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98101",
+      "county": "King",
+      "household_size": 1,
+      "household_assets": 0.0,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 20,
+          "birth_year": 2006,
+          "birth_month": 1,
+          "student": true,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_wsos_bas",
+      "eligible": true,
+      "value": 22500
+    }
+  },
+  {
+    "notes": "Scenario 2: Clearly ineligible — 1-person Washington household above the 2026 1-person 125% MFI cap ($90,500/year). Applicant is a student, so the failure is income only.",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98101",
+      "county": "King",
+      "household_size": 1,
+      "household_assets": 0.0,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 21,
+          "birth_year": 2005,
+          "birth_month": 3,
+          "student": true,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 8000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_wsos_bas",
+      "eligible": false
+    }
+  },
+  {
+    "notes": "Scenario 3: Near-boundary edge case — 4-person household with applicant (HS senior, age 17) just below the 2026 4-person 125% MFI cap because monthly income is rounded down ($14,541/month = $174,492/year vs. $174,500/year cap). Tests household-size scaling and a realistic BaS persona (HS senior in a family of 4). Only the 17-year-old student is the BaS applicant; other household members count toward household size and income.",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98501",
+      "county": "Thurston",
+      "household_size": 4,
+      "household_assets": 0.0,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 46,
+          "birth_year": 1980,
+          "birth_month": 1,
+          "student": false,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 14541.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "spouse",
+          "age": 44,
+          "birth_year": 1982,
+          "birth_month": 3,
+          "student": false,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 17,
+          "birth_year": 2008,
+          "birth_month": 9,
+          "student": true,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 13,
+          "birth_year": 2012,
+          "birth_month": 6,
+          "student": false,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_wsos_bas",
+      "eligible": true,
+      "value": 22500
+    }
+  }
+]


### PR DESCRIPTION
## Context & Motivation

Implements the Washington State Opportunity Scholarship — Baccalaureate (BaS) track. BaS is the undergraduate sister program to `wa_wsos_grd` (already in the registry); both share the same WSOS MFI base and lump-sum award shape, so the implementation closely follows the `wa_wsos_grd` pattern.

- Linear: [MFB-966](https://linear.app/myfriendben/issue/MFB-966/wa-washington-state-opportunity-scholarship-bas)
- Spec: `programs/programs/wa/wsos_bas/spec.md`
- Sibling implementation reference: `programs/programs/wa/wsos_grd/calculator.py`

## Changes Made

**New custom calculator** (`programs/programs/wa/wsos_bas/calculator.py`)

- `WaWsosBas(ProgramCalculator)` — custom rules-based calculator (not PolicyEngine; PE doesn't model state scholarship programs).
- Per-member gate: at least one member has `student == True`. The base `ProgramCalculator.eligible()` automatically marks the household ineligible when no member passes, so a household with no student fails naturally.
- Household income gate: gross household income (yearly, all sources) must be at or below the 2026 published BaS **125% MFI cap** for the household size. Unlike GRD there is **no expanded / hardship band** — BaS uses a single threshold.
- 2026 MFI lookup table for sizes 1-6 sourced verbatim from the [official WSOS BaS MFI Chart](https://waopportunityscholarship.org/wp-content/uploads/2025/10/Baccalaureate-C15-MFI-Chart.pdf). Linear extension of \$28,000/extra person for sizes 7+ (matches the average increment in the published table).
- Comparison uses `calc_gross_income`'s float result against the int limit at full precision, so a household fractionally above the cap is correctly screened out rather than floored onto the boundary. Same approach as `wa_wsos_grd`.
- Lump-sum value of **\$22,500** returned at the household level via `household_value()`; `member_value()` returns 0 so multi-student households don't multiply the award.

**Registration** (`programs/programs/wa/__init__.py`)

- Adds `WaWsosBas` to `wa_calculators` under `\"wa_wsos_bas\"`.

**Unit tests** (`programs/programs/wa/wsos_bas/tests.py`)

17 tests covering:
- All 5 `spec.md` scenarios (eligible singleton, ineligible singleton above cap, 4-person at near-boundary, 4-person above cap, returning-adult-as-HoH).
- Calculator wiring (registry membership, lump-sum amount, declared dependencies).
- Boundary tests at exactly the 125% MFI cap and \$1 above (using a yearly income stream to hit the cap precisely).
- "No student in household" → ineligible.
- Lump-sum value contract: \$22,500 when eligible, \$0 when not, and the value is reported once at the household level rather than multiplied per student.
- MFI table verbatim pin against the spec, plus the 7+ size linear extension.

**Discovery artifacts** (committed in [`fa35b575`](../../commit/fa35b575) — first commit on this branch, separate from the implementation)

- `programs/programs/wa/wsos_bas/spec.md`
- `programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json`
- `validations/management/commands/import_validations/data/wa_wsos_bas.json`

Two small alignment touch-ups vs. the raw Discovery output to match the sibling `wa_wsos_grd` config:

1. `has_calculator: false → true` (we ship a calculator that returns a value).
2. Added `active: true` / `low_confidence: false` so the program is live on import without a separate manual admin step.

A third alignment fix landed in the implementation commit:

3. Dropped the explicit `\"base_program\": null`. The `import_program_config` command stringifies JSON `null` to the literal `\"None\"` and then validates against a closed enum, which fails import. The sibling `wa_wsos_grd` config omits the key entirely; this PR matches that.

## Testing

**Migrations to run**: none.

**Configuration updates needed** (run on local DB after pulling this branch):

\`\`\`bash
python manage.py import_program_config \\
  programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json

python manage.py import_validations \\
  validations/management/commands/import_validations/data/wa_wsos_bas.json
\`\`\`

The config sets \`active: true\`, so no separate activation step is needed.

**Manual testing steps**:

1. Run the unit tests: \`python manage.py test programs.programs.wa.wsos_bas\` (17 tests).
2. Run the validation suite: \`python manage.py validate --program wa_wsos_bas\` — all 3 canonical cases (Scenarios 1-3 from \`spec.md\`) should pass.
3. Optional Playwright walkthrough of all 5 \`spec.md\` scenarios at http://localhost:3000/wa.

### Local verification results

Verified on 2026-05-08 against the local Django + Postgres stack on the up-to-date \`main\` baseline (commits f328d6eb and earlier).

**Unit tests** — 17/17 PASS in 0.041s:

\`\`\`
test_amount_is_22500_lump_sum ............................... ok
test_dependencies_cover_income_and_household_size ............ ok
test_eligible_at_exact_125_pct_mfi_boundary .................. ok
test_eligible_four_person_household_just_below_125_pct_mfi ... ok
test_eligible_returning_adult_student_as_head_with_dependents  ok
test_eligible_single_student_well_below_125_pct_mfi .......... ok
test_income_limit_extension_above_table ...................... ok
test_income_limit_table_lookup ............................... ok
test_ineligible_four_person_household_above_125_pct_mfi ...... ok
test_ineligible_no_student_in_household ...................... ok
test_ineligible_one_dollar_above_125_pct_mfi_boundary ........ ok
test_ineligible_single_student_above_125_pct_mfi ............. ok
test_mfi_table_values_match_spec ............................. ok
test_registered_in_wa_calculators ............................ ok
test_value_is_0_when_ineligible .............................. ok
test_value_is_22500_lump_sum_when_eligible ................... ok
test_value_is_household_level_not_per_member ................. ok
\`\`\`

**Validation suite** — 3/3 PASS, exact value match:

| # | Spec scenario                                                          | Expected         | Actual             |
| - | ---------------------------------------------------------------------- | ---------------- | ------------------ |
| 1 | WA student, 1p, \$2k/mo wages                                          | Eligible \$22,500 | ✓ Eligible \$22,500 |
| 2 | WA student, 1p, \$8k/mo (above 1p 125% MFI cap of \$90,500/yr)         | Ineligible       | ✗ Not Eligible     |
| 3 | 4p family, \$14,541/mo (just below 4p 125% MFI cap of \$174,500/yr)    | Eligible \$22,500 | ✓ Eligible \$22,500 |

**Spec Scenarios 4-5** (verified directly against the running calculator; not in the canonical 3-case validations file by design):

| # | Spec scenario                                                          | Expected         | Actual             |
| - | ---------------------------------------------------------------------- | ---------------- | ------------------ |
| 4 | 4p family, \$16k/mo (above 4p 125% MFI cap)                            | Ineligible       | ✗ \$0              |
| 5 | 3p returning adult student-as-HoH, \$4k/mo                             | Eligible \$22,500 | ✓ Eligible \$22,500 |

That's all the screener-checkable branches: the student gate, the income cap (one-person and multi-person, well-clear and near-boundary on both sides), and household scaling of the 125% MFI table.

## Deployment

- **Post-deployment scripts**: re-run the two import commands above on staging/production after merge.
- **Production config updates**: none beyond the imports.
- **Admin updates needed**: confirm \`wa_wsos_bas\` shows \`Active=True\` in \`/admin/programs/program/\` (it should auto-import that way thanks to \`active: true\` in the config).
- **Notify team/users of**: WA WSOS BaS scholarship is live in WA results.

## Notes for Reviewers

**Inclusivity assumptions documented in the calculator docstring** (per spec.md — fields the screener does not collect; we assume met for any student respondent):

- Has not yet earned a bachelor's degree (BaS funds the *first* bachelor's only).
- Has earned, or will earn by June of the application year, a Washington high school credential or passing GED.
- Cumulative GPA >= 2.75 on a 4.0 scale (or passing GED score).
- Has not earned more than 90 quarter / 60 semester credits since high school graduation. **Per spec direction this constraint is intentionally NOT surfaced in the user-facing description.** Applicants who have already exceeded the credit ceiling will be incorrectly shown the program; this is acceptable given the dev-only handling pattern chosen in spec.md.
- Plans to enroll in at least three credits every fall, winter, and spring term while using the scholarship.
- Enrolled (or planning to enroll) in an eligible STEM or health care major at an eligible Washington institution.

**Caveat on the student gate**: BaS also accepts applicants who plan to enroll but do not yet consider themselves a student. The screener cannot disambiguate, so this gate is an underestimate. A user who plans to enroll but answers \"No\" to \`student\` will be incorrectly screened out. Documented in the calculator docstring; future screener refinement could add an explicit \"planning to enroll\" follow-up question (also noted in spec.md).

**Note on the family-of-11 typo**: the official 2026 BaS MFI Chart publishes \$156,500 for a family of 11, which is out of sequence with surrounding values and identical to the same typo in the GRD chart. Per spec direction, this is NOT silently \"corrected\" in code — the typo is worth flagging to WSOS once across all WSOS programs rather than per-program. The MFI table in this calculator contains only the monotonic published values for sizes 1-6 plus a documented linear extension for sizes 7+.

**Future considerations**:

- Spec.md ships 5 scenarios; \`wa_wsos_bas.json\` ships the 3 representative cases per the canonical reviewer guide. Scenarios 4 and 5 have been verified locally against the running calculator (results in the table above) — they are not committed to the repo so the canonical 3-case format is preserved for CI.
- Could refactor \`MFI_125_BY_SIZE\` (BaS) and \`MFI_155_BY_SIZE\` (GRD) into a shared module since both come from the same WSOS MFI base, but that's pure cleanup — not in scope here.

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Washington State Opportunity Scholarship (WSOS) — Baccalaureate Track program
  * Provides a $22,500 lump-sum award for eligible Washington residents
  * Includes eligibility screening for household income (125% MFI threshold), first bachelor degree requirement, STEM/health major intent, and Washington high school credential/GED
  * Application deadline: 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->