### PR TITLE
MFB-786 changed year 2026 -> 2025 because HUD API doesn't support 2026 yet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ tasks/todo.md
 .claude/settings.local.json
 .claude/
 pull-request-reviews/
+qa/
 
 # Readability check output files in readability-output folder
 readability-output/

--- a/programs/management/commands/import_program_config_data/data/wa_seattle_fresh_bucks_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_seattle_fresh_bucks_initial_config.json
@@ -10,7 +10,7 @@
   },
   "program": {
     "name_abbreviated": "wa_seattle_fresh_bucks",
-    "year": "2026",
+    "year": "2025",
     "legal_status_required": [
       "citizen", "non_citizen", "refugee", "gc_5plus", "gc_5less", "otherWithWorkPermission"
     ],


### PR DESCRIPTION
Root cause: The Seattle Fresh Bucks calculator passes self.program.year.period (value "2026") to the HUD Income Limits API via hud_client.get_screen_il_ami(). The HUD API likely doesn't have FY2026 Section 8 Income Limits data published yet, returning a 404. The calculator catches HudIncomeClientError and calls e.condition(False, ...), making the program universally ineligible without any user-visible error.

Why CSFP works but Fresh Bucks doesn't: CSFP uses self.program.year.get_limit() which calls the HHS Federal Poverty Level API (FPL data IS available for 2026). Fresh Bucks uses the HUD Income Limits API (AMI data may NOT be available for 2026 yet).

Two possible fixes:

Quick fix — change the year to 2025 in the config and re-import: The HUD API has 2025 data. The 80% AMI limits wouldn't change significantly year-over-year, and this gets the program working immediately.
Proper fix — add fallback logic in the calculator: If year 2026 fails, try 2025 as a fallback. This is more resilient but requires a code change.
Want me to implement one of these? The quick fix is changing "year": "2026" to "year": "2025" in the config JSON (or adjusting the program's year in the import). The code fix would add fallback year logic in the calculator's try/except block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Seattle Fresh Bucks program year configuration to 2025.

* **Chores**
  * Updated build configuration to exclude additional directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->