### PR TITLE
Add WA TANF (wa_tanf)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json
@@ -1,0 +1,86 @@
+{
+  "white_label": {
+    "code": "wa"
+  },
+  "program_category": {
+    "external_name": "wa_cash"
+  },
+  "program": {
+    "name_abbreviated": "wa_tanf",
+    "legal_status_required": [
+      "citizen", "gc_5plus", "gc_5less", "refugee", "otherWithWorkPermission"
+    ],
+    "name": "Temporary Assistance for Needy Families (TANF)",
+    "description_short": "Temporary Assistance for Needy Families (TANF) gives families monthly cash to help pay for things like food and rent",
+    "description": "Temporary Assistance for Needy Families (TANF) gives families monthly cash to help pay for things like food and rent. This program is meant to help you take care of your family’s basic needs while you look for work or go to school. \n\nOnce approved, the money is put onto an EBT card, which works just like a debit card. You can use this card to get cash at an ATM or pay for items at most stores. The program also helps you find a job, get training, or find child care so you can start working. \n\nMost adults in the program must take part in work activities through WorkFirst. There are some exceptions for people with disabilities or those caring for a baby. There is a five-year lifetime limit on these cash benefits, and you may be asked to work with the state to seek child support if a parent does not live in the home. Some other rules apply that we cannot check here. For example, if you are 18, you must still be in school. You also cannot get these benefits if you are living in a prison or a similar facility. \n\nYou can apply online at the Washington Connection website or by calling the Department of Social and Health Services (DSHS). You can also visit a local Community Services Office to fill out an application in person. After you send in your forms, you will talk to a worker to finish your application. They will check your information and tell you if you can get help right away.",
+    "learn_more_link": "https://www.dshs.wa.gov/esa/community-services-offices/temporary-assistance-needy-families",
+    "apply_button_link": "https://www.washingtonconnection.org/",
+    "apply_button_description": "",
+    "estimated_application_time": "30 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": null,
+    "value_type": "benefit",
+    "website_description": "Temporary Assistance for Needy Families (TANF) gives families monthly cash to help pay for things like food and rent",
+    "base_program": "tanf",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": true
+  },
+  "documents": [
+    {
+      "external_name": "wa_id_proof",
+      "text": "Proof of identity (ex: driver's license, state ID, passport)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_ssn",
+      "text": "Last four digits of your Social Security number or Tribal ID number for each person applying for help",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_home",
+      "text": "Proof of home address (ex: lease, utility bill, mail with your address)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_earned_income",
+      "text": "Proof of income (ex: pay stubs, employer letter, self-employment records)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_us_status",
+      "text": "Proof of citizenship or immigration status (ex: birth certificate, passport, immigration documents)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_expenses",
+      "text": "Proof of expenses (ex: rent receipts, childcare costs, medical bills)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "wa_resources",
+      "text": "Proof of resources (ex: bank statements, vehicle titles)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "wa_dshs_cso",
+      "name": "DSHS Community Services Offices",
+      "email": "",
+      "phone_number": "+18775012233",
+      "description": "The Washington State Department of Social and Health Services (DSHS) runs the TANF program. You can visit a local office to get help with cash aid and other benefit programs. Workers at these offices can help you fill out forms, answer questions about who can get help, and fix problems with your benefits.\n\nThe offices are open from 8 a.m. to 5 p.m. every day from Monday to Friday. You can go in person or call them if you need help understanding the rules or starting your application. These workers are there to make sure you get the support your family needs.",
+      "assistance_link": "https://www.dshs.wa.gov/esa/community-services-offices/community-services-offices-cso",
+      "counties": [],
+      "languages": []
+    }
+  ]
+}

--- a/programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json
@@ -3,7 +3,9 @@
     "code": "wa"
   },
   "program_category": {
-    "external_name": "wa_cash"
+    "external_name": "wa_cash",
+    "name": "Cash Assistance",
+    "icon": "cash"
   },
   "program": {
     "name_abbreviated": "wa_tanf",
@@ -22,6 +24,7 @@
     "value_format": null,
     "value_type": "benefit",
     "website_description": "Temporary Assistance for Needy Families (TANF) gives families monthly cash to help pay for things like food and rent",
+    "year": 2026,
     "base_program": "tanf",
     "show_on_current_benefits": true,
     "has_calculator": true,

--- a/programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json
@@ -81,7 +81,7 @@
       "email": "",
       "phone_number": "+18775012233",
       "description": "The Washington State Department of Social and Health Services (DSHS) runs the TANF program. You can visit a local office to get help with cash aid and other benefit programs. Workers at these offices can help you fill out forms, answer questions about who can get help, and fix problems with your benefits.\n\nThe offices are open from 8 a.m. to 5 p.m. every day from Monday to Friday. You can go in person or call them if you need help understanding the rules or starting your application. These workers are there to make sure you get the support your family needs.",
-      "assistance_link": "https://www.dshs.wa.gov/esa/community-services-offices/community-services-offices-cso",
+      "assistance_link": "https://www.dshs.wa.gov/office-locations",
       "counties": [],
       "languages": []
     }

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -757,3 +757,13 @@ class FosterCareDependency(Member):
         if self.member.relationship == "fosterChild":
             return True
         return None
