### PR TITLE
MFB-989: Add Trust Her to Texas family planning resources

### DIFF
--- a/configuration/white_labels/tx.py
+++ b/configuration/white_labels/tx.py
@@ -69,6 +69,13 @@ class TxConfigurationData(ConfigurationData):
                 "_default_message": "Concern about your child's development",
             },
         },
+        "familyPlanning": {
+            "icon": {"_icon": "Family_planning", "_classname": "option-card-icon"},
+            "text": {
+                "_label": "acuteConditionOptions.familyPlanning",
+                "_default_message": "Family planning or birth control",
+            },
+        },
         "jobResources": {
             "icon": {"_icon": "Job_resources", "_classname": "option-card-icon"},
             "text": {

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_trust_her.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_trust_her.json
@@ -20,7 +20,7 @@
     "counties": ["Dallas"],
     "required_expense_types": [],
     "fpl": { "year": "2026", "period": "2026" },
-    "active": true,
+    "active": false,
     "low_confidence": false,
     "show_on_current_benefits": true
   }

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_trust_her.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_trust_her.json
@@ -16,10 +16,11 @@
       "website_description": "Free and low-cost birth control and reproductive health services for women and teens in Dallas.",
       "notification_message": ""
     },
-    "functions": [],
+    "functions": ["tx_trust_her"],
     "counties": ["Dallas"],
     "required_expense_types": [],
-    "active": false,
+    "fpl": { "year": "2026", "period": "2026" },
+    "active": true,
     "low_confidence": false,
     "show_on_current_benefits": true
   }

--- a/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
+++ b/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
@@ -319,7 +319,7 @@ class TestTrustHer(TestCase):
         self.assertFalse(self._calc(gross_income=self.INCOME_LIMIT + 1, uninsured=True))
 
     def test_not_eligible_high_income_and_insured(self):
-        self.assertFalse(self._calc(gross_income=50_000, uninsured=False))
+        self.assertFalse(self._calc(gross_income=self.INCOME_LIMIT + 1, uninsured=False))
 
     def test_fpl_percent(self):
         self.assertEqual(TrustHer.fpl_percent, 2.5)

--- a/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
+++ b/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -306,8 +306,8 @@ class TestTrustHer(TestCase):
     def test_eligible_with_low_income_and_no_insurance(self):
         self.assertTrue(self._calc(gross_income=20_000, uninsured=True))
 
-    def test_not_eligible_income_too_high(self):
-        self.assertFalse(self._calc(gross_income=self.INCOME_LIMIT + 1, uninsured=True))
+    def test_not_eligible_income_well_over_limit(self):
+        self.assertFalse(self._calc(gross_income=self.INCOME_LIMIT * 2, uninsured=True))
 
     def test_not_eligible_has_insurance(self):
         self.assertFalse(self._calc(gross_income=20_000, uninsured=False))

--- a/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
+++ b/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
@@ -1,14 +1,16 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
 from programs.models import UrgentNeed
+from programs.models import FederalPoveryLimit
 from programs.programs.urgent_needs.tx.books_beginning_at_birth import BooksBeginningAtBirth
 from programs.programs.urgent_needs.tx.double_up_food_bucks import DoubleUpFoodBucks
 from programs.programs.urgent_needs.tx.hippy import Hippy
 from programs.programs.urgent_needs.tx.oak_cliff_lena import OakCliffLena
 from programs.programs.urgent_needs.tx.serve_southern_dallas import ServeSouthernDallas
 from programs.programs.urgent_needs.tx.snap_employment import SnapEmploymentTraining
+from programs.programs.urgent_needs.tx.trust_her import TrustHer
 from programs.programs.urgent_needs.tx.wic import Wic
 from programs.util import Dependencies
 from screener.models import HouseholdMember, Screen, WhiteLabel
@@ -273,3 +275,57 @@ class TestHippy(TestCase):
 
     def test_not_eligible_no_children(self):
         self.assertFalse(self._calc())
+
+
+# ---------------------------------------------------------------------------
+# TrustHer
+# ---------------------------------------------------------------------------
+
+
+class TestTrustHer(TestCase):
+    # 2026 FPL for household_size=2 is $21,640 (make_tx_screen default); 250% = $54,100
+    FPL_SIZE_2 = 21_640
+    INCOME_LIMIT = int(2.5 * FPL_SIZE_2)  # 54_100
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Texas", code="tx", state_code="TX")
+        self.urgent_need = make_urgent_need(self.white_label, "tx_trust_her")
+        fpl, _ = FederalPoveryLimit.objects.get_or_create(year="2026", defaults={"period": "2026"})
+        self.urgent_need.year = fpl
+        self.urgent_need.save()
+        self.screen = make_tx_screen(self.white_label)
+        HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=30)
+
+    def _calc(self, gross_income=0, uninsured=True):
+        with (
+            patch.object(self.screen.__class__, "calc_gross_income", return_value=gross_income),
+            patch.object(self.screen.__class__, "has_insurance_types", return_value=uninsured),
+        ):
+            return TrustHer(self.screen, self.urgent_need, Dependencies(), {}).eligible()
+
+    def test_eligible_with_low_income_and_no_insurance(self):
+        self.assertTrue(self._calc(gross_income=20_000, uninsured=True))
+
+    def test_not_eligible_income_too_high(self):
+        self.assertFalse(self._calc(gross_income=self.INCOME_LIMIT + 1, uninsured=True))
+
+    def test_not_eligible_has_insurance(self):
+        self.assertFalse(self._calc(gross_income=20_000, uninsured=False))
+
+    def test_eligible_at_income_boundary(self):
+        self.assertTrue(self._calc(gross_income=self.INCOME_LIMIT, uninsured=True))
+
+    def test_not_eligible_one_dollar_over_limit(self):
+        self.assertFalse(self._calc(gross_income=self.INCOME_LIMIT + 1, uninsured=True))
+
+    def test_not_eligible_high_income_and_insured(self):
+        self.assertFalse(self._calc(gross_income=50_000, uninsured=False))
+
+    def test_fpl_percent(self):
+        self.assertEqual(TrustHer.fpl_percent, 2.5)
+
+    def test_dependencies(self):
+        self.assertIn("income_amount", TrustHer.dependencies)
+        self.assertIn("income_frequency", TrustHer.dependencies)
+        self.assertIn("household_size", TrustHer.dependencies)
+        self.assertIn("health_insurance", TrustHer.dependencies)

