### PR TITLE
MFB-920: Spec Fixes

### DIFF
--- a/programs/programs/wa/liheap/spec.md
+++ b/programs/programs/wa/liheap/spec.md
@@ -12,9 +12,9 @@
 
 1. **Household income must be at or below 150% FPG (heating/crisis)**
    - Screener evaluates heating/crisis only (150% FPG). Weatherization (200% FPG) is out of scope — handled by local provider. No cooling component (see Benefit Value section for nuance).
-   - FY2026 threshold, household of 4: 150% FPG = $48,225/year. Full table by household size in PY26 LIHEAP Eligibility Guidelines PDF.
+   - FY2026 threshold, household of 4: 150% FPG = $49,500/year. Full table by household size in PY26 LIHEAP Eligibility Guidelines PDF.
    - WA uses FPG (not SMI), applied uniformly across all household sizes. Program year: October 2025 – September 2026.
-   - **Note on FPG year**: The dollar thresholds quoted throughout this spec come from the 2025 federal poverty guidelines, which LIHEAP IM2025-02 makes mandatory for FY26 LIHEAP. If the MFB calculator pulls FPL values keyed to `year: 2026` (i.e., the 2026 federal poverty guidelines published in early 2026), the computed thresholds will be slightly higher than the LIHEAP-canonical ones quoted here. Dev should confirm which FPL table the calculator is using.
+   - **Note on FPG year**: The dollar thresholds quoted throughout this spec use the 2026 federal poverty guidelines to match the calculator's configured year (`year: 2026`). Note that LIHEAP IM2025-02 technically mandates the 2025 FPG for FY26 LIHEAP, which produces slightly lower thresholds (e.g., HH of 1: 150% FPG = $23,475 under 2025 vs. $23,940 under 2026). The calculator's use of the 2026 FPG is marginally more inclusive — acceptable for a pre-screener.
    - WA uses gross income (not net). Countable income types per WA 2026 Model Plan §1.9: wages, self-employment, unemployment insurance, strike pay, SSA benefits (excluding Medicare deduction), SSI, TANF, general assistance, retirement/pension benefits, loans that need to be repaid, cash gifts, jury duty compensation, rental income, work study income, alimony, child support, interest/dividends/royalties, commissions, legal settlements (if structured, recurring, and used for household expenses), foster care funds, third-party payments for daily living expenses.
    - Non-countable income (excluded from calculation): contract income, mortgage/sales contract payments, savings account balance, one-time lump-sum payments, WIA employment income, insurance payments (direct or for bill repayment), VA benefits, earned income of children under 18, retirement/pension/annuity account balances with withdrawal penalty, income tax refunds, VISTA stipends, AmeriCorps allowances, reimbursements.
    - Note: Households reporting zero income are not automatically excluded. The screener cannot replicate WA's zero-income verification process — treat as potentially eligible and direct to local provider.
@@ -38,7 +38,7 @@
    - Source: WA LIHEAP 2026 Model Plan §4.6
 
 5. **Tribal households: 60% SMI income threshold; categorical eligibility available at 12 of 19 tribal grantees** ⚠️ *pending field request*
-   - 19 WA tribal grantees operate independently from the state program. Most use 60% SMI (more generous than state 150% FPG). HH of 4: 60% SMI = $83,587 vs. 150% FPG = $48,225.
+   - 19 WA tribal grantees operate independently from the state program. Most use 60% SMI (more generous than state 150% FPG). HH of 4: 60% SMI = $83,587 vs. 150% FPG = $49,500.
    - **FY2026 WA 60% SMI thresholds**: 1 person: $43,465 | 2: $56,839 | 3: $70,213 | 4: $83,587 | 5: $96,960 | 6: $110,334 | 7: $112,842 | 8: $115,350
    - **Tribes using 150% FPG instead**: Jamestown S'Klallam, Nooksack, Quileute, Spokane, Yakama. South Puget Intertribal: 60% SMI for heating, 150% FPG for crisis.
    - **Screener approach**: If tribal affiliation indicated, evaluate against 60% SMI. Slightly over-inclusive for 5 tribes — acceptable for a pre-screener. Tribal affiliation is self-reported.
@@ -164,7 +164,7 @@ Key notes: WA does not implement categorical eligibility — all households must
 **Steps**:
 - **Location**: Enter ZIP code `98101`, Select county `King County`
 - **Household**: Number of people: `1`
-- **Person 1**: Birth month/year: `June 1986` (age 39), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$1,980` per month ($23,760/year — exceeds 150% FPG of $23,475 for household of 1)
+- **Person 1**: Birth month/year: `June 1986` (age 39), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$2,000` per month ($24,000/year — exceeds 150% FPG of $23,940 for household of 1)
 - **Expenses**: Indicate household has heating costs
 - **Current Benefits**: None
 
@@ -199,7 +199,7 @@ Key notes: WA does not implement categorical eligibility — all households must
 **Steps**:
 - **Location**: Enter ZIP code `98901`, Select county `Yakima County`
 - **Household**: Number of people: `1`
-- **Person 1**: Birth month/year: `August 1986` (age 39), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$1,956` per month ($23,472/year ≈ 150% FPG of $23,475 for household of 1)
+- **Person 1**: Birth month/year: `August 1986` (age 39), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$1,995` per month ($23,940/year = 150% FPG of $23,940 for household of 1)
 - **Expenses**: Indicate household has heating costs
 - **Current Benefits**: None
 
@@ -284,7 +284,7 @@ Key notes: WA does not implement categorical eligibility — all households must
 - **Expenses**: Indicate household has heating costs
 - **Current Benefits**: None
 