+
+
+class EmploymentIncomeBeforeLsrDependency(IncomeDependency):
+    field = "employment_income_before_lsr"
+    income_types = ["wages"]
+
+
+class SelfEmploymentIncomeBeforeLsrDependency(IncomeDependency):
+    field = "self_employment_income_before_lsr"
+    income_types = ["selfEmployment"]

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -484,3 +484,14 @@ class MortgageDependency(SpmUnit):
 
 class TxCcs(SpmUnit):
     field = "tx_ccs"
+
+
+class WaTanf(SpmUnit):
+    field = "wa_tanf"
+
+
+class WaShowAllCashAssistanceProgramsDependency(SpmUnit):
+    field = "wa_show_all_cash_assistance_programs"
+
+    def value(self):
+        return True

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1242,3 +1242,77 @@ class TestFosterCareDependency(TestCase):
         """Returns None for the head of household (not a foster child)."""
         dep = member.FosterCareDependency(self.screen, self.head, {})
         self.assertIsNone(dep.value())
+
+
+class TestEmploymentIncomeBeforeLsrDependency(TestCase):
+    """Tests for EmploymentIncomeBeforeLsrDependency used by WaTanf calculator."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="98101",
+            county="King",
+            household_size=2,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=35)
+
+    def test_field_name(self):
+        dep = member.EmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.field, "employment_income_before_lsr")
+
+    def test_value_calculates_annual_wages(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=800, frequency="monthly"
+        )
+        dep = member.EmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 9600)  # $800/month * 12
+
+    def test_value_returns_zero_when_no_wages(self):
+        dep = member.EmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 0)
+
+    def test_value_excludes_self_employment(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="selfEmployment", amount=500, frequency="monthly"
+        )
+        dep = member.EmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 0)
+
+
+class TestSelfEmploymentIncomeBeforeLsrDependency(TestCase):
+    """Tests for SelfEmploymentIncomeBeforeLsrDependency used by WaTanf calculator."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="98101",
+            county="King",
+            household_size=2,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=35)
+
+    def test_field_name(self):
+        dep = member.SelfEmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.field, "self_employment_income_before_lsr")
+
+    def test_value_calculates_annual_self_employment(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="selfEmployment", amount=600, frequency="monthly"
+        )
+        dep = member.SelfEmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 7200)  # $600/month * 12
+
+    def test_value_returns_zero_when_no_self_employment(self):
+        dep = member.SelfEmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 0)
+
+    def test_value_excludes_wages(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=1000, frequency="monthly"
+        )
+        dep = member.SelfEmploymentIncomeBeforeLsrDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 0)

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -499,3 +499,30 @@ class TestTanfDependency(TestCase):
 
         dep = spm.Tanf(self.screen, None, {})
         self.assertIsNone(dep.value())
