### PR TITLE
MFB-851: Send capital gains as component variable

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -524,7 +524,7 @@ class SocialSecurityIncomeDependency(IncomeDependency):
 
 
 class InvestmentIncomeDependency(IncomeDependency):
-    field = "capital_gains"
+    field = "long_term_capital_gains"
     income_types = ["investment"]
 
 


### PR DESCRIPTION
## Summary

- Switches `InvestmentIncomeDependency.field` from `capital_gains` (roll-up) to `long_term_capital_gains` (node variable) so PolicyEngine's EITC investment income threshold check works correctly

## Problem

QA Scenario 13 for WA EITC found that a household with $12,000/yr investment income (above the TY2025 $11,950 cap per [26 U.S.C. § 32(i)](https://www.law.cornell.edu/uscode/text/26/32#i)) was incorrectly shown as EITC-eligible at $1,347/yr.

**Root cause:** We send `capital_gains` (a person-level roll-up variable with `adds = ["short_term_capital_gains", "long_term_capital_gains"]`) as a PE input. Setting the roll-up overrides its formula but does **not** propagate back to its components. PolicyEngine's EITC investment income check reads `net_capital_gains` (tax-unit level), which independently re-sums `long_term + short_term` — both still 0 — so `eitc_relevant_investment_income` always evaluates to $0 and the threshold check always passes.

We filed a change request with PolicyEngine and they confirmed this is expected behavior for roll-up variables. They asked us to send node-level variables (`long_term_capital_gains` or `short_term_capital_gains`) instead.

## Fix

One-line change: `InvestmentIncomeDependency.field` from `"capital_gains"` → `"long_term_capital_gains"`.

With this change, PE computes `capital_gains` from its adds formula (`long_term_capital_gains + short_term_capital_gains = 12000 + 0`), so every variable reading the aggregate still sees the correct value. And `net_capital_gains` (tax-unit) now picks up the input through its own adds, fixing the EITC investment income chain.

## Impact audit

Full audit at `discovery-reviews/MFB-851/investment_income_dependency_impact_audit.md`. Summary:

**Programs that read `capital_gains` directly (unchanged — aggregate still computes to same value):**
- WIC (`wic_countable_income` → `person("capital_gains")`)
- IL AABD (`il_aabd_gross_unearned_income` → parameter includes `capital_gains`)
- IL HBWD (`il_hbwd_countable_unearned_income` → parameter includes `capital_gains`)
- AGI/MAGI chain → Medicaid, ACA PTC, CHIP (`irs_gross_income` sources include `capital_gains`)

**Programs fixed (now correctly read investment income via `net_capital_gains`):**
- EITC (federal, WA, CO, MA, IL, TX)
- WA WFTC (piggybacks on federal EITC)

**Programs with no capital gains dependency (no impact):**
- SNAP, TANF (all variants), SSI, CTC (all variants), Lifeline, ACP, Pell Grant, Head Start, CCDF, CSFP, School Meals, LIHEAP, EAEDC, OAP, ANDCS, CHP+, FATC, Care Worker Credit, SCCA, CCS

**PE-internal variables that now see `long_term_capital_gains` instead of 0:**
- ~20 state tax variables (WA capital gains tax, MA income brackets, MT, etc.) — none are PE output variables we request, none feed back into eligibility.

## Staging verification

Screen `5fa36c18` on staging confirmed the bug: PE request sends `capital_gains: 12000`, PE response returns `eitc: 1347.73` (should be 0). The admin PE data view shows the investment income is sent but silently dropped by PE's dependency chain.

## Test plan

- [x] All 160 PE calculator dependency tests pass
- [x] All 1085 state program tests pass (IL, WA, CO, MA, TX, federal)
- [x] Re-run QA Scenario 13 on staging after deploy — EITC should not appear for $12,000/yr investment income
- [x] Re-run QA Scenario 12 — EITC should still appear for $11,940/yr investment income (under threshold)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated investment income calculation to use the correct income data source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->