### PR TITLE
MFB-991: Add First Step Staffing as TX job resources urgent need

### DIFF
--- a/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
@@ -13,7 +13,7 @@
       "description": "First Step Staffing helps people get jobs — and stay in them. They match job seekers with local employers and offer extra help along the way. This includes rides to and from work, coaching to prepare for a job, and support for talking with coworkers and bosses. They also check in over time to help people stay employed.",
       "link": "https://www.firststepstaffing.com/application",
       "warning": "",
-      "website_description": "Staffing agency connecting Dallas-area job seekers facing barriers to employment with jobs and wraparound support services like transportation and coaching.",
+      "website_description": "Staffing agency that helps Dallas-area job seekers find work and stay employed.",
       "notification_message": ""
     },
     "phone_number": "+14698993867",

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
@@ -1,0 +1,27 @@
+{
+  "white_label": { "code": "tx" },
+  "need": {
+    "external_name": "tx_first_step_staffing",
+    "category_type": {
+      "external_name": "tx_job_resources",
+      "name": "Job resources",
+      "icon": "job_resources"
+    },
+    "type_short": ["job resources"],
+    "translations": {
+      "name": "First Step Staffing",
+      "description": "First Step Staffing helps people facing barriers to employment find jobs and keep them. They place job seekers with local employers and provide wraparound support including transportation to and from work, job readiness coaching, workplace communication support, and long-term retention services.",
+      "link": "https://www.firststepstaffing.com/application",
+      "warning": "",
+      "website_description": "Staffing agency connecting Dallas-area job seekers facing barriers to employment with jobs and wraparound support services like transportation and coaching.",
+      "notification_message": ""
+    },
+    "phone_number": "+14698993867",
+    "functions": [],
+    "counties": ["Dallas"],
+    "required_expense_types": [],
+    "active": true,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
@@ -17,7 +17,7 @@
       "notification_message": ""
     },
     "phone_number": "+14698993867",
-    "functions": [],
+    "functions": ["tx_first_step_staffing"],
     "counties": ["Dallas"],
     "required_expense_types": [],
     "active": true,

--- a/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json
@@ -10,7 +10,7 @@
     "type_short": ["job resources"],
     "translations": {
       "name": "First Step Staffing",
-      "description": "First Step Staffing helps people facing barriers to employment find jobs and keep them. They place job seekers with local employers and provide wraparound support including transportation to and from work, job readiness coaching, workplace communication support, and long-term retention services.",
+      "description": "First Step Staffing helps people get jobs — and stay in them. They match job seekers with local employers and offer extra help along the way. This includes rides to and from work, coaching to prepare for a job, and support for talking with coworkers and bosses. They also check in over time to help people stay employed.",
       "link": "https://www.firststepstaffing.com/application",
       "warning": "",
       "website_description": "Staffing agency connecting Dallas-area job seekers facing barriers to employment with jobs and wraparound support services like transportation and coaching.",

--- a/programs/programs/urgent_needs/tx/__init__.py
+++ b/programs/programs/urgent_needs/tx/__init__.py
@@ -30,6 +30,7 @@ from .hippy import Hippy
 from .trust_her import TrustHer
 from .legal_aid_northwest_texas import LegalAidNorthwestTexas
 from .crossroads_community_services import CrossroadsCommunitySvcs
+from .first_step_staffing import FirstStepStaffing
 
 tx_urgent_need_functions: dict[str, type[UrgentNeedFunction]] = {
     "tx_early_intervention": EarlyIntervention,
@@ -63,4 +64,5 @@ tx_urgent_need_functions: dict[str, type[UrgentNeedFunction]] = {
     "tx_trust_her": TrustHer,
     "tx_legal_aid_northwest_texas": LegalAidNorthwestTexas,
     "tx_crossroads_community_services": CrossroadsCommunitySvcs,
+    "tx_first_step_staffing": FirstStepStaffing,
 }

--- a/programs/programs/urgent_needs/tx/first_step_staffing.py
+++ b/programs/programs/urgent_needs/tx/first_step_staffing.py
@@ -1,0 +1,19 @@
+from ..base import UrgentNeedFunction
+
+
+class FirstStepStaffing(UrgentNeedFunction):
+    """
+    First Step Staffing
+
+    Places job seekers facing barriers to employment with Dallas-area employers
+    and provides wraparound support including transportation, job readiness
+    coaching, workplace communication support, and long-term retention services.
+
+    Dallas County; no code-level eligibility requirements.
+    County restriction managed via admin configuration.
+    """
+
+    dependencies = []
+
+    def eligible(self) -> bool:
+        return True


### PR DESCRIPTION
## Context & Motivation

Eric Clayton (GM, Texas Market) from First Step Staffing reached out asking to connect MyFriendBen users who select "job resources" with FSS. We confirmed we'd add them as a Job Resources urgent need on the Texas white label.

- Linear: [MFB-991](https://linear.app/myfriendben/issue/MFB-991/add-first-step-staffing-as-an-additional-resource-job-resources)

## Changes Made

- Add `programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json`
  - White label: `tx`
  - `category_type`: existing `tx_job_resources` (matches `tx_workforce_solutions_greater_dallas`, `tx_snap_employment`)
  - `type_short`: `["job resources"]`
  - County filter: `Dallas` (FSS's only TX office; Eric is the TX market GM)
  - Phone: Dallas office line `+1 469-899-3867`
  - Link: `https://www.firststepstaffing.com/application` (per ticket)
  - Description drafted from firststepstaffing.com — covers job placement for people facing employment barriers plus wraparound supports (transportation, coaching, retention)
  - `active: true` — the application link is confirmed in the ticket

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - Dry-run import: `python manage.py import_urgent_need_config programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json --dry-run`
  - Run import: `python manage.py import_urgent_need_config programs/management/commands/import_urgent_need_config_data/data/tx_first_step_staffing.json`
  - In the TX white label, complete a screen and confirm First Step Staffing appears under Job Resources on the results page
  - Verify counties filter limits visibility to Dallas County households

## Deployment

- Post-deployment scripts needed: run the `import_urgent_need_config` command above on staging, then production after merge
- Production config updates: none
- Admin updates needed: confirm in Django admin that translations populated for en/es after import
- Notify team/users of: Eric Clayton at FSS once live in production

## Notes for Reviewers

- Description copy is drafted from the public site since Eric is "still working on getting the job resource-specific information" (per ticket) — happy to swap in his copy when it arrives
- Followed the `tx_workforce_solutions_greater_dallas` pattern closely; main delta is `active: true` (workforce_solutions is `false`) and a phone number is included
- Known limitations: only Dallas County for now — FSS has no other TX offices; if they expand we can add counties later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "First Step Staffing" urgent-need option is now available to users in Dallas, with name/description, website link, and contact phone displayed.
  * The option is active and configured to appear on the current benefits experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1523)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->