+
+
+class TestWaTanfDependency(TestCase):
+    """Tests for WaTanf output dependency and WaShowAllCashAssistanceProgramsDependency."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Washington", code="wa", state_code="WA")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="98101",
+            county="King",
+            household_size=3,
+            completed=False,
+        )
+
+    def test_wa_tanf_field_name(self):
+        dep = spm.WaTanf(self.screen, None, {})
+        self.assertEqual(dep.field, "wa_tanf")
+
+    def test_wa_show_all_field_name(self):
+        dep = spm.WaShowAllCashAssistanceProgramsDependency(self.screen, None, {})
+        self.assertEqual(dep.field, "wa_show_all_cash_assistance_programs")
+
+    def test_wa_show_all_returns_true(self):
+        """WaShowAllCashAssistanceProgramsDependency always returns True to bypass PE immigration checks."""
+        dep = spm.WaShowAllCashAssistanceProgramsDependency(self.screen, None, {})
+        self.assertTrue(dep.value())

--- a/programs/programs/wa/pe/__init__.py
+++ b/programs/programs/wa/pe/__init__.py
@@ -10,6 +10,7 @@ wa_member_calculators = {
 wa_spm_calculators = {
     "wa_lifeline": spm.WaLifeline,
     "wa_snap": spm.WaSnap,
+    "wa_tanf": spm.WaTanf,
 }
 
 wa_tax_calculators = {

--- a/programs/programs/wa/pe/spm.py
+++ b/programs/programs/wa/pe/spm.py
@@ -1,5 +1,5 @@
 import programs.programs.policyengine.calculators.dependencies as dependency
-from programs.programs.federal.pe.spm import Lifeline, Snap
+from programs.programs.federal.pe.spm import Lifeline, Snap, Tanf
 
 
 class WaLifeline(Lifeline):
@@ -14,3 +14,41 @@ class WaSnap(Snap):
         *Snap.pe_inputs,
         dependency.household.WaStateCodeDependency,
     ]
+
+
+class WaTanf(Tanf):
+    """
+    Washington TANF / SFA cash assistance calculator using PolicyEngine.
+
+    PolicyEngine's `wa_tanf` variable handles the full eligibility check
+    (qualifying dependent child or pregnancy, gross and countable income limits,
+    WA residency, resource limit) and calculates the monthly benefit as
+    `payment_standard − countable_earned_income − gross_unearned_income`.
+
+    Earned-income disregards (WAC 388-450-0170: $500 flat + 50% of remainder,
+    effective 2024-08-01) are applied by PolicyEngine automatically when
+    `employment_income_before_lsr` and `self_employment_income_before_lsr` are
+    provided as inputs.  Gross income is also checked against the separate WAC
+    388-478-0035 income limits table.
+
+    Immigration eligibility is handled at the screener level via
+    `legal_status_required`; `wa_show_all_cash_assistance_programs` is set to
+    True to bypass PE's per-member immigration check and avoid double-filtering.
+
+    See programs/programs/wa/tanf/spec.md for full eligibility criteria and
+    the known gross-income-approximation limitation.
+    """
+
+    pe_name = "wa_tanf"
+    pe_inputs = [
+        *Tanf.pe_inputs,
+        dependency.household.WaStateCodeDependency,
+        dependency.member.PregnancyDependency,
+        dependency.member.EmploymentIncomeBeforeLsrDependency,
+        dependency.member.SelfEmploymentIncomeBeforeLsrDependency,
+        dependency.member.SocialSecurityIncomeDependency,
+        dependency.member.UnemploymentIncomeDependency,
+        dependency.spm.CashAssetsDependency,
+        dependency.spm.WaShowAllCashAssistanceProgramsDependency,
+    ]
+    pe_outputs = [dependency.spm.WaTanf]

--- a/programs/programs/wa/tanf/spec.md
+++ b/programs/programs/wa/tanf/spec.md
@@ -171,7 +171,7 @@ Source: [WAC 388-478-0035](https://app.leg.wa.gov/WAC/default.aspx?cite=388-478-
 
 ### Scenario 7: 18-Year-Old Child, Income Above 2-Person Payment Standard — Ineligible
 
-**What we're checking**: Reframed from the draft. Under the inclusivity assumption documented in Criterion 1 (all individuals under age 19 are treated as qualifying dependents), an 18-year-old counts as a qualifying dependent, so this scenario no longer isolates the dependent-child age branch. The household is ineligible on income — $800/month gross exceeds the 2-person payment standard of $440/month and would still exceed it after disregards (($800 − $90) × 0.5 = $355, but still subject to other deduction rules).
+**What we're checking**: Under the inclusivity assumption in Criterion 1 (all individuals under age 19 are treated as qualifying dependents), an 18-year-old counts as a qualifying dependent. The household is ineligible on income — $1,800/month gross exceeds the 2-person payment standard after disregards. With PE's $500+50% disregard: ($1,800 − $500) × 0.5 = $650 countable earned income, which exceeds the 2-person payment standard ($570).
 
 **Expected**: Ineligible
 
@@ -179,7 +179,7 @@ Source: [WAC 388-478-0035](https://app.leg.wa.gov/WAC/default.aspx?cite=388-478-
 
 * **Location**: Enter ZIP code `98117`, Select county `King County`
 * **Household**: Number of people: `2`
-* **Person 1 (Head)**: Birth month/year: `May 1985` (age 41), Employment income: `$800/month`
+* **Person 1 (Head)**: Birth month/year: `May 1985` (age 41), Employment income: `$1,800/month`
 * **Person 2 (Child)**: Birth month/year: `April 2008` (age 18), No income
 * **Assets**: `$1,000`
 

--- a/programs/programs/wa/tanf/spec.md
+++ b/programs/programs/wa/tanf/spec.md
@@ -1,0 +1,334 @@
+# Temporary Assistance for Needy Families (TANF) — Implementation Spec
+
+**Program:** `wa_tanf`
+**State:** Washington
+**White Label:** `wa`
+**Research Date:** 2026-05-12
+
+> ⚠️ **Income methodology note:** Washington TANF applies earned income disregards ($90 work-related expense deduction, then 50% of remaining earned income disregarded). The screener cannot apply these disregards precisely and compares **gross income directly to the TANF payment standard** as an approximation. This overstates countable income — some households flagged as ineligible by the screener may actually qualify. This is documented as a known limitation. See Criterion 2 and the Data Gaps section for details.
+
+> ⚠️ **Household size > 5 note:** WAC 388-478-0035 only documents payment standards for household sizes 1–5. For households of 6+, the calculator uses an extrapolation rule ($826 + $105 × (household_size − 5)). This favors inclusion (false positives over false negatives) and is explicitly marked as an extrapolation beyond the cited WAC. See Criterion 2 and Benefit Value for details.
+
+---
+
+## Eligibility Criteria
+
+1. **Household must include a dependent child under age 19, OR the applicant must be pregnant**
+   - Screener fields: `household_members` (age, relationship), `pregnant`
+   - Note: The full WA TANF rule requires a dependent child under age 18, OR age 18 if expected to complete high school before turning 19. The screener has no field for "expected to complete high school." Per the false-positive-over-false-negative preference, the screener treats **all individuals under age 19** as potentially qualifying dependents.
+   - Source: [Washington DSHS TANF Program Overview](https://www.dshs.wa.gov/esa/community-services-offices/temporary-assistance-needy-families); RCW 74.04.005; WAC 388-400-0005
+
+2. **Household income must be at or below the TANF/SFA payment standard for household size (using gross income as screener approximation)**
+   - Screener fields: `income_streams`, `household_size`
+   - Note: The screener compares **gross earned income directly to the payment standard** as an approximation. The true TANF methodology applies earned income disregards ($90 work-related deduction, then 50% of remaining earned income disregarded). Using gross income overstates countable income and will screen out some technically eligible households. Devs should add a comment in the calculator noting that gross income is used as an approximation and the actual eligibility threshold is higher when disregards are applied.
+   - WA TANF/SFA payment standards (WAC 388-478-0035): 1-person: $339/mo | 2-person: $440/mo | 3-person: $654/mo | 4-person: $721/mo | 5-person: $826/mo.
+   - **For household sizes 6+ (extrapolation rule — not in the cited WAC):** payment standard = $826 + $105 × (household_size − 5). The $105 increment matches the documented HH 4 → HH 5 increment. This is explicitly an extrapolation beyond the WAC source, intended to keep the calculator from breaking for larger households and to favor false positives. Dev note: revisit if WA publishes standards for HH 6+.
+   - Source: [WAC 388-478-0035](https://app.leg.wa.gov/WAC/default.aspx?cite=388-478-0035); WAC 388-450-0156; WAC 388-450-0170
+
+3. **Household must reside in Washington State**
+   - Screener fields: `zipcode`, `county`
+   - Source: [Washington DSHS TANF Program Overview](https://www.dshs.wa.gov/esa/community-services-offices/temporary-assistance-needy-families); RCW 74.04.005
+
+4. **Household resources/assets must not exceed $6,000**
+   - Screener fields: `household_assets`
+   - Note: The $6,000 limit applies to countable resources. Certain assets are excluded (primary vehicle up to a value, household goods, burial funds up to $1,500). The screener captures a single `household_assets` figure as an approximation. Assets exactly at $6,000 are eligible (≤ comparison).
+   - Source: [WAC 388-470-0005](https://app.leg.wa.gov/WAC/default.aspx?cite=388-470-0005); WAC 388-470-0045
+
+5. **Citizenship/immigration status** ⚠️ *data gap* — Federal TANF requires U.S. citizenship or qualified alien status; 5-year bar may apply for some qualified aliens. Washington SFA provides state-funded assistance for some immigrants who don't qualify federally. The screener has no citizenship/immigration field. `legal_status_required` is set to `["citizen", "gc_5plus", "gc_5less", "refugee", "otherWithWorkPermission"]` to reflect both federal TANF and WA SFA pathways and to favor false positives over false negatives. Source: 8 U.S.C. § 1612; WAC 388-424-0010
+
+6. **SSI receipt per member** ⚠️ *data gap* — SSI recipients are excluded from the TANF assistance unit. The screener has `has_ssi` at household level but not per-member. Source: WAC 388-450-0162
+
+7. **60-month lifetime time limit** ⚠️ *data gap* — TANF has a 60-month federal lifetime limit on cash assistance. The screener does not track benefit history. Inclusivity assumption: we assume households have months remaining and rely on DSHS to enforce the limit at application. Source: WAC 388-484-0005; 42 U.S.C. § 608(a)(7)
+
+8. **Work participation (WorkFirst)** ⚠️ *data gap* — Non-exempt adults must participate in WorkFirst activities. Exemptions exist for disabled individuals, caregivers of children under 1, pregnant women (third trimester), domestic violence victims, and adults over 60. The screener partially captures some exemption categories but cannot fully determine work-requirement compliance. Treated as a post-enrollment compliance issue. Source: RCW 74.08A.100; Chapter 388-310 WAC
+
+---
+
+## Benefit Value
+
+TANF benefit amounts are based on household size per WAC 388-478-0035. Monthly payment standards:
+
+| Household size | Monthly payment standard | Source |
+|---|---|---|
+| 1 | $339 | WAC 388-478-0035 |
+| 2 | $440 | WAC 388-478-0035 |
+| 3 | $654 | WAC 388-478-0035 |
+| 4 | $721 | WAC 388-478-0035 |
+| 5 | $826 | WAC 388-478-0035 |
+| 6+ | $826 + $105 × (size − 5) | Extrapolation (not in cited WAC) |
+
+**Calculator methodology:** Return the payment standard for the household size as the monthly benefit value. For household sizes 6+, apply the extrapolation rule above. `value_format` is `null` (monthly). `estimated_value` is `""` (blank — defers to calculator).
+
+Source: [WAC 388-478-0035](https://app.leg.wa.gov/WAC/default.aspx?cite=388-478-0035)
+
+---
+
+## Test Scenarios
+
+> ⚠️ **Income inconsistency note (devs):** Several "Eligible" scenarios carry gross income that exceeds the payment standard for their household size (Scenarios 1, 2, 6, 9). Under the screener's gross-income approximation in Criterion 2, these would be flagged as ineligible. The draft assumed earned-income disregards would apply ($90 + 50%). If the calculator does not apply disregards, these test cases will fail. Either (a) the calculator should implement disregards, or (b) the income amounts in these scenarios should be lowered before running tests.
+
+---
+
+### Scenario 1: Clearly Eligible Single Parent with Two Young Children
+
+**What we're checking**: Golden-path eligible case — single parent, two young children, WA resident, low assets. Gross income $800/month for household of 3 vs. payment standard $654/month (WAC 388-478-0035). Note: gross exceeds standard by $146; with disregards applied, ($800 − $90) × 0.5 = $355 countable, below the $654 threshold. See income inconsistency note above.
+
+**Expected**: Eligible, value: `654` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98101`, Select county `King County`
+* **Household**: Number of people: `3`
+* **Person 1 (Head)**: Birth month/year: `June 1996` (age 29), Employment income: `$800/month`
+* **Person 2 (Child)**: Birth month/year: `April 2019` (age 7), No income
+* **Person 3 (Child)**: Birth month/year: `July 2022` (age 3), No income
+* **Assets**: `$1,500`
+
+---
+
+### Scenario 2: Minimally Eligible — Single Parent with One Child at Boundary Conditions
+
+**What we're checking**: Boundary conditions across three dimensions — child just under 18 (will turn 18 in mid-2026), assets exactly at the $6,000 limit (≤ comparison), and income at $521/month for household of 2. Gross income $521 vs. payment standard $440; with disregards: ($521 − $90) × 0.5 = $215.50, below threshold. See income inconsistency note above.
+
+**Expected**: Eligible, value: `440` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98109`, Select county `King County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `March 1990` (age 36), Employment income: `$521/month`
+* **Person 2 (Child)**: Birth month/year: `June 2008` (age 17), No income
+* **Assets**: `$6,000`
+
+---
+
+### Scenario 3: Single Parent with Three Children — Income $1 Below 4-Person Payment Standard
+
+**What we're checking**: Gross income $720/month is $1 below the 4-person payment standard of $721/month. Confirms the ≤ comparison admits values just under the threshold.
+
+**Expected**: Eligible, value: `721` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98112`, Select county `King County`
+* **Household**: Number of people: `4`
+* **Person 1 (Head)**: Birth month/year: `April 1992` (age 34), Employment income: `$720/month`
+* **Person 2 (Child)**: Birth month/year: `June 2014` (age 11), No income
+* **Person 3 (Child)**: Birth month/year: `August 2017` (age 8), No income
+* **Person 4 (Child)**: Birth month/year: `March 2021` (age 5), No income
+* **Assets**: `$2,000`
+
+---
+
+### Scenario 4: Single Parent with One Child — Income Exactly at 2-Person Payment Standard
+
+**What we're checking**: Gross income exactly at $440/month, the 2-person payment standard. Should be eligible under the ≤ comparison.
+
+**Expected**: Eligible, value: `440` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98103`, Select county `King County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `October 1995` (age 30), Employment income: `$440/month`
+* **Person 2 (Child)**: Birth month/year: `February 2020` (age 6), No income
+* **Assets**: `$1,500`
+
+---
+
+### Scenario 5: Single Parent with Two Children — Income $46 Above 3-Person Payment Standard — Ineligible
+
+**What we're checking**: Gross income $700/month exceeds the 3-person payment standard of $654/month by $46. Screener approximation marks ineligible. With disregards applied, this household would likely qualify — documented as a known false negative of the gross-income methodology.
+
+**Expected**: Ineligible
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98115`, Select county `King County`
+* **Household**: Number of people: `3`
+* **Person 1 (Head)**: Birth month/year: `July 1993` (age 32), Employment income: `$700/month`
+* **Person 2 (Child)**: Birth month/year: `March 2018` (age 8), No income
+* **Person 3 (Child)**: Birth month/year: `November 2021` (age 4), No income
+* **Assets**: `$2,000`
+
+---
+
+### Scenario 6: Newborn Child (Age 0) — Minimum Age for Dependent Child
+
+**What we're checking**: A newborn (age 0) satisfies the dependent-child requirement. Tests the lower age boundary. Gross income $500/month vs. 2-person payment standard $440/month; with disregards: ($500 − $90) × 0.5 = $205. See income inconsistency note above.
+
+**Expected**: Eligible, value: `440` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98105`, Select county `King County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `November 1994` (age 31), Employment income: `$500/month`
+* **Person 2 (Child)**: Birth month/year: `January 2026` (age 0), No income
+* **Assets**: `$1,000`
+
+---
+
+### Scenario 7: 18-Year-Old Child, Income Above 2-Person Payment Standard — Ineligible
+
+**What we're checking**: Reframed from the draft. Under the inclusivity assumption documented in Criterion 1 (all individuals under age 19 are treated as qualifying dependents), an 18-year-old counts as a qualifying dependent, so this scenario no longer isolates the dependent-child age branch. The household is ineligible on income — $800/month gross exceeds the 2-person payment standard of $440/month and would still exceed it after disregards (($800 − $90) × 0.5 = $355, but still subject to other deduction rules).
+
+**Expected**: Ineligible
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98117`, Select county `King County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `May 1985` (age 41), Employment income: `$800/month`
+* **Person 2 (Child)**: Birth month/year: `April 2008` (age 18), No income
+* **Assets**: `$1,000`
+
+---
+
+### Scenario 8: Parent with 9-Year-Old Child — Clearly Within Age Range, No Income
+
+**What we're checking**: A 9-year-old (well within the dependent-child age range) and a parent with no earned income. Confirms the middle of the age range works and the calculator handles zero income.
+
+**Expected**: Eligible, value: `440` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98122`, Select county `King County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `August 1990` (age 35), No income
+* **Person 2 (Child)**: Birth month/year: `July 2016` (age 9), No income
+* **Assets**: `$500`
+
+---
+
+### Scenario 9: Valid WA ZIP Code (Spokane) — Eastern WA Residency Confirmed
+
+**What we're checking**: A Spokane ZIP code (99201) satisfies WA state residency. Confirms the screener recognizes eastern WA ZIPs. Gross income $500/month vs. 2-person payment standard $440; with disregards: ($500 − $90) × 0.5 = $205. See income inconsistency note above.
+
+**Expected**: Eligible, value: `440` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `99201`, Select county `Spokane County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `November 1994` (age 31), Employment income: `$500/month`
+* **Person 2 (Child)**: Birth month/year: `March 2022` (age 4), No income
+* **Assets**: `$1,500`
+
+---
+
+### Scenario 10: Mixed Household — Adult Non-Dependent Plus Two Young Children
+
+**What we're checking**: A 21-year-old adult child does not count as a qualifying dependent, but the two younger children (ages 7 and 3) do. Confirms mixed-age households are assessed correctly. Spouse earns $800/month; household of 5 vs. payment standard $826/month (eligible at $800 ≤ $826).
+
+**Expected**: Eligible, value: `826` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98201`, Select county `Snohomish County`
+* **Household**: Number of people: `5`
+* **Person 1 (Head)**: Birth month/year: `February 1986` (age 40), No income
+* **Person 2 (Spouse)**: Birth month/year: `September 1987` (age 38), Employment income: `$800/month`
+* **Person 3 (Adult Child)**: Birth month/year: `March 2005` (age 21), No income
+* **Person 4 (Child)**: Birth month/year: `June 2018` (age 7), No income
+* **Person 5 (Child)**: Birth month/year: `April 2023` (age 3), No income
+* **Assets**: `$2,500`
+
+---
+
+### Scenario 11: Two-Parent Household with Three Children of Varying Ages
+
+**What we're checking**: All three children (ages 14, 8, and 1) qualify as dependents. Tests that all children count toward the assistance unit and the 5-person payment standard ($826/month) is used. Spouse income $800/month ≤ $826.
+
+**Expected**: Eligible, value: `826` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98226`, Select county `Whatcom County`
+* **Household**: Number of people: `5`
+* **Person 1 (Head)**: Birth month/year: `January 1985` (age 41), No income
+* **Person 2 (Spouse)**: Birth month/year: `October 1986` (age 39), Employment income: `$800/month`
+* **Person 3 (Child)**: Birth month/year: `September 2011` (age 14), No income
+* **Person 4 (Child)**: Birth month/year: `October 2017` (age 8), No income
+* **Person 5 (Child)**: Birth month/year: `February 2025` (age 1), No income
+* **Assets**: `$2,500`
+
+---
+
+### Scenario 12: Assets Exactly at $6,000 Limit — Maximum Allowable Resources
+
+**What we're checking**: Assets at exactly $6,000 should still be eligible per the ≤ comparison in WAC 388-470-0005. Income $300/month is comfortably under the 2-person payment standard.
+
+**Expected**: Eligible, value: `440` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98444`, Select county `Pierce County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `December 1996` (age 29), Employment income: `$300/month`
+* **Person 2 (Child)**: Birth month/year: `April 2022` (age 4), No income
+* **Assets**: `$6,000`
+
+---
+
+### Scenario 13: Pregnant Applicant, No Children — Eligible via Pregnancy Branch
+
+**What we're checking**: Criterion 1's pregnancy branch. A pregnant applicant with no children in the household should be eligible. Tests that pregnancy alone satisfies the dependent-child / pregnancy requirement.
+
+**Expected**: Eligible, value: `339` (monthly)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98101`, Select county `King County`
+* **Household**: Number of people: `1`
+* **Person 1 (Head)**: Birth month/year: `July 1998` (age 27), Employment income: `$200/month`, **Pregnant: yes**
+* **Assets**: `$500`
+
+---
+
+### Scenario 14: Income Well Above Payment Standard — Clearly Ineligible
+
+**What we're checking**: Clear income ineligibility. Gross income $2,000/month for a household of 3 is well above the $654/month payment standard, and remains over the threshold even with disregards applied (($2,000 − $90) × 0.5 = $955).
+
+**Expected**: Ineligible
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98103`, Select county `King County`
+* **Household**: Number of people: `3`
+* **Person 1 (Head)**: Birth month/year: `May 1990` (age 36), Employment income: `$2,000/month`
+* **Person 2 (Spouse)**: Birth month/year: `October 1992` (age 33), No income
+* **Person 3 (Child)**: Birth month/year: `April 2021` (age 5), No income
+* **Assets**: `$1,000`
+
+---
+
+### Scenario 15: Assets Above $6,000 Limit — Ineligible on Resources
+
+**What we're checking**: Asset exclusion. Assets of $7,500 exceed the $6,000 limit; household is otherwise eligible (low income, qualifying child, WA resident).
+
+**Expected**: Ineligible
+
+**Steps**:
+
+* **Location**: Enter ZIP code `98033`, Select county `King County`
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `March 1991` (age 35), Employment income: `$200/month`
+* **Person 2 (Child)**: Birth month/year: `June 2022` (age 3), No income
+* **Assets**: `$7,500`
+
+---
+
+### Scenario 16: Out-of-State ZIP Code — Ineligible on Residency
+
+**What we're checking**: Residency exclusion. An Oregon ZIP code (97201, Portland) should fail the WA state residency requirement; household is otherwise eligible.
+
+**Expected**: Ineligible
+
+**Steps**:
+
+* **Location**: Enter ZIP code `97201`, Select county `Multnomah County` (Oregon — outside WA)
+* **Household**: Number of people: `2`
+* **Person 1 (Head)**: Birth month/year: `November 1994` (age 31), Employment income: `$300/month`
+* **Person 2 (Child)**: Birth month/year: `April 2022` (age 4), No income
+* **Assets**: `$1,000`

--- a/validations/management/commands/import_validations/data/wa_tanf.json
+++ b/validations/management/commands/import_validations/data/wa_tanf.json
@@ -1,7 +1,7 @@
 [
   {
     "notes": "Scenario 1: Clearly eligible single parent with two young children. Income $800/month, assets $1,500, WA resident, not receiving TANF.",
-       "household": {
+    "household": {
       "white_label": "wa",
       "is_test": true,
       "agree_to_tos": true,
@@ -78,7 +78,7 @@
     }
   },
   {
-    "notes": "Scenario 2: Minimally eligible — single parent with one child (age 17, turns 18 in May 2026), income $521/month, assets exactly at $6,000 limit.",
+    "notes": "Scenario 2: Minimally eligible — single parent with one child (age 17, turns 18 in June 2026), income $521/month, assets exactly at $6,000 limit.",
     "household": {
       "white_label": "wa",
       "is_test": true,

--- a/validations/management/commands/import_validations/data/wa_tanf.json
+++ b/validations/management/commands/import_validations/data/wa_tanf.json
@@ -1,0 +1,218 @@
+[
+  {
+    "notes": "Scenario 1: Clearly eligible single parent with two young children. Income $800/month, assets $1,500, WA resident, not receiving TANF.",
+       "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98101",
+      "county": "King",
+      "household_size": 3,
+      "household_assets": 1500,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 29,
+          "birth_year": 1996,
+          "birth_month": 6,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 800,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 7,
+          "birth_year": 2019,
+          "birth_month": 4,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 3,
+          "birth_year": 2022,
+          "birth_month": 7,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_tanf",
+      "eligible": true,
+      "value": 654
+    }
+  },
+  {
+    "notes": "Scenario 2: Minimally eligible — single parent with one child (age 17, turns 18 in May 2026), income $521/month, assets exactly at $6,000 limit.",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98109",
+      "county": "King",
+      "household_size": 2,
+      "household_assets": 6000,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 36,
+          "birth_year": 1990,
+          "birth_month": 3,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 521,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 17,
+          "birth_year": 2008,
+          "birth_month": 6,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_tanf",
+      "eligible": true,
+      "value": 440
+    }
+  },
+  {
+    "notes": "Scenario 5: Single parent with two children, income $700/month — exceeds 3-person payment standard ($654/month) by $46. Ineligible per screener gross income approximation.",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98115",
+      "county": "King",
+      "household_size": 3,
+      "household_assets": 2000,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 32,
+          "birth_year": 1993,
+          "birth_month": 7,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 700,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 8,
+          "birth_year": 2018,
+          "birth_month": 3,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        },
+        {
+          "relationship": "child",
+          "age": 4,
+          "birth_year": 2021,
+          "birth_month": 11,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true,
+            "employer": false,
+            "private": false,
+            "medicaid": false,
+            "medicare": false,
+            "chp": false,
+            "va": false
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_tanf",
+      "eligible": false
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/wa_tanf.json
+++ b/validations/management/commands/import_validations/data/wa_tanf.json
@@ -74,7 +74,7 @@
     "expected_results": {
       "program_name": "wa_tanf",
       "eligible": true,
-      "value": 654
+      "value": 6672
     }
   },
   {
@@ -135,11 +135,11 @@
     "expected_results": {
       "program_name": "wa_tanf",
       "eligible": true,
-      "value": 440
+      "value": 6714
     }
   },
   {
-    "notes": "Scenario 5: Single parent with two children, income $700/month — exceeds 3-person payment standard ($654/month) by $46. Ineligible per screener gross income approximation.",
+    "notes": "Scenario 5: Single parent with two children, income $2,500/month — countable earned income after disregard ($1,000) exceeds 3-person payment standard ($706). Ineligible.",
     "household": {
       "white_label": "wa",
       "is_test": true,
@@ -159,7 +159,7 @@
           "income_streams": [
             {
               "type": "wages",
-              "amount": 700,
+              "amount": 2500,
               "frequency": "monthly"
             }
           ],


### PR DESCRIPTION
## Context & Motivation

- Implements [MFB-749](https://linear.app/myfriendben/issue/MFB-749)
- Adds Washington State TANF (Temporary Assistance for Needy Families) as a PolicyEngine-based SPM calculator

## Changes Made

- **Research files**: Added `programs/programs/wa/tanf/spec.md`, initial config JSON, and validation test cases
- **New dependencies**: `EmploymentIncomeBeforeLsrDependency` and `SelfEmploymentIncomeBeforeLsrDependency` in `member.py` — these feed PE's `tanf_gross_earned_income` so the $500 flat + 50% earned income disregard (WAC 388-450-0170) is applied automatically
- **New dependencies**: `WaTanf` output and `WaShowAllCashAssistanceProgramsDependency` (bypasses PE per-member immigration check; screener handles via `legal_status_required`) in `spm.py`
- **Calculator**: `WaTanf` class in `wa/pe/spm.py` inheriting from federal `Tanf`, registered in `wa/pe/__init__.py`
- **Dependency tests**: Full coverage for `EmploymentIncomeBeforeLsrDependency`, `SelfEmploymentIncomeBeforeLsrDependency`, `WaTanf`, and `WaShowAllCashAssistanceProgramsDependency`
- **Initial config**: Creates `wa_cash` category, program with legal statuses, documents, and DSHS CSO navigator
- **Test cases**: 3 validation scenarios — eligible HH3, eligible HH2 (edge case), ineligible (income exceeds payment standard after disregard)

## Testing

- Migrations to run: None
- Configuration updates needed: Run `python manage.py import_program_config programs/management/commands/import_program_config_data/data/wa_tanf_initial_config.json`
- Environment variables/settings to add: None
- Manual testing steps:
  1. Import config (above)
  2. Import validations: `python manage.py import_validations validations/management/commands/import_validations/data/wa_tanf.json`
  3. Activate program: set `wa_tanf` active via admin
  4. Run `python manage.py validate --white-label wa --program wa_tanf` — all 3 should pass

## Deployment

- Post-deployment scripts needed: Run import_program_config for wa_tanf_initial_config.json, then activate program
- Production config updates: None
- Admin updates needed: Activate wa_tanf program after import
- Notify team/users of: New WA TANF program available

## Notes for Reviewers

- Known limitations: PE uses gross income as an approximation for the WAC 388-478-0035 income limits check (no earned income disregard applied at screener level). This may cause slight over-screening but not under-screening.
- Future considerations: Test case values use 2026 payment standards ($706 HH3, $570 HH2) and the 2024-08-01 earned income disregard ($500 + 50%). These will need updating when PE updates its parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Washington TANF (wa) support including eligibility logic, benefit calculation, and navigator entry for local service offices.

* **Documentation**
  * Added comprehensive WA TANF specification with eligibility rules, benefit standard methodology, limits, and example scenarios.

* **Tests**
  * Added unit tests and validation scenarios covering WA TANF inputs, income handling, and expected benefit outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1518)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->