--- a/programs/programs/urgent_needs/tx/trust_her.py
+++ b/programs/programs/urgent_needs/tx/trust_her.py
@@ -5,16 +5,21 @@ class TrustHer(UrgentNeedFunction):
     """
     Trust Her
 
-    Provides free or low-cost birth control and reproductive health services to Dallas
-    women and teens, with same-day access to all contraception methods and enrollment
-    support for Medicaid and coverage programs.
+    Free or low-cost birth control and reproductive health services for Dallas women
+    and teens, with same-day access to all contraception methods.
 
-    Dallas County; women and teens; no age minimum; free or low cost based on income.
-    County restriction managed via admin configuration.
+    Dallas County ZIP code (county restriction managed via admin); 250% FPL or less;
+    at least one household member has no health insurance.
     """
 
-    dependencies = []
+    dependencies = ["income_amount", "income_frequency", "household_size", "health_insurance"]
+    fpl_percent = 2.5
 
     def eligible(self) -> bool:
-        # Dallas County; women and teens — county restriction managed via admin configuration
-        return True
+        income = self.screen.calc_gross_income("yearly", ["all"])
+        income_limit = int(self.urgent_need.year.get_limit(self.screen.household_size) * self.fpl_percent)
+
+        if income > income_limit:
+            return False
+
+        return self.screen.has_insurance_types(["none"])

--- a/programs/programs/urgent_needs/tx/trust_her.py
+++ b/programs/programs/urgent_needs/tx/trust_her.py
@@ -16,6 +16,9 @@ class TrustHer(UrgentNeedFunction):
     fpl_percent = 2.5
 
     def eligible(self) -> bool:
+        if self.urgent_need.year is None:
+            return False
+
         income = self.screen.calc_gross_income("yearly", ["all"])
         income_limit = int(self.urgent_need.year.get_limit(self.screen.household_size) * self.fpl_percent)
 


### PR DESCRIPTION
## Context & Motivation

Adds **Trust Her** as a Texas family planning resource on the Additional Resources tab, covering free/low-cost birth control and reproductive health services for Dallas women and teens.

- Fixes [MFB-989](https://linear.app/myfriendben/issue/MFB-989/add-trust-her-to-texas-family-planning-resources)

## Changes Made

- **New eligibility function** at `programs/programs/urgent_needs/tx/trust_her.py` implementing the three eligibility gates:
  - Dallas County (enforced via `counties` in the JSON config + base-class `county_eligible()`)
  - Household income at or below 250% FPL (uses the 2026 FPL table)
  - At least one household member is uninsured (`screen.has_insurance_types(["none"])`)
  - Defensive null-guard for `urgent_need.year` (FK is `null=True, on_delete=SET_NULL`)
- **Config import data** at `programs/management/commands/import_urgent_need_config_data/data/tx_trust_her.json`:
  - Wired `tx_trust_her` function and FPL year `2026`
  - Currently `"active": false` — flip to `true` to launch (see Deployment)
- **Unit tests** in `programs/programs/urgent_needs/tx/test_urgent_needs_functions.py` — 8 tests covering income boundary, high-income rejection, insurance gate, combined failures, and class-level config (`fpl_percent`, `dependencies`)

## Testing

- Migrations to run: none
- Configuration updates needed: re-run `python manage.py import_urgent_need_config_data --override` after deploy to apply the updated urgent need
- Environment variables/settings to add: none
- Manual testing steps:
  - `python manage.py test programs.programs.urgent_needs.tx.test_urgent_needs_functions.TestTrustHer` — all 8 pass locally
  - After flipping `active: true`, complete a TX screen with Dallas County, household income ≤ 250% FPL, and at least one member marked uninsured — Trust Her should surface under family planning resources

## Deployment

- Post-deployment scripts needed: run `python manage.py import_urgent_need_config_data` to load the new config record
- Production config updates: flip `"active": true` in `tx_trust_her.json` (and re-import) when ready to launch to users
- Admin updates needed: confirm `tx_family_planning` category surfaces on the correct FE step (Step 8 / category_benefits) so Trust Her appears in the right place
- Notify team/users of: Spanish translations are not yet populated — schedule a follow-up to add them before public launch

## Notes for Reviewers

- The "uninsured" gate uses `screen.has_insurance_types(["none"])` which returns true if *any* household member is uninsured. This matches the urgent-need framework (HH-level only; no per-member hook exists) and the intent of surfacing the resource whenever the household contains someone who could use it.
- Pattern mirrors `programs/programs/urgent_needs/tx/law_help.py` (FPL × class-level `fpl_percent` + delegation to base-class `county_eligible()`).
- Known limitations: Spanish translation strings (description, website_description) still need to be added.
- Future considerations: if program rules ever require *applicant-only* insurance status, the framework would need a per-member hook — not in scope here.