### PR TITLE
MFB-853: Washington NSLP calculator

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_nslp_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_nslp_initial_config.json
@@ -1,0 +1,75 @@
+{
+  "white_label": {
+    "code": "wa"
+  },
+  "program_category": {
+    "external_name": "wa_food",
+    "name": "Food and Nutrition",
+    "icon": "food"
+  },
+  "program": {
+    "name_abbreviated": "wa_nslp",
+    "active": true,
+    "year": "2025",
+    "legal_status_required": [
+      "citizen",
+      "non_citizen",
+      "refugee",
+      "gc_5plus",
+      "gc_5less",
+      "otherWithWorkPermission"
+    ],
+    "name": "National School Lunch Program (NSLP)",
+    "description_short": "Free or low-cost school lunches for kids",
+    "description": "The National School Lunch Program helps students get lunch at school. Some students get free meals. Some families may qualify for lower-cost meals.\n\nStudents get meals at school during the school day. The program does not give cash or a card. Your child usually needs a school or district that takes part in school meal programs.\n\nSome children may also qualify through pathways the screener doesn't capture, such as foster care, unstable housing, or migrant status. Schools may also enroll children automatically using FDPIR or state Medicaid records. Your child's school or district makes the final decision.\n\nTo apply, open the Washington School Meals Application Finder. Choose your school district. Then follow the district's meal application link. You can also ask your child's school or district for help.",
+    "learn_more_link": "https://ospi.k12.wa.us/policy-funding/child-nutrition/school-meals/national-school-lunch-program",
+    "apply_button_link": "https://ospi.k12.wa.us/policy-funding/child-nutrition/school-meals/washington-school-meals-application-finder",
+    "apply_button_description": "Find Your School Meal Application",
+    "estimated_application_time": "15-30 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": "estimated_annual",
+    "value_type": "benefit",
+    "website_description": "Free or low-cost school lunches for kids",
+    "base_program": "nslp",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": true
+  },
+  "documents": [
+    {
+      "external_name": "wa_nslp_cneeb_application",
+      "text": "Completed Child Nutrition Eligibility & Education Benefit (CNEEB) application",
+      "link_url": "https://ospi.k12.wa.us/policy-funding/child-nutrition/school-meals/national-school-lunch-program/meal-application-and-verification-information",
+      "link_text": "Get the OSPI application from the meal information page"
+    },
+    {
+      "external_name": "wa_nslp_income_proof",
+      "text": "Proof of household income (e.g., wages, benefits, child support, pensions, Social Security)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_nslp_basic_food_tanf_fdpir_case_number",
+      "text": "Basic Food, TANF, or FDPIR case number (if applicable)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_nslp_adult_ssn_last_four",
+      "text": "Last four digits of the signing adult's Social Security number (if not exempt)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "wa_ospi_school_meal_programs",
+      "name": "Washington OSPI School Meal Programs",
+      "email": "schoolmeals@k12.wa.us",
+      "description": "OSPI School Meal Programs administers Washington's National School Lunch Program and School Breakfast Program. The team can answer general questions about school meal eligibility, applications, and program rules. For district-specific application help, proof of enrollment, or eligibility letters, contact your child's school district directly.",
+      "assistance_link": "https://ospi.k12.wa.us/policy-funding/child-nutrition/child-nutrition-contacts",
+      "phone_number": "+13607256203"
+    }
+  ]
+}

--- a/programs/programs/wa/__init__.py
+++ b/programs/programs/wa/__init__.py
@@ -9,6 +9,7 @@ from ..calc import ProgramCalculator
 from .seattle_fresh_bucks.calculator import WaSeattleFreshBucks
 from .ssdi.calculator import WaSsdi
 from .wic.calculator import WaWic
