### PR TITLE
MFB-826: Update Additional Resources Tile to Mental health support

### DIFF
--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -66,7 +66,7 @@ class ConfigurationData:
             "icon": {"_icon": "Support", "_classname": "option-card-icon"},
             "text": {
                 "_label": "acuteConditionOptions.support",
-                "_default_message": "A challenge you or your child would like to talk about",
+                "_default_message": "Mental health support",
             },
         },
         "childDevelopment": {

--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -89,7 +89,7 @@ class CoConfigurationData(ConfigurationData):
             "icon": {"_icon": "Support", "_classname": "option-card-icon"},
             "text": {
                 "_label": "acuteConditionOptions.support",
-                "_default_message": "A challenge you or your child would like to talk about",
+                "_default_message": "Mental health support",
             },
         },
         "childDevelopment": {

--- a/configuration/white_labels/il.py
+++ b/configuration/white_labels/il.py
@@ -59,7 +59,7 @@ class IlConfigurationData(ConfigurationData):
             "icon": {"_icon": "Support", "_classname": "option-card-icon"},
             "text": {
                 "_label": "acuteConditionOptions.support",
-                "_default_message": "A challenge you or your child would like to talk about",
+                "_default_message": "Mental health support",
             },
         },
         "childDevelopment": {

--- a/configuration/white_labels/ma.py
+++ b/configuration/white_labels/ma.py
@@ -69,7 +69,7 @@ class MaConfigurationData(ConfigurationData):
             "icon": {"_icon": "Support", "_classname": "option-card-icon"},
             "text": {
                 "_label": "acuteConditionOptions.support",
-                "_default_message": "A challenge you or your child would like to talk about",
+                "_default_message": "Mental health support",
             },
         },
         "childDevelopment": {

--- a/configuration/white_labels/nc.py
+++ b/configuration/white_labels/nc.py
@@ -76,7 +76,7 @@ class NcConfigurationData(ConfigurationData):
             "icon": {"_icon": "Support", "_classname": "option-card-icon"},
             "text": {
                 "_label": "acuteConditionOptions.support",
-                "_default_message": "A challenge you or your child would like to talk about",
+                "_default_message": "Mental health support",
             },
         },
         "childDevelopment": {

--- a/configuration/white_labels/tx.py
+++ b/configuration/white_labels/tx.py
@@ -59,7 +59,7 @@ class TxConfigurationData(ConfigurationData):
             "icon": {"_icon": "Support", "_classname": "option-card-icon"},
             "text": {
                 "_label": "acuteConditionOptions.support",
-                "_default_message": "A challenge you or your child would like to talk about",
+                "_default_message": "Mental health support",
             },
         },
         "childDevelopment": {


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-826](https://linear.app/myfriendben/issue/MFB-826/update-additional-resources-tile-mental-health)


## Changes Made

**Config files** —` _default_message` updated to "Mental health support" in all white label files.
**Translation admin** — `acuteConditionOptions.support`  record updated 
<img width="1512" height="1494" alt="Screenshot 2026-05-13 at 5 18 03 PM" src="https://github.com/user-attachments/assets/38803bf6-8922-48f4-ad49-27cbe5238d48" />

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:

1. In Django admin, navigate to Translations and find label `acuteConditionOptions.support ` and update text to **"Mental health support"** . 
2. Open the screener and navigate to **Step 9** ("Tell us some final information about your household")
3. Confirm the mental health tile now reads **"Mental health support"** instead of **"A challenge you or your child would like to talk about"**

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: Yes 
Run `python manage.py add_config` 
- Production config updates: None
- Admin updates needed: Yes
In Django admin, navigate to Translations and find label `acuteConditionOptions.support ` and update text to **"Mental health support"** . Make sure you checked "Auto-translate to all languages"
- Notify team/users of: 

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized mental health support option labels across regional configurations by replacing generic placeholder messaging with more specific "Mental health support" language, providing clearer guidance to users seeking support resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1515)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->