### PR TITLE
MFB-855: Show warning message for SNAP categorical eligibility

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -61,6 +61,13 @@
       "link_text": ""
     }
   ],
+  "warning_messages": [
+    {
+      "external_name": "wa_lifeline_snap_enrollment",
+      "calculator": "_show",
+      "message": "If your screener results indicate you are eligible for SNAP and you are not currently receiving it, you must enroll in SNAP before applying for Lifeline."
+    }
+  ],
   "navigators": [
     {
       "external_name": "lifeline_support_center",

--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -65,7 +65,7 @@
     {
       "external_name": "wa_lifeline_snap_enrollment",
       "calculator": "_show",
-      "message": "If your screener results indicate you are eligible for SNAP and you are not currently receiving it, you must enroll in SNAP before applying for Lifeline."
+      "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
     }
   ],
   "navigators": [


### PR DESCRIPTION
## Summary

- Adds a warning message to the WA Lifeline program config advising users that SNAP enrollment is required before applying for Lifeline

## Problem

During QA ([Scenario 2](https://linear.app/myfriendben/issue/MFB-855)), we discovered that PolicyEngine's `is_lifeline_eligible` variable returns `true` for households that are *theoretically* SNAP-eligible — even when they aren't enrolled in SNAP. This is because PE's categorical eligibility list (`medicaid`, `snap`, `ssi`) uses calculated eligibility rather than actual program participation.

The real Lifeline program (per 47 CFR § 54.409) requires **active enrollment** in a qualifying program like SNAP, not just eligibility. This means some users may see Lifeline as a result without understanding they need to enroll in SNAP first.

## Solution

Added a `warning_messages` entry to `wa_lifeline_initial_config.json` with `calculator: "_show"` (displays for all eligible users):

> "If your screener results indicate you are eligible for SNAP and you are not currently receiving it, you must enroll in SNAP before applying for Lifeline."

## Follow-up

- [x] Run `import_program_config` management command in staging and production after merge
- [x] Verify warning message renders on the Lifeline results card in the frontend
- [ ] Consider adding Spanish translation for the warning message

## Test plan

- [x] Run `import_program_config wa_lifeline` on staging
- [x] Submit a screener for a WA household eligible for both SNAP and Lifeline
- [x] Confirm warning message appears on the Lifeline result card
- [x] Confirm warning message does not appear when household is not eligible for Lifeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning message that alerts users eligible for SNAP to enroll before applying for Lifeline assistance in Washington.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->