+from .nslp.calculator import WaNslp
 
 wa_calculators: dict[str, type[ProgramCalculator]] = {
     "wa_csfp": WaCsfp,
@@ -21,4 +22,5 @@ wa_calculators: dict[str, type[ProgramCalculator]] = {
     "wa_wsos_grd": WaWsosGrd,
     "wa_seattle_fresh_bucks": WaSeattleFreshBucks,
     "wa_wic": WaWic,
+    "wa_nslp": WaNslp,
 }

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import programs.programs.messages as messages
 from programs.programs.calc import Eligibility, MemberEligibility, ProgramCalculator
 from screener.models import HouseholdMember, IncomeStream
@@ -91,7 +93,7 @@ class WaNslp(ProgramCalculator):
         streams: list[IncomeStream] = []
         for m in self.screen.household_members.all():
             for inc in m.income_streams.all():
-                if inc.amount is not None and float(inc.amount) > 0 and inc.frequency:
+                if inc.amount is not None and inc.amount > 0 and inc.frequency:
                     streams.append(inc)
         return streams
 
@@ -101,32 +103,27 @@ class WaNslp(ProgramCalculator):
             return True
 
         freqs = {s.frequency for s in streams}
-        hh = self._household_size_for_limits()
-        red_ann = self._reduced_annual_limit()
-        red_mo = self._reduced_monthly_limit()
+        red_ann = Decimal(self._reduced_annual_limit())
+        red_mo = Decimal(self._reduced_monthly_limit())
 
         if len(freqs) > 1:
-            gross = int(self.screen.calc_gross_income("yearly", ["all"]))
+            gross = Decimal(str(self.screen.calc_gross_income("yearly", ["all"])))
             return gross <= red_ann
 
         f = next(iter(freqs))
+        total = sum((s.amount for s in streams), Decimal(0))
         if f == "monthly":
-            total = sum(float(s.amount) for s in streams)
-            return int(total) <= red_mo
+            return total <= red_mo
         if f == "yearly":
-            total = sum(float(s.amount) for s in streams)
-            return int(total) <= red_ann
+            return total <= red_ann
         if f == "weekly":
-            total = sum(float(s.amount) for s in streams)
-            return int(total * 52) <= red_ann
+            return (total * Decimal(52)) <= red_ann
         if f == "biweekly":
-            total = sum(float(s.amount) for s in streams)
-            return int(total * 26) <= red_ann
+            return (total * Decimal(26)) <= red_ann
         if f == "semimonthly":
-            total = sum(float(s.amount) for s in streams)
-            return int(total * 24) <= red_ann
+            return (total * Decimal(24)) <= red_ann
         # Hourly (and any other): use annualized gross from screener conversion rules.
-        gross = int(self.screen.calc_gross_income("yearly", ["all"]))
+        gross = Decimal(str(self.screen.calc_gross_income("yearly", ["all"])))
         return gross <= red_ann
 
     def _household_categorical(self) -> bool:

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -1,0 +1,168 @@
+import programs.programs.messages as messages
+from programs.programs.calc import Eligibility, MemberEligibility, ProgramCalculator
+from screener.models import HouseholdMember, IncomeStream
+
+
+class WaNslp(ProgramCalculator):
+    """
+    Washington National School Lunch Program (NSLP) — screening calculator.
+
+    Estimates free or reduced-price school lunch eligibility using OSPI 2025–26
+    income guidelines (not raw FPL math), frequency-matched income comparison
+    when a single pay frequency applies, and screenable categorical pathways
+    (SNAP/Basic Food, TANF, Head Start flags, foster-child proxy).
+
+    Value: $828/year per likely eligible student ($4.60 × 180 days, SY 2025–26).
+
+    Data gaps (see spec.md): school participation, exact K-12 enrollment vs. age
+    proxy 5–18, FDPIR, migrant/runaway, CEP/Provision 2/3, Medicaid direct
+    certification. Medicaid alone must not create categorical eligibility.
+    """
+
+    # Likely school-meal student proxy (spec): not using `student` (postsecondary).
+    SCHOOL_MEAL_RELATIONSHIPS = frozenset({"child", "fosterChild", "grandChild"})
+    MIN_SCHOOL_MEAL_AGE = 5
+    MAX_SCHOOL_MEAL_AGE = 18
+
+    ANNUAL_VALUE_PER_CHILD = 828
+
+    # OSPI / USDA Child Nutrition income guidelines, Jul 2025 – Jun 2026 (reduced-price cap).
+    _RED_ANN = {
+        1: 28_953,
+        2: 39_128,
+        3: 49_303,
+        4: 59_478,
+        5: 69_653,
+        6: 79_828,
+        7: 90_003,
+        8: 100_178,
+    }
+    _RED_ANN_STEP = 10_175
+    _RED_MO = {
+        1: 2_413,
+        2: 3_261,
+        3: 4_109,
+        4: 4_957,
+        5: 5_805,
+        6: 6_653,
+        7: 7_501,
+        8: 8_349,
+    }
+    _RED_MO_STEP = 848
+
+    dependencies = (
+        "household_size",
+        "income_amount",
+        "income_frequency",
+        "relationship",
+        "age",
+    )
+
+    def _household_size_for_limits(self) -> int:
+        n = self.screen.household_size or 0
+        return max(n, 1)
+
+    def _reduced_annual_limit(self) -> int:
+        n = self._household_size_for_limits()
+        if n <= 8:
+            return self._RED_ANN[n]
+        return self._RED_ANN[8] + (n - 8) * self._RED_ANN_STEP
+
+    def _reduced_monthly_limit(self) -> int:
+        n = self._household_size_for_limits()
+        if n <= 8:
+            return self._RED_MO[n]
+        return self._RED_MO[8] + (n - 8) * self._RED_MO_STEP
+
+    def _member_age(self, member: HouseholdMember) -> int | None:
+        if member.birth_year_month is not None:
+            return member.calc_age()
+        return member.age
+
+    def _is_school_meal_proxy_student(self, member: HouseholdMember) -> bool:
+        if member.relationship not in self.SCHOOL_MEAL_RELATIONSHIPS:
+            return False
+        age = self._member_age(member)
+        if age is None:
+            return False
+        return self.MIN_SCHOOL_MEAL_AGE <= age <= self.MAX_SCHOOL_MEAL_AGE
+
+    def _positive_income_streams(self) -> list[IncomeStream]:
+        streams: list[IncomeStream] = []
+        for m in self.screen.household_members.all():
+            for inc in m.income_streams.all():
+                if inc.amount is not None and float(inc.amount) > 0 and inc.frequency:
+                    streams.append(inc)
+        return streams
+
+    def _income_at_or_below_reduced_cap(self) -> bool:
+        streams = self._positive_income_streams()
+        if not streams:
+            return True
+
+        freqs = {s.frequency for s in streams}
+        hh = self._household_size_for_limits()
+        red_ann = self._reduced_annual_limit()
+        red_mo = self._reduced_monthly_limit()
+
+        if len(freqs) > 1:
+            gross = int(self.screen.calc_gross_income("yearly", ["all"]))
+            return gross <= red_ann
+
+        f = next(iter(freqs))
+        if f == "monthly":
+            total = sum(float(s.amount) for s in streams)
+            return int(total) <= red_mo
+        if f == "yearly":
+            total = sum(float(s.amount) for s in streams)
+            return int(total) <= red_ann
+        if f == "weekly":
+            total = sum(float(s.amount) for s in streams)
+            return int(total * 52) <= red_ann
+        if f == "biweekly":
+            total = sum(float(s.amount) for s in streams)
+            return int(total * 26) <= red_ann
+        if f == "semimonthly":
+            total = sum(float(s.amount) for s in streams)
+            return int(total * 24) <= red_ann
+        # Hourly (and any other): use annualized gross from screener conversion rules.
+        gross = int(self.screen.calc_gross_income("yearly", ["all"]))
+        return gross <= red_ann
+
+    def _household_categorical(self) -> bool:
+        if self.screen.has_snap or self.screen.has_tanf:
+            return True
+        if self.screen.has_head_start or self.screen.has_early_head_start:
+            return True
+        return False
+
+    def _foster_school_age_categorical(self) -> bool:
+        for m in self.screen.household_members.all():
+            if m.relationship == "fosterChild" and self._is_school_meal_proxy_student(m):
+                return True
+        return False
+
+    def member_eligible(self, e: MemberEligibility):
+        e.condition(self._is_school_meal_proxy_student(e.member))
+
+    def household_eligible(self, e: Eligibility):
+        e.condition(
+            not self.screen.has_benefit("nslp"),
+            messages.must_not_have_benefit("NSLP"),
+        )
+
+        gross_for_message = int(self.screen.calc_gross_income("yearly", ["all"]))
+        income_limit_message = self._reduced_annual_limit()
+
+        categorical = self._household_categorical() or self._foster_school_age_categorical()
+        income_ok = self._income_at_or_below_reduced_cap()
+
+        e.condition(
+            categorical or income_ok,
+            messages.income(gross_for_message, income_limit_message),
+        )
+
+    def member_value(self, member: HouseholdMember) -> int:
+        if self._is_school_meal_proxy_student(member):
+            return self.ANNUAL_VALUE_PER_CHILD
+        return 0

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -157,10 +157,13 @@ class WaNslp(ProgramCalculator):
         categorical = self._household_categorical() or self._foster_school_age_categorical()
         income_ok = self._income_at_or_below_reduced_cap()
 
-        e.condition(
-            categorical or income_ok,
-            messages.income(gross_for_message, income_limit_message),
-        )
+        # Do not attach the income tuple when categorical applies: `Eligibility.condition`
+        # treats the message as a pass message if the flag is True, which would incorrectly
+        # imply an income test was met for high-income SNAP/TANF/Head Start households.
+        if categorical:
+            e.condition(True, messages.presumed_eligibility())
+        else:
+            e.condition(income_ok, messages.income(gross_for_message, income_limit_message))
 
     def member_value(self, member: HouseholdMember) -> int:
         if self._is_school_meal_proxy_student(member):

--- a/programs/programs/wa/nslp/spec.md
+++ b/programs/programs/wa/nslp/spec.md
@@ -1,0 +1,379 @@
+# Washington National School Lunch Program (NSLP) — Eligibility Spec
+
+## Program Details
+
+- **Program:** National School Lunch Program (NSLP)
+- **State:** Washington
+- **White label:** `wa`
+- **Internal program name:** `wa_nslp`
+- **Review date:** 2026-05-08
+- **Base program:** `nslp`
+
+## Reviewer Notes
+
+This spec treats NSLP as a household/student screening program for free or reduced-price school lunch eligibility. It does **not** treat Community Eligibility Provision (CEP), Provision 2, or Provision 3 as household eligibility pathways because those are school-level service models. A student may still receive meals at no cost through their school even when household income screening would not show eligibility.
+
+The calculator should be intentionally inclusive where MFB does not capture school-specific facts. It should estimate eligibility based on Washington white-label routing, a likely child/student proxy, income, and screenable categorical pathways, while warning that the school or district makes the final eligibility decision.
+
+## Eligibility Criteria
+
+1. **Child must attend a participating NSLP/SBP school, district, or eligible institution** ⚠️ *data gap*
+
+   - **Screener fields:** none
+   - **How to implement:** Do not screen households out based on this criterion because MFB does not collect the child's school, district, grade, or residential child care institution (RCCI). Use an inclusivity assumption: if the household otherwise appears eligible, assume the school/institution participation requirement may be met.
+   - **Notes:** This is a real program requirement, but it is not the same as a standalone "Washington residency" rule. If it were known that the child does not attend a participating NSLP/SBP school, district, or eligible institution, the child would not be eligible for NSLP benefits through that school. MFB can only route users to Washington materials through the WA white label and should tell users that their school or district makes the final decision.
+   - **Suggested screener improvement:** Do not add a school-participation question unless MFB has a reliable school/district participation dataset. Without that dataset, keep this as an application-stage verification item.
+   - **Sources:**
+      - 7 CFR § 245.1
+      - 7 CFR § 210.2
+      - OSPI Meal Application and Verification Information
+
+2. **Household must include at least one child/student who could receive school meals** ⚠️ *partial data gap*
+
+   - **Screener fields:**
+      - `household_members[].relationship`
+      - `household_members[].birth_month`
+      - `household_members[].birth_year`
+      - derived `age` only for validation consistency; calculator should use `birth_month` + `birth_year`
+   - **How to implement:** Count household members with relationship `child`, `fosterChild`, or `grandChild` who are age 5 through 18, using `birth_month` and `birth_year` rather than relying only on deprecated `age`. Do not use the screener's `student` field for this check because that field is meant for postsecondary/student-status questions, not K-12 enrollment.
+   - **Notes:** This is a screening proxy, not a perfect legal rule. Federal NSLP rules define a "child" by school enrollment/grade or certain eligible institution/afterschool settings, not by a simple household age band. Some students outside the age 5-18 proxy may qualify, such as a student still enrolled in high school, a child under 21 in an eligible institution/center, or a student with a disability in an eligible school program. MFB cannot verify grade level, K-12 enrollment, school-year start age, RCCI status, or eligible disability-program enrollment, so this should remain a partial data gap.
+   - **Suggested screener improvement:** If MFB later adds a question, keep it simple, such as: "Does this child attend elementary, middle, or high school, or another school meal program?" Avoid using the postsecondary `student` field for this.
+   - **Dev note (validation):** `grandChild` is a valid relationship in the screener model and is used in production calculators (`il_ccap`, `co_first_step_savings`, `il_medicaid`). It is **not** currently in the `test_case_schema.json` relationship enum, so validation scenarios cannot include `grandChild` members. This is a schema limitation, not a spec issue. Validation coverage for grandchild households is deferred until the schema is updated.
+   - **Sources:**
+      - 7 CFR § 210.2
+      - OSPI CNEEB Application
+
+3. **Household income must be at or below the reduced-price income limit to screen as eligible**
+
+   - **Screener fields:**
+      - `household_size`
+      - `income_streams[].type`
+      - `income_streams[].amount`
+      - `income_streams[].frequency`
+      - `calc_gross_income(frequency, ["all"])`
+   - **How to implement:** Compare household gross income to the 2025-26 OSPI/USDA Child Nutrition Program income guideline for the household size, using a **frequency-matched limit** from the OSPI table rather than always annualizing. The OSPI table publishes both annual and monthly limits; for some household sizes the monthly limit × 12 differs from the annual limit by a few dollars because OSPI rounds the monthly value (for HH size 3, $4,109/mo × 12 = $49,308 vs. the published $49,303 annual). Mirror OSPI's published behavior: if a household reports a single pay frequency, compare against the matching OSPI limit (monthly income → monthly limit; yearly income → annual limit). Only annualize when income streams are reported at mixed frequencies — in that case, use `calc_gross_income("yearly", ["all"])` and compare to the annual limit. Classify as:
+      - **Free meal income tier:** income is at or below the free limit for the matched frequency.
+      - **Reduced-price meal income tier:** income is above the free limit and at or below the reduced-price limit for the matched frequency.
+   - **Notes:** For validation and initial implementation, use the OSPI 2025-26 rounded income table as the source of truth rather than re-calculating raw FPL percentages, because the published table is the operative household-facing source. If the MFB FPL table is used instead, confirm it reproduces the OSPI rounded limits. The legal rule uses current household income at the time of application; MFB's gross income calculation should annualize income streams according to the published pay-frequency conversion rules only when frequency-matching isn't possible. The school/district verifies the final application details.
+   - **Sources:**
+      - 42 U.S.C. § 1758(b)(1)(A)
+      - 42 U.S.C. § 1758(b)(9)(A)-(B)
+      - 7 CFR § 245.3(a)-(c)
+      - 7 CFR § 245.6(c)(4)
+      - Federal Register, Child Nutrition Programs: Income Eligibility Guidelines, 90 FR 11938 (Mar. 13, 2025)
+      - OSPI Income Guidelines 2025-26
+
+4. **Household is categorically eligible for free meals through Basic Food/SNAP, TANF, or FDPIR** ⚠️ *partial data gap*
+
+   - **Screener fields:**
+      - `has_benefits`
+      - `has_snap`
+      - `has_tanf`
+   - **How to implement:** If the household has at least one child/student who meets the MFB proxy and `has_snap` or `has_tanf` is true, screen the household as eligible regardless of income. Do not implement FDPIR as an automatic eligibility check unless a `has_fdpir` or equivalent field is confirmed.
+   - **Notes:** In Washington, the application refers to SNAP as **Basic Food**. Federal rules extend categorical eligibility to all children in a household receiving SNAP, FDPIR, or TANF. The OSPI application asks for FDPIR case numbers, but MFB does not appear to capture FDPIR participation in the current screener field list. User-facing copy should mention that some pathways may not be fully captured by the screener.
+   - **Suggested screener improvement:** Consider adding `has_fdpir` to the WA current-benefits list if FDPIR should be reusable for categorical eligibility across programs.
+   - **Sources:**
+      - 7 CFR § 245.2
+      - 7 CFR § 245.6(b)(7)
+      - 7 CFR § 245.6(c)(4)(i)
+      - 42 U.S.C. § 1758(b)(12)
+      - OSPI CNEEB Application
+
+5. **Individual child is categorically eligible for free meals through Head Start, Early Head Start, foster care, homelessness, migrant status, or runaway status** ⚠️ *partial data gap*
+
+   - **Screener fields:**
+      - `has_head_start`
+      - `has_early_head_start`
+      - `household_members[].relationship` where relationship is `fosterChild` (partial proxy only)
+      - `housing_situation` only if confirmed available for the WA flow (partial proxy only)
+   - **How to implement:** Treat `has_head_start` or `has_early_head_start` as a categorical pathway when a child/student who meets the MFB proxy is present. Treat `relationship == "fosterChild"` as a partial proxy for foster categorical eligibility, but note that formal foster status is ultimately verified by the school/agency. Do not implement migrant or runaway status unless a screener field is added. Do not rely on `needs_housing_help` as a homelessness proxy.
+   - **Notes:** Under federal rules, foster/homeless/migrant/runaway/Head Start categorical eligibility is individual to that child and does not extend to all other children in the household. MFB should not overextend this pathway across the whole household unless the implementing calculator only returns one household-level recommendation and documents the simplification.
+   - **Suggested screener improvement:** Do not add sensitive questions for this initial launch unless the team decides these pathways are important enough to screen directly. If added later, use simple optional yes/no questions, and avoid collecting more detail than needed.
+   - **Dev note (validation):** `has_head_start` and `has_early_head_start` exist in the screener model but are **not** currently in the `test_case_schema.json` household properties. Validation scenarios that test the Head Start pathway (Spec Scenario 7 below) cannot be represented in the JSON format. Recommend a follow-up engineering ticket to add these fields to `test_case_schema.json` so the Head Start categorical pathway becomes validation-testable. Coverage gap is acknowledged in the current 3-scenario validation file.
+   - **Sources:**
+      - 7 CFR § 245.2
+      - 7 CFR § 245.6(b)(8)
+      - 42 U.S.C. § 1758(b)(12)
+      - OSPI CNEEB Application
+      - USDA/FNS Eligibility Manual for School Meals
+
+## Other Eligibility Pathways / Data Gaps Not Implemented as Automatic Checks
+
+### Medicaid direct certification
+
+- **Screener fields:** `has_medicaid` and member-level Medicaid fields are **not sufficient by themselves**.
+- **How to implement:** Do not screen a household as NSLP-eligible based only on `has_medicaid`. The household may still qualify through income or other categorical pathways.
+- **Notes:** Federal law allows direct certification through Medicaid for children in families with income at or below a specified poverty-line threshold, and federal verification rules require Medicaid income/household-size detail in states with higher Medicaid income limits. MFB does not capture the Medicaid income percentage or direct-certification match data needed to safely use this pathway.
+- **Suggested screener improvement:** Do not add a generic Medicaid shortcut. Only implement this pathway if MFB receives reliable state Medicaid direct-certification data or a direct-certification indicator.
+- **Sources:**
+   - 42 U.S.C. § 1758(b)(15)
+   - 7 CFR § 245.6a(g)(4)
+   - USDA/FNS Direct Certification with Medicaid Demonstration Project
+
+### CEP, Provision 2, and Provision 3 school-wide free meals
+
+- **Screener fields:** none.
+- **How to implement:** Do not treat CEP, Provision 2, or Provision 3 as household eligibility pathways in the calculator. A household may screen ineligible through household-based NSLP rules and still have a child who receives no-cost meals at a school-wide free-meal school.
+- **Notes:** Surface this in the program description by telling users that some Washington schools provide meals at no cost to all students and that the school/district makes the final decision.
+- **Suggested screener improvement:** Only add a school lookup if MFB has reliable, maintained school-level data for CEP/Provision 2/Provision 3 or other no-cost meal participation.
+- **Sources:**
+   - 7 CFR § 245.9
+   - OSPI NSLP / Meal Application information
+
+## Already-Has / Display Suppression Logic — Not an Eligibility Criterion
+
+- **Screener fields:**
+   - `has_benefits`
+   - `has_nslp`
+- **How to implement:** If `has_nslp` is true, suppress the program from the results or show it as already received, depending on MFB's standard current-benefits behavior.
+- **Notes:** This is not an eligibility criterion; it is display/suppression logic.
+
+## Priority Criteria
+
+No household-level priority criteria were identified for this initial implementation. CEP, Provision 2, Provision 3, and other school-wide no-cost meal models are school-level service models, not household priority criteria.
+
+## Income Guideline Table for 2025-26
+
+Use the OSPI/USDA Child Nutrition Program Income Guidelines effective July 1, 2025 through June 30, 2026.
+
+| Household size | Free annual limit | Free monthly limit | Reduced-price annual limit | Reduced-price monthly limit |
+|---:|---:|---:|---:|---:|
+| 1 | $20,345 | $1,696 | $28,953 | $2,413 |
+| 2 | $27,495 | $2,292 | $39,128 | $3,261 |
+| 3 | $34,645 | $2,888 | $49,303 | $4,109 |
+| 4 | $41,795 | $3,483 | $59,478 | $4,957 |
+| 5 | $48,945 | $4,079 | $69,653 | $5,805 |
+| 6 | $56,095 | $4,675 | $79,828 | $6,653 |
+| 7 | $63,245 | $5,271 | $90,003 | $7,501 |
+| 8 | $70,395 | $5,867 | $100,178 | $8,349 |
+| Each additional member | +$7,150 | +$596 | +$10,175 | +$848 |
+
+**Note on monthly vs annual rounding:** OSPI's published monthly limits are rounded values derived from the annual limits. For some household sizes the monthly limit × 12 differs slightly from the published annual limit (e.g., HH size 3: $4,109 × 12 = $49,308 vs. published $49,303). When comparing household income to the table, **use the frequency-matched limit** (monthly income against the monthly column; annual income against the annual column) rather than always annualizing. Only annualize when income streams are reported at mixed frequencies.
+
+For mixed pay frequencies, annualize using the OSPI method:
+- monthly x 12
+- twice per month x 24
+- every two weeks x 26
+- weekly x 52
+
+## Benefit Value
+
+**Type:** In-kind benefit estimate.
+
+**Recommended calculator value:** `eligible_school_age_child_count * 828`, displayed as an estimated annual value.
+
+**Methodology:**
+
+- Use an estimated **$828 per eligible child per school year**.
+- Calculation: **$4.60 per lunch x 180 school days = $828**.
+- The $4.60 per-lunch estimate uses the SY 2025-26 contiguous-state federal reimbursement components for free lunches in lower-payment SFAs: $0.44 Section 4 payment + $4.16 Section 11 free-lunch payment.
+- This is a conservative proxy. It excludes the additional $0.09 performance-based payment and excludes USDA Foods/cash-in-lieu value. It also does not try to estimate district-specific lunch prices or local/state copay policies.
+- For reduced-price eligible households, use the same estimated annual value for MFB screening unless devs decide to display a lower avoided-cost value. Washington/local policy may make reduced-price meals effectively no-cost for many students, but this should be verified before coding a separate value.
+
+**Sources:**
+- USDA/FNS SY 2025-26 National Average Payments/Maximum Reimbursement Rates
+- OSPI Income Guidelines 2025-26
+
+## Suggested Implementation Logic
+
+1. If `has_nslp` is true, suppress or mark as already received.
+2. Count likely eligible students:
+   - relationship in `child`, `fosterChild`, `grandChild`
+   - age 5 through 18 using `birth_month` and `birth_year`
+3. If count is 0, return ineligible.
+4. If `has_snap` or `has_tanf` is true, return eligible with value `count * 828`.
+5. If `has_head_start` or `has_early_head_start` is true, return eligible with value `count * 828`, while noting this is an imperfect household-level simplification.
+6. Determine the household's income frequency. Compare household gross income to the OSPI reduced-price limit for `household_size` using the **frequency-matched column** (monthly income → monthly limit; yearly income → annual limit). If income streams are at mixed frequencies, annualize using `calc_gross_income("yearly", ["all"])` and compare to the annual limit.
+7. If income is at or below the reduced-price limit for the matched frequency, return eligible with value `count * 828`; otherwise return ineligible, but the program description should still explain that school-wide free meals may apply.
+
+## Test Scenarios
+
+### Scenario 1: Eligible by income — standard free-meal case
+
+**What this checks:** A standard WA household with one likely school-meal-eligible child and income below the free-meal income limit.
+
+**Expected:** Eligible. Estimated annual value: `$828`.
+
+**Steps:**
+- Location: ZIP `98101`, county `King County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born March 1990, wages `$2,000` monthly.
+- Person 2: `spouse`, born July 1991, no income.
+- Person 3: `child`, born September 2018, no income.
+- Current benefits: no SNAP, TANF, or NSLP.
+
+**Why this matters:** This is the golden-path income scenario and validates the core household-size plus gross-income pathway.
+
+### Scenario 2: Eligible at the reduced-price upper boundary
+
+**What this checks:** A household at the published monthly reduced-price limit remains eligible. Acts as a regression test for the frequency-matched comparison rule in Criterion 3.
+
+**Expected:** Eligible. Estimated annual value: `$828`.
+
+**Steps:**
+- Location: ZIP `98103`, county `King County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born January 1987, wages `$4,109` monthly.
+- Person 2: `spouse`, born June 1988, no income.
+- Person 3: `child`, born September 2013, no income.
+- Current benefits: no SNAP, TANF, or NSLP.
+
+**Why this matters:** Household size 3 has a 2025-26 reduced-price monthly limit of `$4,109` and annual limit of `$49,303`. The household reports income monthly, so the calculator should compare `$4,109/mo` to the monthly column (`$4,109`) and return eligible. A calculator that incorrectly always annualizes will compute `$4,109 × 12 = $49,308`, compare to the annual limit `$49,303`, and incorrectly return ineligible by `$5`. This scenario therefore serves as a regression test for the frequency-matched comparison rule in Criterion 3.
+
+### Scenario 3: Ineligible above the reduced-price limit; Medicaid alone is not enough
+
+**What this checks:** A household just above the reduced-price limit should be ineligible even if it reports Medicaid.
+
+**Expected:** Ineligible. No value.
+
+**Steps:**
+- Location: ZIP `98103`, county `King County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born January 1987, wages `$4,110` monthly.
+- Person 2: `spouse`, born June 1988, no income.
+- Person 3: `child`, born September 2013, no income.
+- Current benefits: Medicaid reported, but no SNAP, TANF, Head Start, Early Head Start, or NSLP.
+
+**Why this matters:** `has_medicaid` alone is not enough because MFB does not capture Medicaid direct-certification income/match data. `$4,110/mo` exceeds the monthly limit ($4,109) directly and also exceeds the annual limit when annualized ($49,320 vs $49,303) — so this is unambiguously ineligible under any comparison approach.
+
+### Scenario 4: Ineligible because there is no likely school-meal-eligible child
+
+**What this checks:** Categorical eligibility through SNAP should not bypass the need for a likely child/student.
+
+**Expected:** Ineligible. No value.
+
+**Steps:**
+- Location: ZIP `98103`, county `King County`.
+- Household size: `2`.
+- Person 1: `headOfHousehold`, born March 1986, wages `$1,800` monthly.
+- Person 2: `child`, born September 2022, age 3, no income.
+- Current benefits: SNAP selected.
+
+**Why this matters:** This validates the MFB applicability proxy. NSLP should not be shown to a household with no likely school-meal-eligible child.
+
+### Scenario 5: Eligible through Basic Food/SNAP categorical pathway despite high income
+
+**What this checks:** A household with SNAP/Basic Food is categorically eligible even if income is above the normal income limit.
+
+**Expected:** Eligible. Estimated annual value: `$828`.
+
+**Steps:**
+- Location: ZIP `99201`, county `Spokane County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born June 1985, wages `$7,000` monthly.
+- Person 2: `spouse`, born February 1987, no income.
+- Person 3: `child`, born March 2016, no income.
+- Current benefits: SNAP selected; no NSLP.
+
+**Why this matters:** This validates the screenable household categorical pathway.
+
+### Scenario 6: Eligible through TANF categorical pathway despite high income
+
+**What this checks:** A household with TANF is categorically eligible even if income is above the normal income limit.
+
+**Expected:** Eligible. Estimated annual value: `$828`.
+
+**Steps:**
+- Location: ZIP `98901`, county `Yakima County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born April 1989, wages `$5,500` monthly.
+- Person 2: `spouse`, born August 1990, no income.
+- Person 3: `child`, born October 2017, no income.
+- Current benefits: TANF selected; no NSLP.
+
+**Why this matters:** This separately validates `has_tanf`, which is a screenable household categorical pathway.
+
+### Scenario 7: Eligible through Head Start / Early Head Start pathway
+
+**What this checks:** A household with a likely child/student and Head Start or Early Head Start participation can screen eligible through a child categorical pathway.
+
+**Expected:** Eligible. Estimated annual value: `$828`.
+
+**Steps:**
+- Location: ZIP `98402`, county `Pierce County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born May 1992, wages `$5,000` monthly.
+- Person 2: `spouse`, born September 1993, no income.
+- Person 3: `child`, born May 2021, age 5, no income.
+- Current benefits: Head Start or Early Head Start selected; no SNAP, TANF, or NSLP.
+
+**Why this matters:** This validates the screenable child categorical pathway and checks that income does not block the categorical pathway.
+
+**Dev note:** This scenario cannot currently be expressed in the validation JSON because `has_head_start` and `has_early_head_start` are not in `test_case_schema.json` household properties. See Criterion 5 dev note. The calculator should still implement this pathway.
+
+### Scenario 8: Already receiving NSLP suppression
+
+**What this checks:** A household that reports already receiving NSLP should not receive a new recommendation for the same program.
+
+**Expected:** Ineligible/suppressed or marked already received, according to MFB current-benefits behavior.
+
+**Steps:**
+- Location: ZIP `98101`, county `King County`.
+- Household size: `3`.
+- Person 1: `headOfHousehold`, born March 1990, wages `$2,000` monthly.
+- Person 2: `spouse`, born July 1991, no income.
+- Person 3: `child`, born September 2018, no income.
+- Current benefits: NSLP selected.
+
+**Why this matters:** This validates already-has/display suppression and keeps it separate from true eligibility.
+
+### Scenario 9: Multiple likely eligible children — value scales by child count
+
+**What this checks:** A larger household with more than one likely school-meal-eligible child should receive a value estimate for each likely eligible child.
+
+**Expected:** Eligible. Estimated annual value: `$2,484` for three likely eligible children (`3 x $828`).
+
+**Steps:**
+- Location: ZIP `99201`, county `Spokane County`.
+- Household size: `6`.
+- Person 1: `headOfHousehold`, born March 1985, wages `$2,400` monthly.
+- Person 2: `spouse`, born July 1987, wages `$800` monthly.
+- Person 3: `child`, born September 2010, no income.
+- Person 4: `child`, born January 2014, no income.
+- Person 5: `child`, born November 2019, no income.
+- Person 6: `child`, born February 2023, no income.
+- Current benefits: no SNAP, TANF, or NSLP.
+
+**Why this matters:** This validates household-size income logic and the benefit value method for multiple likely eligible children.
+
+## Representative Validation Scenarios Used in `wa_nslp.json`
+
+The validation file contains 3 scenarios chosen to give broad coverage of the eligibility space without duplicating test dimensions:
+
+1. **Eligible by income — household of 3 with one school-age child below the free-meal income limit**
+   - WA household of 3 (head + spouse + child age 7). Head earns `$2,000/mo` wages — well below the free-meal monthly limit (`$2,888` for HH size 3).
+   - Expected: eligible, estimated value `$828`.
+
+2. **Ineligible by income — household just above the reduced-price limit; Medicaid alone is not enough**
+   - WA household of 3 (head + spouse + child age 12). Head earns `$4,110/mo` wages — `$1` above the reduced-price monthly limit (`$4,109`). Household reports Medicaid but not SNAP, TANF, or Head Start.
+   - Expected: ineligible. Validates that `has_medicaid` alone is not a categorical pathway.
+
+3. **Eligible by categorical pathway — household receives Basic Food/SNAP despite income above the reduced-price limit**
+   - WA household of 3 (head + spouse + child age 10). Head earns `$7,000/mo` wages — far above the reduced-price limit — but `has_snap: true`.
+   - Expected: eligible, estimated value `$828`. Validates the SNAP categorical pathway overrides the income test.
+
+These 3 cover: (a) the standard income-eligible golden path, (b) the most common disqualifying reason with a noise variable (Medicaid) thrown in, and (c) the highest-volume categorical override. Spec Scenarios 2 (boundary), 4 (no child), 6 (TANF), 7 (Head Start), 8 (suppression), and 9 (multi-child value scaling) are documented in the spec but not in `wa_nslp.json` due to either the 3-scenario design constraint or current test-schema limitations (see Criterion 5 dev note for Head Start).
+
+## Source Verification Notes
+
+- **7 CFR Part 245:** Supports using Part 245 as the primary CFR source for eligibility determinations, income guidelines, applications, direct certification, categorical eligibility, and school-level alternatives.
+- **7 CFR § 210.2:** Supports the student/school-enrollment definition of "child," which is why MFB age screening is only a proxy.
+- **42 U.S.C. § 1758:** Supports the 130% FPL free-lunch threshold, 185% FPL reduced-price threshold, income eligibility, and automatic eligibility pathways.
+- **OSPI Income Guidelines 2025-26:** Supports the exact WA 2025-26 income limits and annualization method.
+- **OSPI CNEEB Application:** Supports Washington-specific application pathways, including Basic Food, TANF, FDPIR, income, foster/homeless/migrant indicators, SSN exceptions, and school-use approval categories.
+- **OSPI Application Finder and Meal Application page:** Supports using a district application finder as the apply link and explains that families can apply any time during the school year.
+- **USDA/FNS reimbursement rates:** Supports the conservative annual value estimate.
+
+## Source URLs
+
+- https://www.ecfr.gov/current/title-7/subtitle-B/chapter-II/subchapter-A/part-245
+- https://www.ecfr.gov/current/title-7/subtitle-B/chapter-II/subchapter-A/part-210#210.2
+- https://uscode.house.gov/view.xhtml?req=%28title%3A42%20section%3A1758%20edition%3Aprelim%29
+- https://www.federalregister.gov/documents/2025/03/13/2025-03821/child-nutrition-programs-income-eligibility-guidelines
+- https://www.fns.usda.gov/cn/eligibility-manual-school-meals
+- https://www.fns.usda.gov/cn/direct-certification-medicaid-demonstration-project
+- https://ospi.k12.wa.us/sites/default/files/2025-03/incomeguidelines_25-26.pdf
+- https://ospi.k12.wa.us/policy-funding/child-nutrition/school-meals/national-school-lunch-program/meal-application-and-verification-information
+- https://ospi.k12.wa.us/policy-funding/child-nutrition/school-meals/national-school-lunch-program
+- https://ospi.k12.wa.us/policy-funding/child-nutrition/school-meals/washington-school-meals-application-finder
+- https://www.fns.usda.gov/schoolmeals/fr-072425

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -145,6 +145,24 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertFalse(result.eligible)
 
+    def test_eligible_early_head_start_flag_high_income(self):
+        screen = self._screen_base(
+            zipcode="98402",
+            county="Pierce County",
+            has_early_head_start=True,
+            has_benefits="true",
+        )
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=33, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=5000, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=32, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=5, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
     def test_eligible_head_start_flag_high_income(self):
         screen = self._screen_base(
             zipcode="98402",
@@ -162,6 +180,25 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertTrue(result.eligible)
         self.assertEqual(result.value, 828)
+
+    def test_snap_categorical_uses_presumed_eligibility_pass_message_not_income(self):
+        screen = self._screen_base(
+            zipcode="99201",
+            county="Spokane County",
+            has_snap=True,
+            has_benefits="true",
+        )
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=7000, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=39, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=10, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertTrue(any("Presumed eligibility" in str(m) for m in result.pass_messages))
+        self.assertFalse(any("Household makes" in str(m) for m in result.pass_messages))
 
     def test_eligible_foster_child_categorical(self):
         screen = self._screen_base(household_size=3)

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -1,0 +1,232 @@
+from django.test import TestCase
+
+from programs.models import Program, FederalPoveryLimit
+from programs.programs.calc import MemberEligibility
+from programs.programs.wa import wa_calculators
+from programs.programs.wa.nslp.calculator import WaNslp
+from programs.util import Dependencies
+from screener.models import HouseholdMember, IncomeStream, Screen, WhiteLabel
+
+
+class TestWaNslp(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Washington", code="wa", state_code="WA")
+        cls.fpl_year = FederalPoveryLimit.objects.create(year="2025", period="2025")
+        cls.program = Program.objects.new_program(white_label="wa", name_abbreviated="wa_nslp")
+        cls.program.year = cls.fpl_year
+        cls.program.save()
+
+    def _calc(self, screen: Screen) -> WaNslp:
+        return WaNslp(screen, self.program, {}, Dependencies())
+
+    def _screen_base(self, **kwargs) -> Screen:
+        defaults = dict(
+            white_label=self.white_label,
+            agree_to_tos=True,
+            completed=False,
+            household_size=3,
+            has_nslp=False,
+            has_snap=False,
+            has_tanf=False,
+            has_head_start=False,
+            has_early_head_start=False,
+            has_medicaid=False,
+        )
+        defaults.update(kwargs)
+        return Screen.objects.create(**defaults)
+
+    def test_registered(self):
+        self.assertIn("wa_nslp", wa_calculators)
+        self.assertIs(wa_calculators["wa_nslp"], WaNslp)
+
+    def test_eligible_by_income_below_free_tier(self):
+        """Spec / validation: HH 3, one school-age child, income below reduced cap."""
+        screen = self._screen_base(zipcode="98101", county="King County")
+        HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen,
+            household_member=screen.household_members.get(relationship="headOfHousehold"),
+            type="wages",
+            amount=2000,
+            frequency="monthly",
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=34, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=7, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
+    def test_ineligible_income_one_dollar_over_reduced_monthly(self):
+        """$4,110/mo for HH3 — over $4,109 monthly reduced-price cap; Medicaid irrelevant."""
+        screen = self._screen_base(
+            zipcode="98103",
+            county="King County",
+            household_size=3,
+            has_medicaid=True,
+            has_benefits="true",
+        )
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=39, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=4110, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=37, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=12, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertFalse(result.eligible)
+
+    def test_eligible_at_reduced_monthly_cap_exact(self):
+        """Regression: frequency-matched monthly must not always annualize (+$5 error)."""
+        screen = self._screen_base(zipcode="98103", county="King County")
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=39, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=4109, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=37, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=12, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
+    def test_eligible_snap_categorical_high_income(self):
+        screen = self._screen_base(
+            zipcode="99201",
+            county="Spokane County",
+            has_snap=True,
+            has_benefits="true",
+        )
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=7000, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=39, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=10, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
+    def test_eligible_tanf_categorical(self):
+        screen = self._screen_base(zipcode="98901", county="Yakima County", has_tanf=True, has_benefits="true")
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=5500, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=35, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=9, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
+    def test_ineligible_snap_but_no_school_age_child(self):
+        screen = self._screen_base(zipcode="98103", county="King County", household_size=2, has_snap=True)
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=1800, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=3, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertFalse(result.eligible)
+
+    def test_ineligible_already_has_nslp(self):
+        screen = self._screen_base(has_nslp=True)
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=2000, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=34, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=7, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertFalse(result.eligible)
+
+    def test_eligible_head_start_flag_high_income(self):
+        screen = self._screen_base(
+            zipcode="98402",
+            county="Pierce County",
+            has_head_start=True,
+            has_benefits="true",
+        )
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=33, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=5000, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=32, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=5, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
+    def test_eligible_foster_child_categorical(self):
+        screen = self._screen_base(household_size=3)
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=35, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=8000, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=34, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="fosterChild", age=12, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)
+
+    def test_two_school_age_children_value_scales(self):
+        screen = self._screen_base(zipcode="99201", county="Spokane County", household_size=6)
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=2400, frequency="monthly"
+        )
+        spouse = HouseholdMember.objects.create(screen=screen, relationship="spouse", age=38, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=spouse, type="wages", amount=800, frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=15, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=11, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=6, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=2, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828 * 3)
+
+    def test_mixed_frequency_uses_annual_limit(self):
+        screen = self._screen_base(household_size=3)
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=39, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=2000, frequency="monthly"
+        )
+        IncomeStream.objects.create(screen=screen, household_member=head, type="wages", amount=500, frequency="yearly")
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=37, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=12, has_income=False)
+
+        calc = self._calc(screen)
+        self.assertTrue(calc._income_at_or_below_reduced_cap())
+
+    def test_member_eligible_false_for_head(self):
+        calc = self._calc(self._screen_base())
+        e = MemberEligibility(HouseholdMember(relationship="headOfHousehold", age=30))
+        calc.member_eligible(e)
+        self.assertFalse(e.eligible)
+
+    def test_grandchild_counts(self):
+        screen = self._screen_base(household_size=3)
+        HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=55, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen,
+            household_member=screen.household_members.get(relationship="headOfHousehold"),
+            type="wages",
+            amount=2500,
+            frequency="monthly",
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=54, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="grandChild", age=10, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertTrue(result.eligible)
+        self.assertEqual(result.value, 828)

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.test import TestCase
 
 from programs.models import Program, FederalPoveryLimit
