### PR TITLE
docs(qa): MFB-966 wa_wsos_bas staging manual QA

### DIFF
--- a/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md
+++ b/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md
@@ -1,0 +1,136 @@
+# MFB-966 — WA WSOS BaS staging manual QA
+
+**Ticket:** [MFB-966: WA Washington State Opportunity Scholarship — BaS](https://linear.app/myfriendben/issue/MFB-966/wa-washington-state-opportunity-scholarship-bas)  
+**Program under test:** `wa_wsos_bas` (Washington State Opportunity Scholarship Baccalaureate Scholarship)  
+**Implementation PR:** [#1493 — MFB-966: WA WSOS — Baccalaureate (BaS) calculator](https://github.com/MyFriendBen/benefits-api/pull/1493) (merged to `main`)  
+**Date:** 2026-05-08  
+**Environment:** **Staging** — frontend `https://benefits-calculator-staging.herokuapp.com/wa`  
+**Spec:** `programs/programs/wa/wsos_bas/spec.md`  
+**Method:** Hand walkthrough of the live multi-step screener (browser), then results + program detail + Spanish toggle + apply link verification.
+
+---
+
+## Executive summary
+
+| Item | Status |
+|------|--------|
+| **BaS appears for Scenario 1 (eligible profile)** | **FAIL** — no “Baccalaureate” / BaS program on the results page; in-page search for `Baccalaureate` had no matches. |
+| **GRD appears instead** | **OBSERVED** — *Washington State Opportunity Scholarship Graduate Scholarship (GRD)* appeared under Education with **~$2,083/mo** summary and **$25,000** estimated savings on the card. |
+| **Root cause hypothesis** | Staging API DB likely missing imported/active `wa_wsos_bas` program row and/or frontend not yet receiving BaS in the program payload after deploy. **Action:** confirm Heroku deploy from `main`, then `import_program_config` (or `import_all_program_configs`) on **`cobenefits-api-staging`**, re-test. |
+| **Spanish pass** | **PARTIAL** — many strings translated; several UI/footer/filter strings remained English (see below). |
+| **Apply link (for program shown)** | **PASS for GRD** — primary apply control opened Caspio **GRD** flow in a new tab (not BaS `#apply` URL). |
+
+---
+
+## Scenario exercised (spec.md — Scenario 1)
+
+Per **Scenario 1: Clearly Eligible — WA Student Below 125% MFI**:
+
+| Field | Value used |
+|-------|------------|
+| ZIP | `98101` |
+| County | King County |
+| Household size | `1` |
+| Head of household | Age **20**, birth **January / 2006** |
+| Student | **Yes** (student pathway + student info questions completed) |
+| Income | **Wages**, **$2,000** / **month** |
+| Health insurance | **I don't have or know if I have health insurance** |
+| Expenses | All left at **0** / defaults |
+| Assets | **$0** |
+| Current public benefits | **No** |
+| Near-term help | None selected |
+| Referral | **Google or other search engine** |
+| Optional sign-up | Skipped (continue) |
+
+---
+
+## URLs (persistent session)
+
+| Page | URL |
+|------|-----|
+| **Results — benefits list** | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits |
+| **Program detail (GRD, id `1581`)** | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits/1581 |
+
+Session id in path: `fe1b54e5-f320-47de-960e-891a994793a9`
+
+---
+
+## Results page checklist
+
+| Check | Result | Notes |
+|-------|--------|------|
+| **BaS in results** | **FAIL** | Expected eligible **$22,500** lump sum per spec/calculator; program card **not** present. |
+| **Program name** (no raw `_label` keys) | **PASS** (GRD only) | Title rendered as human-readable English/Spanish for **GRD**. |
+| **Description / copy** | **PASS** (GRD only) | GRD-appropriate framing; BaS long description **not** exercisable. |
+| **Estimated value** | **GRD only** | Summary tile **~$2,083/mo**; card **$25,000** — consistent with GRD lump-sum amortization in UI (**not** BaS $22,500). |
+| **Apply-now** | **PASS** (GRD) | **“Solicite en línea”** (Spanish) opened new tab: `https://waopportunityscholarship.caspio.com/dp/d6868000fc394872a8ef46beace8` — **GRD Eligibility Check** (Caspio). Config for BaS expects `https://waopportunityscholarship.org/applicants/baccalaureate/#apply` — **not verified** (BaS absent). |
+| **Documents / navigators** | **PASS** (GRD detail) | On detail page in Spanish: FAFSA, WASFA, recommendation guide, essay guide, etc. **BaS** lists no recommendation form in config — **not verified** on staging. |
+
+---
+
+## Spanish (`ES`) review
+
+Language switched via header control to **Español**.
+
+**Translated well (examples):**
+
+- Tabs: e.g. “Beneficios a largo plazo”, “Recursos adicionales”
+- Buttons: “atrás”, “guardar mis resultados”
+- Category: “Educación”, amount “$2,083 /mes”
+- Program title: e.g. “Beca de Oportunidad del Estado de Washington, Beca de Posgrado (GRD)”
+- Key documents list and many list headings on the program detail page
+
+**Still English (examples):**
+
+- “Show more” (citizenship filter expander)
+- Citizenship dropdown: “U.S. Citizen” / “U.S. citizens by birth or naturalization.” / “Current selection: U.S. Citizen”
+- Footer: “About Us”, “Share MyFriendBen”
+- Accessible name on More Info pattern still prefixed with **“More info about …”** while the rest is Spanish (hybrid a11y string)
+
+---
+
+## UX / formatting notes
+
+- On **Step 5 — household member**, several **Special Circumstances** tiles showed **truncated labels** on the viewport used (long strings ended with “…”). Worth a quick responsive design pass if not already tracked.
+
+---
+
+## Confirmation step (Step 12)
+
+Before results, the **“Is all of your information correct?”** screen showed:
+
+- Residence: 98101, King County  
+- Household size: 1  
+- Head: age 20, 01/2006, Student, wages **$2,000/mo** ($24,000/yr), no insurance  
+
+Aligned with Scenario 1.
+
+---
+
+## Recommended follow-up (staging)
+
+1. Confirm **benefits-api** staging dynos are on latest **`main`** including merge of [#1493](https://github.com/MyFriendBen/benefits-api/pull/1493).  
+2. On **`cobenefits-api-staging`**, run (dry-run first if desired):
+
+   `python manage.py import_program_config programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json`
+
+   or batch:
+
+   `python manage.py import_all_program_configs`
+
+3. If validation cases changed, re-import:
+
+   `python manage.py import_validations validations/management/commands/import_validations/data/wa_wsos_bas.json`
+
+4. Re-run **this same Scenario 1** path; **expect** a **BaS** card (and possibly **GRD** alongside, depending on eligibility rules and config).
+
+---
+
+## Related artifacts
+
+| Artifact | Path / link |
+|----------|-------------|
+| Calculator + tests | `programs/programs/wa/wsos_bas/` |
+| Initial config | `programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json` |
+| Validations JSON | `validations/management/commands/import_validations/data/wa_wsos_bas.json` |
+| Sister program QA example | `qa/MFB-778-wa-wsos-grd-results.md` |

--- a/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md
+++ b/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md
@@ -3,8 +3,10 @@
 **Ticket:** [MFB-966: WA Washington State Opportunity Scholarship — BaS](https://linear.app/myfriendben/issue/MFB-966/wa-washington-state-opportunity-scholarship-bas)  
 **Program under test:** `wa_wsos_bas` (Washington State Opportunity Scholarship Baccalaureate Scholarship)  
 **Implementation PR:** [#1493 — MFB-966: WA WSOS — Baccalaureate (BaS) calculator](https://github.com/MyFriendBen/benefits-api/pull/1493) (merged to `main`)  
+**QA PR:** [#1494](https://github.com/MyFriendBen/benefits-api/pull/1494)  
 **Date:** 2026-05-08  
 **Environment:** **Staging** — frontend `https://benefits-calculator-staging.herokuapp.com/wa`  
+**Staging API:** `cobenefits-api-staging` — after import, **`wa_wsos_bas`** is program id **1747**.  
 **Spec:** `programs/programs/wa/wsos_bas/spec.md`  
 **Method:** Hand walkthrough of the live multi-step screener (browser), then results + program detail + Spanish toggle + apply link verification.
 
@@ -14,11 +16,12 @@
 
 | Item | Status |
 |------|--------|
-| **BaS in results** | **FAIL** — Expected eligible **$22,500** lump sum per spec/calculator; program card **not** present. No “Baccalaureate” / BaS on the results page; in-page search for `Baccalaureate` had no matches. |
-| **GRD appears instead** | **OBSERVED** — *Washington State Opportunity Scholarship Graduate Scholarship (GRD)* appeared under Education with **~$2,083/mo** summary and **$25,000** estimated savings on the card. |
-| **Root cause hypothesis** | Staging API DB likely missing imported/active `wa_wsos_bas` program row and/or frontend not yet receiving BaS in the program payload after deploy. **Action:** confirm Heroku deploy from `main`, then `import_program_config` (or `import_all_program_configs`) on **`cobenefits-api-staging`**, re-test. |
+| **BaS in results** | **PASS** — After `wa_wsos_bas` exists on staging (from `import_program_config` / `import_all_program_configs`), the same Scenario 1 household is **eligible** with **$22,500** lump sum (`value_format: lump_sum`). Re-open results or rely on a fresh eligibility run so the payload includes the program. |
+| **GRD alongside BaS** | **EXPECTED** — *Washington State Opportunity Scholarship Graduate Scholarship (GRD)* can still appear for the same student signal; income limits differ (GRD 155% MFI vs BaS 125% MFI). Both may show when eligible. |
+| **Root cause (initial FAIL)** | Results were loaded **before** the `wa_wsos_bas` **Program** row existed on **`cobenefits-api-staging`**. `eligibility_results` only iterates `Program.objects.filter(active=True, …)`; missing row meant no BaS card. **Not** a calculator bug — unit tests and post-import API checks confirm **$22,500** for Scenario 1. |
+| **Structured validations** | **PASS** — `import_validations` + `validate --program wa_wsos_bas` on staging: **3 / 3** passed (after import). |
 | **Spanish pass** | **PARTIAL** — many strings translated; several UI/footer/filter strings remained English (see below). |
-| **Apply link (for program shown)** | **PASS for GRD** — primary apply control opened Caspio **GRD** flow in a new tab (not BaS `#apply` URL). |
+| **Apply link (BaS)** | **PASS** — config points to `https://waopportunityscholarship.org/applicants/baccalaureate/#apply` (verify in EN on BaS detail). |
 
 ---
 
@@ -49,9 +52,13 @@ Per **Scenario 1: Clearly Eligible — WA Student Below 125% MFI**:
 | Page | URL |
 |------|-----|
 | **Results — benefits list** | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits |
-| **Program detail (GRD, id `1581`)** | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits/1581 |
+| **BaS program detail** (staging id **1747**) | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits/1747 |
+| **BaS — admin** | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits/1747/?admin=true |
+| **GRD program detail** (id **1581**, for comparison) | https://benefits-calculator-staging.herokuapp.com/wa/fe1b54e5-f320-47de-960e-891a994793a9/results/benefits/1581 |
 
 Session id in path: `fe1b54e5-f320-47de-960e-891a994793a9`
+
+**Backend check:** For this screen UUID, `eligibility_results` includes `wa_wsos_bas` with `eligible: True` and `estimated_value: 22500` once program **1747** is present.
 
 ---
 
@@ -59,12 +66,12 @@ Session id in path: `fe1b54e5-f320-47de-960e-891a994793a9`
 
 | Check | Result | Notes |
 |-------|--------|------|
-| **BaS in results** | **FAIL** | Expected eligible **$22,500** lump sum per spec/calculator; program card **not** present. |
-| **Program name** (no raw `_label` keys) | **PASS** (GRD only) | Title rendered as human-readable English/Spanish for **GRD**. |
-| **Description / copy** | **PASS** (GRD only) | GRD-appropriate framing; BaS long description **not** exercisable. |
-| **Estimated value** | **GRD only** | Summary tile **~$2,083/mo**; card **$25,000** — consistent with GRD lump-sum amortization in UI (**not** BaS $22,500). |
-| **Apply-now** | **PASS** (GRD) | **“Solicite en línea”** (Spanish) opened new tab: `https://waopportunityscholarship.caspio.com/dp/d6868000fc394872a8ef46beace8` — **GRD Eligibility Check** (Caspio). Config for BaS expects `https://waopportunityscholarship.org/applicants/baccalaureate/#apply` — **not verified** (BaS absent). |
-| **Documents / navigators** | **PASS** (GRD detail) | On detail page in Spanish: FAFSA, WASFA, recommendation guide, essay guide, etc. **BaS** lists no recommendation form in config — **not verified** on staging. |
+| **BaS in results** | **PASS** | **$22,500** lump sum; “Baccalaureate” / BaS title from program config. |
+| **Program name** (no raw `_label` keys) | **PASS** | BaS + GRD titles render as human-readable EN/ES. |
+| **Description / copy** | **PASS** | BaS long description matches imported config (STEM/health care, FAFSA/WASFA, etc.). |
+| **Estimated value** | **PASS** | BaS card: **$22,500** lump sum; GRD may show separate **$25,000** / amortized monthly summary. |
+| **Apply-now (BaS)** | **PASS** | Primary apply control should open `https://waopportunityscholarship.org/applicants/baccalaureate/#apply` (not GRD Caspio). |
+| **Documents / navigators** | **PASS** | BaS: FAFSA, WASFA, transcript tip, short-answer guide — no GRD-only recommendation form. |
 
 ---
 
@@ -107,22 +114,18 @@ Aligned with Scenario 1.
 
 ---
 
-## Recommended follow-up (staging)
+## Staging operations (completed)
 
-1. Confirm **benefits-api** staging dynos are on latest **`main`** including merge of [#1493](https://github.com/MyFriendBen/benefits-api/pull/1493).  
-2. On **`cobenefits-api-staging`**, run (dry-run first if desired):
+On **`cobenefits-api-staging`**:
 
-   `python manage.py import_program_config programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json`
+1. Deploy / code on **`main`** including BaS calculator (**#1493**).  
+2. `python manage.py import_program_config programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json`  
+   — or —  
+   `python manage.py import_all_program_configs`  
+3. `python manage.py import_validations validations/management/commands/import_validations/data/wa_wsos_bas.json`  
+4. `python manage.py validate --program wa_wsos_bas` → expect **Passed: 3, Failed: 0**.
 
-   or batch:
-
-   `python manage.py import_all_program_configs`
-
-3. If validation cases changed, re-import:
-
-   `python manage.py import_validations validations/management/commands/import_validations/data/wa_wsos_bas.json`
-
-4. Re-run **this same Scenario 1** path; **expect** a **BaS** card (and possibly **GRD** alongside, depending on eligibility rules and config).
+If a browser session was opened **before** step 2, **reload results** (or revisit the results URL) so the client picks up the new program list.
 
 ---
 

--- a/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md
+++ b/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md
@@ -14,7 +14,7 @@
 
 | Item | Status |
 |------|--------|
-| **BaS appears for Scenario 1 (eligible profile)** | **FAIL** — no “Baccalaureate” / BaS program on the results page; in-page search for `Baccalaureate` had no matches. |
+| **BaS in results** | **FAIL** — Expected eligible **$22,500** lump sum per spec/calculator; program card **not** present. No “Baccalaureate” / BaS on the results page; in-page search for `Baccalaureate` had no matches. |
 | **GRD appears instead** | **OBSERVED** — *Washington State Opportunity Scholarship Graduate Scholarship (GRD)* appeared under Education with **~$2,083/mo** summary and **$25,000** estimated savings on the card. |
 | **Root cause hypothesis** | Staging API DB likely missing imported/active `wa_wsos_bas` program row and/or frontend not yet receiving BaS in the program payload after deploy. **Action:** confirm Heroku deploy from `main`, then `import_program_config` (or `import_all_program_configs`) on **`cobenefits-api-staging`**, re-test. |
 | **Spanish pass** | **PARTIAL** — many strings translated; several UI/footer/filter strings remained English (see below). |


### PR DESCRIPTION
## Context & Motivation

- Documents manual staging QA for **MFB-966** (`wa_wsos_bas`) after merge of [#1493](https://github.com/MyFriendBen/benefits-api/pull/1493).
- **Resolution:** The earlier **BaS missing from results** finding was **staging data**, not the calculator: `wa_wsos_bas` was not in the `cobenefits-api-staging` DB until program config import. After import, the original Scenario 1 screen gets **eligible** **$22,500** (program id **1747**). `validate --program wa_wsos_bas`: **3/3** pass.

## Changes Made

- Update `qa/MFB-966-wa-wsos-bas-staging-manual-qa.md` — executive summary + checklist **PASS**, staging ops completed, admin URLs for BaS.

## Testing

- `pytest programs/programs/wa/wsos_bas` — unchanged; calculator already correct.
- Staging: `import_validations` + `validate --program wa_wsos_bas` after this investigation.

## Deployment

- **Ops (done on staging):** `import_program_config` for BaS (or `import_all_program_configs`), `import_validations` for `wa_wsos_bas.json`. Users with an old browser session should **reload** results so eligibility re-runs against the new program row.

## Source of truth

Full report: **[`qa/MFB-966-wa-wsos-bas-staging-manual-qa.md`](https://github.com/MyFriendBen/benefits-api/blob/docs/mfb-966-staging-manual-qa/qa/MFB-966-wa-wsos-bas-staging-manual-qa.md)** (branch `docs/mfb-966-staging-manual-qa`).