-**Why this matters**: Tests the WA residency criterion. Income is under threshold ($24,000/year vs. $31,725 for HH of 2), so this household would otherwise be eligible. Confirms ZIP/county gates eligibility by state before evaluating income.
+**Why this matters**: Tests the WA residency criterion. Income is under threshold ($24,000/year vs. $32,460 for HH of 2), so this household would otherwise be eligible. Confirms ZIP/county gates eligibility by state before evaluating income.
 
 ---
 
@@ -303,18 +303,18 @@ Key notes: WA does not implement categorical eligibility — all households must
 
 ---
 
-### Scenario 11: Eligible — Household with Mixed Countable and Non-Countable Income
-**What we're checking**: Household where total income appears over the threshold but countable income is under once non-countable income (loans) is excluded.
+### Scenario 11: Eligible — Single Adult Near Income Threshold
+**What we're checking**: Single adult with wages just under the 150% FPG ceiling for a 1-person household is correctly shown as eligible.
 **Expected**: Eligible
 
 **Steps**:
 - **Location**: Enter ZIP code `98101`, County `King County`
 - **Household**: Number of people: `1`
-- **Person 1**: Birth month/year: `June 1985` (age 40), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$1,800` per month; Income type: Loans that need to be repaid, Amount: `$600` per month (non-countable per WA Model Plan §1.9)
+- **Person 1**: Birth month/year: `June 1985` (age 40), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$1,800` per month ($21,600/year — under 150% FPG of $23,940 for household of 1)
 - **Expenses**: Indicate household has heating costs
 - **Current Benefits**: None
 
-**Why this matters**: Validates that non-countable income types are correctly excluded from the gross income calculation. Countable income is $1,800/month = $21,600/year — under 150% FPG for HH of 1 ($23,475). Without the exclusion, total income of $2,400/month = $28,800/year would incorrectly show as ineligible.
+**Why this matters**: Validates eligibility for a single adult near (but under) the income threshold with no priority flags. Note: the original spec tested mixed countable/non-countable income using "Loans" as a non-countable income type, but "Loans" is not an available income type in the screener. This scenario was simplified to test basic income eligibility. Non-countable income exclusion cannot be validated through the screener UI with current income type options.
 
 ---
 
@@ -343,7 +343,7 @@ Key notes: WA does not implement categorical eligibility — all households must
 - **Household**: Number of people: `2`
 - **Person 1**: Birth month/year: `April 1978` (age 47), Relationship: Head of Household, Has income: Yes, Income type: Wages, Amount: `$2,500` per month, Special Circumstances: `Currently have any disabilities that make you unable to work now or in the future`
 - **Person 2**: Birth month/year: `June 1980` (age 45), Relationship: Spouse, Has income: Yes, Income type: Wages, Amount: `$500` per month
-- **Total income**: $3,000/month = $36,000/year — exceeds 150% FPG for HH of 2 ($31,725/year)
+- **Total income**: $3,000/month = $36,000/year — exceeds 150% FPG for HH of 2 ($32,460/year)
 - **Expenses**: Indicate household has heating costs
 - **Current Benefits**: None
 


### PR DESCRIPTION
## Summary

Fixes WA LIHEAP spec test scenarios and FPG references based on QA results from 2026-05-12 staging run. The calculator is configured with `year: 2026` (2026 FPG), but the spec was written using 2025 FPG thresholds, causing a Scenario 2 false failure and making Scenario 11 untestable.

- **Scenario 2 (ineligible income test)**: Updated income from $1,980/mo ($23,760/yr) to $2,000/mo ($24,000/yr) to exceed the 2026 FPG threshold of $23,940. Previous value was only above the 2025 threshold ($23,475), not the 2026 threshold actually used by the calculator.
- **Scenario 4 (boundary test)**: Updated income from $1,956/mo ($23,472/yr) to $1,995/mo ($23,940/yr) to match the exact 2026 FPG boundary for HH of 1.
- **Scenario 11 (mixed income)**: Removed "Loans that need to be repaid" as a second income type — "Loans" is not an available income type in the screener UI. Simplified to wages-only at $1,800/mo to test near-threshold eligibility. Added note explaining the limitation.
- **All FPG references updated to 2026 values**: HH of 1 150% FPG: $23,475→$23,940 | HH of 2: $31,725→$32,460 | HH of 4: $48,225→$49,500
- **FPG year note updated**: Clarified that spec now uses 2026 FPG to match calculator config, with note about 2025 vs 2026 LIHEAP mandate discrepancy.

## Context

QA run on staging (2026-05-12) produced 11/12 passing scenarios, with:
- Scenario 2 reclassified from FAIL to PASS after code review confirmed 2026 FPG is correct
- Scenario 11 marked INCONCLUSIVE because "Loans" doesn't exist as a screener income type

No code changes — spec only. The validation JSON in `benefits-api` was already corrected during implementation. This PR brings the spec.md in sync.

## Test plan

- [x] Verify spec Scenario 2 income ($2,000/mo = $24,000/yr) exceeds 2026 150% FPG for HH of 1 ($23,940)
- [x] Verify spec Scenario 4 income ($1,995/mo = $23,940/yr) equals 2026 150% FPG for HH of 1 ($23,940)
- [x] Verify Scenario 11 no longer references "Loans" income type
- [x] Verify all FPG dollar amounts use 2026 values consistently
- [ ] Re-run QA Scenarios 2 and 11 after merge to confirm expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LIHEAP WA eligibility criteria specifications to reflect 2026 federal poverty guidelines with updated income thresholds and FPG ceiling references (150% FPG).
  * Refreshed eligibility test scenarios, boundary cases, and tribal guidance examples to align with revised thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->