@@ -57,6 +59,19 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertTrue(result.eligible)
         self.assertEqual(result.value, 828)
+
+    def test_ineligible_monthly_income_cents_over_reduced_cap(self):
+        """HH3 monthly cap $4,109 — cents must not be truncated (CodeRabbit / Decimal)."""
+        screen = self._screen_base(zipcode="98103", county="King County", household_size=3)
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=39, has_income=True)
+        IncomeStream.objects.create(
+            screen=screen, household_member=head, type="wages", amount=Decimal("4109.99"), frequency="monthly"
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=37, has_income=False)
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=12, has_income=False)
+
+        result = self._calc(screen).calc()
+        self.assertFalse(result.eligible)
 
     def test_ineligible_income_one_dollar_over_reduced_monthly(self):
         """$4,110/mo for HH3 — over $4,109 monthly reduced-price cap; Medicaid irrelevant."""

--- a/screener/models.py
+++ b/screener/models.py
@@ -415,6 +415,7 @@ class Screen(models.Model):
             "il_eitc": self.has_il_eitc,
             "nslp": self.has_nslp,
             "tx_nslp": self.has_nslp,
+            "wa_nslp": self.has_nslp,
             "ctc": self.has_ctc,
             "tx_ctc": self.has_ctc,
             "il_ctc": self.has_il_ctc,

