### PR TITLE
fix(hud): FMR basicdata list shape (unblocks WA eligibility)

### DIFF
--- a/integrations/clients/hud_income_limits/client.py
+++ b/integrations/clients/hud_income_limits/client.py
@@ -261,6 +261,24 @@ class HudIncomeClient:
         4: "Four-Bedroom",
     }
 
+    @staticmethod
+    def _normalize_fmr_basicdata(basic_data: object, bedroom_field: str) -> dict:
+        """
+        HUD's fmr/data payload usually has data.basicdata as a dict of bedroom
+        columns. Some responses return basicdata as a list of per-area dicts
+        instead, which caused AttributeError when calling .get on a list.
+        """
+        if isinstance(basic_data, dict):
+            return basic_data
+        if isinstance(basic_data, list):
+            for item in basic_data:
+                if isinstance(item, dict) and item.get(bedroom_field) is not None:
+                    return item
+            for item in basic_data:
+                if isinstance(item, dict):
+                    return item
+        return {}
+
     def get_screen_fmr(
         self,
         screen: Screen,
@@ -301,9 +319,8 @@ class HudIncomeClient:
             raise HudIncomeClientError(f"No FMR data found for {county}, {screen.white_label.state_code}")
 
         area_data = data["data"]
-        basic_data = area_data.get("basicdata", {})
-
         field = self.FMR_BEDROOM_FIELDS[bedrooms]
+        basic_data = self._normalize_fmr_basicdata(area_data.get("basicdata", {}), field)
         value = basic_data.get(field)
         if value is None:
             raise HudIncomeClientError(f"No FMR data for {bedrooms}-bedroom in {county}")

--- a/integrations/clients/hud_income_limits/tests/test_client.py
+++ b/integrations/clients/hud_income_limits/tests/test_client.py
@@ -697,3 +697,27 @@ class TestHudIncomeClientHTTPErrors(TestCase):
         self.assertEqual(retry_config.backoff_factor, 1)
         self.assertEqual(retry_config.status_forcelist, [429, 500, 502, 503, 504])
         self.assertIn("GET", retry_config.allowed_methods)
+
+
+class TestHudIncomeClientFmrBasicdata(TestCase):
+    """Regression: HUD sometimes returns data.basicdata as a list of dicts."""
+
+    def test_normalize_dict_passthrough(self) -> None:
+        d = {"Two-Bedroom": 2082}
+        self.assertEqual(HudIncomeClient._normalize_fmr_basicdata(d, "Two-Bedroom"), d)
+
+    def test_normalize_list_selects_row_with_bedroom_field(self) -> None:
+        rows = [{"One-Bedroom": 1500}, {"Two-Bedroom": 2082, "Efficiency": 950}]
+        out = HudIncomeClient._normalize_fmr_basicdata(rows, "Two-Bedroom")
+        self.assertEqual(out["Two-Bedroom"], 2082)
+
+    def test_normalize_list_fallback_first_dict(self) -> None:
+        rows = [{"Two-Bedroom": 1500}]
+        self.assertEqual(HudIncomeClient._normalize_fmr_basicdata(rows, "Two-Bedroom"), rows[0])
+
+    def test_normalize_empty_list(self) -> None:
+        self.assertEqual(HudIncomeClient._normalize_fmr_basicdata([], "Two-Bedroom"), {})
+
+    def test_normalize_non_dict_non_list(self) -> None:
+        self.assertEqual(HudIncomeClient._normalize_fmr_basicdata(None, "Two-Bedroom"), {})
+        self.assertEqual(HudIncomeClient._normalize_fmr_basicdata("bad", "Two-Bedroom"), {})


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'list' object has no attribute 'get'` in `HudIncomeClient.get_screen_fmr` when HUD returns `data.basicdata` as a **list** of dicts instead of a single dict. This broke **WA** `eligibility_results` (e.g. `wa_hcv`) and caused staging results pages / `validate` to 500.

## Changes

- `HudIncomeClient._normalize_fmr_basicdata` — dict passthrough; if list, pick first dict containing the requested bedroom column, else first dict.
- Unit tests: `TestHudIncomeClientFmrBasicdata`

## Context

Staging QA for `wa_nslp`: `python manage.py validate --program wa_nslp` and FE results URLs failed before NSLP ran because `wa_hcv.household_value` called `get_screen_fmr` and crashed on `basic_data.get(...)`.

## Testing

`ENABLE_GOOGLE_INTEGRATIONS=false python manage.py test integrations.clients.hud_income_limits.tests.test_client.TestHudIncomeClientFmrBasicdata`

Made with [Cursor](https://cursor.com)