### PR TITLE
MFB-786: Fix Fresh Bucks spec S3 boundary test income

### DIFF
--- a/programs/programs/wa/seattle_fresh_bucks/spec.md
+++ b/programs/programs/wa/seattle_fresh_bucks/spec.md
@@ -11,7 +11,7 @@
 
 1. **Household income must be at or below 80% Area Median Income (AMI) of the Seattle/King County Area**
    - Screener fields: `household_size`, income streams across all household members
-   - Note: AMI thresholds are updated annually. Approximate 2025 80% AMI values for King County: 1-person: $84,850/yr ($7,071/mo) | 2-person: $96,950/yr ($8,079/mo) | 3-person: $109,050/yr ($9,088/mo) | 4-person: $121,150/yr ($10,096/mo) | 5-person: $130,850/yr ($10,904/mo). Priority is given to households at the lowest income tiers (see Priority Criteria).
+   - Note: AMI thresholds are updated annually. Approximate 2025 80% AMI values for King County: 1-person: $84,850/yr ($7,071/mo) | 2-person: $96,950/yr ($8,079/mo) | 3-person: $109,050/yr ($9,087/mo) | 4-person: $121,150/yr ($10,096/mo) | 5-person: $130,850/yr ($10,904/mo). Priority is given to households at the lowest income tiers (see Priority Criteria).
    - Source: [Seattle Fresh Bucks Eligibility](https://www.seattlefreshbucks.org/apply/)
 
 2. **Applicant must reside within Seattle city limits**
@@ -90,10 +90,10 @@ All 12 scenarios below were approved (KEEP or KEEP BUT REVISE).
 - **Location**: Enter ZIP code `98103`
 - **Household**: Number of people: `3`
 - **Person 1 (Head of Household)**: Relationship: `Head of Household`, Has income: `Yes`, Income type: `Wages/Salaries`, Income amount: `$6,588`, Income frequency: `Monthly`
-- **Person 2 (Spouse)**: Relationship: `Spouse`, Has income: `Yes`, Income type: `Wages/Salaries`, Income amount: `$2,500`, Income frequency: `Monthly`
+- **Person 2 (Spouse)**: Relationship: `Spouse`, Has income: `Yes`, Income type: `Wages/Salaries`, Income amount: `$2,499`, Income frequency: `Monthly`
 - **Person 3 (Child)**: Relationship: `Child`, Has income: `No`, Income type: `None`, Income amount: `$0`, Income frequency: `Null`
 
-**Why this matters**: Confirms the threshold logic handles values immediately below the cutoff.
+**Why this matters**: Confirms the threshold logic handles values immediately below the cutoff. Combined income: $9,087/mo ($109,044/yr), which is $6 below the FY2025 3-person 80% AMI limit of $109,050.
 
 ---
 


### PR DESCRIPTION
## Summary
- **Scenario 3** in the Seattle Fresh Bucks spec had a combined income of $9,088/mo ($109,056/yr), which is $6 **over** the FY2025 3-person 80% AMI limit of $109,050. This caused the QA boundary test to fail (expected eligible, got ineligible).
- Reduced Person 2 income from $2,500 → $2,499, bringing the total to $9,087/mo ($109,044/yr) — correctly just below the threshold.
- Corrected the 3-person monthly AMI approximation in the eligibility notes from $9,088/mo → $9,087/mo (floor of $109,050 ÷ 12).

**Context:** Per investigation on MFB-786, the year stays at FY2025 — Seattle Fresh Bucks is still operationally using FY2025 limits. See [PR #1496](https://github.com/MyFriendBen/benefits-api/pull/1496) for the original year change and the [QA results](https://github.com/MyFriendBen/benefits-api/blob/main/qa/MFB-786-wa_seattle_fresh_bucks-results.md) showing 12/13 pass with only S3 failing due to this calibration issue.

## Test plan
- [ ] Re-run S3 QA scenario with updated income ($6,588 + $2,499 = $9,087/mo) and verify eligible result
- [ ] Confirm other boundary scenarios (S2, S4, S5) remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated income threshold calculations for the WA Seattle/King County 80% AMI screener with corrected 3-person monthly threshold ($9,087/mo instead of $9,088/mo).
  * Adjusted test scenario documentation to align with updated financial threshold values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->