--- a/validations/management/commands/import_validations/data/wa_nslp.json
+++ b/validations/management/commands/import_validations/data/wa_nslp.json
@@ -1,0 +1,250 @@
+[
+  {
+    "notes": "WA NSLP - eligible by income: household of 3 with one school-age child below the free-meal income limit",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98101",
+      "county": "King County",
+      "household_size": 3,
+      "household_assets": 0.0,
+      "has_benefits": "false",
+      "has_snap": false,
+      "has_tanf": false,
+      "has_nslp": false,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 3,
+          "birth_year": 1990,
+          "age": 36,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 7,
+          "birth_year": 1991,
+          "age": 34,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 9,
+          "birth_year": 2018,
+          "age": 7,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": [],
+      "has_medicaid": false
+    },
+    "expected_results": {
+      "program_name": "wa_nslp",
+      "eligible": true,
+      "value": 828
+    }
+  },
+  {
+    "notes": "WA NSLP - ineligible: household just above reduced-price income limit; Medicaid alone is not enough",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98103",
+      "county": "King County",
+      "household_size": 3,
+      "household_assets": 0.0,
+      "has_benefits": "true",
+      "has_snap": false,
+      "has_tanf": false,
+      "has_nslp": false,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 1,
+          "birth_year": 1987,
+          "age": 39,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 4110.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 6,
+          "birth_year": 1988,
+          "age": 37,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 9,
+          "birth_year": 2013,
+          "age": 12,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": false,
+            "employer": false,
+            "private": false,
+            "medicaid": true,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": [],
+      "has_medicaid": true
+    },
+    "expected_results": {
+      "program_name": "wa_nslp",
+      "eligible": false
+    }
+  },
+  {
+    "notes": "WA NSLP - eligible by categorical pathway: household receives Basic Food/SNAP despite income above the reduced-price limit",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "99201",
+      "county": "Spokane County",
+      "household_size": 3,
+      "household_assets": 0.0,
+      "has_benefits": "true",
+      "has_snap": true,
+      "has_tanf": false,
+      "has_nslp": false,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1985,
+          "age": 40,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 7000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 2,
+          "birth_year": 1987,
+          "age": 39,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 3,
+          "birth_year": 2016,
+          "age": 10,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": [],
+      "has_medicaid": false
+    },
+    "expected_results": {
+      "program_name": "wa_nslp",
+      "eligible": true,
+      "value": 828
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Implements [MFB-853](https://linear.app/myfriendben/issue/MFB-853/wa-nslp) — Washington **National School Lunch Program (NSLP)** as a **custom** `ProgramCalculator` (not PolicyEngine), per researcher spec: OSPI 2025–26 reduced-price income limits, frequency-matched income comparison, categorical pathways (SNAP, TANF, Head Start/Early Head Start, foster-child proxy), and `$828`/year per eligible school-age proxy child.

## Changes

- `programs/programs/wa/nslp/calculator.py` — `WaNslp`
- `programs/programs/wa/nslp/tests.py` — 14 unit tests (incl. $4,109 monthly boundary regression)
- `programs/programs/wa/nslp/spec.md` — ticket spec
- `programs/management/commands/import_program_config_data/data/wa_nslp_initial_config.json` — program config (**`"active": true`** so imports are enabled; `new_program` defaults inactive)
- `validations/management/commands/import_validations/data/wa_nslp.json` — 3 validation scenarios
- `screener/models.py` — `has_benefit` map `wa_nslp` → `has_nslp` (reuse NSLP checkbox)

## Local verification

- `python manage.py test programs.programs.wa.nslp.tests`
- `import_program_config ... wa_nslp_initial_config.json` — use `--skip-translation` if `GOOGLE_APPLICATION_CREDENTIALS` is unset
- `migrate` (ensure DB has latest programs migrations, e.g. navigator eligibility M2M)
- `import_validations` + `validate --program wa_nslp` — all 3 passed

## Deploy / QA notes

- Staging/prod: run full import (translations) and `import_validations`; run `validate --program wa_nslp`.
- WA white label already includes `nslp` in food category benefits (`configuration/white_labels/wa.py`); no new Screen field.

## PolicyEngine

TX/IL NSLP use PE `SchoolLunch`; WA uses OSPI-rounded tables and explicit rules from `spec.md`, so this stays a custom calculator wired via `programs.programs.calculators` (not `policyengine` registry).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Washington National School Lunch Program (NSLP) eligibility screening. Users can now determine school meal benefit eligibility based on household income and categorical criteria (SNAP, TANF, Head Start, foster care status).

* **Tests**
  * Comprehensive test suite and validation scenarios added to ensure accurate eligibility calculations across multiple household configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1514)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->