### PR TITLE
Fix Black formatting in WA calculators

### DIFF
--- a/programs/programs/wa/head_start/calculator.py
+++ b/programs/programs/wa/head_start/calculator.py
@@ -55,16 +55,11 @@ class WaHeadStart(ProgramCalculator):
         )
 
         # Foster care categorical — any age-eligible member regardless of income (§ 1302.12(c)(1)(iv))
-        has_foster_child = any(
-            me.eligible and me.member.relationship == "fosterChild"
-            for me in e.eligible_members
-        )
+        has_foster_child = any(me.eligible and me.member.relationship == "fosterChild" for me in e.eligible_members)
 
         # TANF, SSI, SNAP categorical eligibility per OHS interpretation (ACF-IM-HS-22-03)
         categorical = (
-            self.screen.has_benefit("tanf")
-            or self.screen.has_benefit("ssi")
-            or self.screen.has_benefit("snap")
+            self.screen.has_benefit("tanf") or self.screen.has_benefit("ssi") or self.screen.has_benefit("snap")
         )
 
         gross_income = self.screen.calc_gross_income("yearly", ["all"])

--- a/programs/programs/wa/wic/calculator.py
+++ b/programs/programs/wa/wic/calculator.py
@@ -37,9 +37,7 @@ class WaWic(ProgramCalculator):
 
     def household_eligible(self, e: Eligibility):
         adjunctive_eligible = (
-            self.screen.has_benefit("snap")
-            or self.screen.has_benefit("medicaid")
-            or self.screen.has_benefit("tanf")
+            self.screen.has_benefit("snap") or self.screen.has_benefit("medicaid") or self.screen.has_benefit("tanf")
         )
 
         if adjunctive_eligible:


### PR DESCRIPTION
## Summary
- Applies Black formatting to `wa/head_start/calculator.py` and `wa/wic/calculator.py`
- Fixes formatting failures from PRs #1501 and #1505 that were merged with failing Black checks

## Test plan
- [ ] CI Black formatter check passes
- [ ] No functional changes — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)