### PR TITLE
fix(tx-ccs): set childcare attending days to 10/month to match TX CCS validation

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -451,19 +451,19 @@ class ChildcareAttendingDaysPerMonthDependency(Member):
     """
     Number of days per month a child attends childcare.
 
-    Default: 20 days/month (typical full-time childcare for working parents).
+    Set to 10 days/month instead of default 20 days/month to align with Texas CCS (Child Care Services) validation
+    references and provider payment rate calculations. Using 20 days resulted in
+    tx_ccs benefit values approximately 2x higher than expected, because the Board's
+    maximum daily reimbursement rate is multiplied by attending days per month.
 
-    This represents standard full-time childcare usage (5 days/week × ~4 weeks/month).
-    Used by childcare subsidy programs to calculate benefit amounts.
-
-    Note: 20 days is a reasonable default for families seeking childcare subsidies,
-    as they typically need care to support full-time work.
+    Note: If other state childcare subsidy programs require a different default,
+    this value may need to be made program-specific.
     """
 
     field = "childcare_attending_days_per_month"
 
     def value(self):
-        return 20
+        return 10
 
 
 class MaStateSupplementProgram(Member):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1012,7 +1012,7 @@ class TestChildcareAttendingDaysPerMonthDependency(TestCase):
     def test_value_returns_default_20_days(self):
         """Test ChildcareAttendingDaysPerMonthDependency.value() returns default of 20 days per month."""
         dep = member.ChildcareAttendingDaysPerMonthDependency(self.screen, self.child, {})
-        self.assertEqual(dep.value(), 20)
+        self.assertEqual(dep.value(), 10)
 
     def test_field_name_is_correct(self):
         """Test that field name matches PolicyEngine's childcare_attending_days_per_month variable."""

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1009,8 +1009,8 @@ class TestChildcareAttendingDaysPerMonthDependency(TestCase):
         self.parent = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=30)
         self.child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=3)
 
-    def test_value_returns_default_20_days(self):
-        """Test ChildcareAttendingDaysPerMonthDependency.value() returns default of 20 days per month."""
+    def test_value_returns_10_days(self):
+        """Test ChildcareAttendingDaysPerMonthDependency.value() returns 10 days per month."""
         dep = member.ChildcareAttendingDaysPerMonthDependency(self.screen, self.child, {})
         self.assertEqual(dep.value(), 10)
 
@@ -1026,14 +1026,14 @@ class TestChildcareAttendingDaysPerMonthDependency(TestCase):
         self.assertTrue(issubclass(member.ChildcareAttendingDaysPerMonthDependency, Member))
 
     def test_value_same_for_all_children(self):
-        """Test that all children get the same default value of 20 days."""
+        """Test that all children get the same value of 10 days."""
         child2 = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=5)
 
         dep1 = member.ChildcareAttendingDaysPerMonthDependency(self.screen, self.child, {})
         dep2 = member.ChildcareAttendingDaysPerMonthDependency(self.screen, child2, {})
 
-        self.assertEqual(dep1.value(), 20)
-        self.assertEqual(dep2.value(), 20)
+        self.assertEqual(dep1.value(), 10)
+        self.assertEqual(dep2.value(), 10)
 
     def test_works_with_relationship_map(self):
         """Test that dependency works correctly with relationship_map parameter."""
@@ -1042,7 +1042,7 @@ class TestChildcareAttendingDaysPerMonthDependency(TestCase):
         dep = member.ChildcareAttendingDaysPerMonthDependency(self.screen, self.child, relationship_map)
 
         self.assertIsNotNone(dep)
-        self.assertEqual(dep.value(), 20)
+        self.assertEqual(dep.value(), 10)
 
     def test_has_correct_unit(self):
         """Test that dependency has correct unit (people) for PolicyEngine."""


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[mfb-639](https://linear.app/myfriendben/issue/MFB-639/tx-fix-tx-ccs-validation-failures)

TX CCS validation failures were traced to `childcare_attending_days_per_month` being set to 10 in `ChildcareAttendingDaysPerMonthDependency`. Since PolicyEngine's TX CCS formula multiples the Board's maximum daily reimbursement rate by attending days per month, passing 20 instead of 10 caused calculated tx_ccs benefits values to be approximately 2x higher than expected (e.g., $12,912 returned vs $6,528 expected for a test household).

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Updated `ChildcareAttendingDaysPerMonthDependency.value()` in `member.py` to return 10 instead of 20, aligning with the TX CCS validation reference values 
- Updated the class docstring to explain the rationale for this value
- Updated `TestChildcareAttendingDaysPerMonthDependency` tests in `test_member.py` to assert `10` days
  instead of `20` across all three affected test cases


## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
- 
**View  test case**

---

### TC-01 · 2 person · Age 30
| Field | Value |
|---|---|
| Travis County | 78701 Texas  |
| HH size |  2 |
| Age (DOB) | 30 (01/1996) |
| Coverage | no insurance  |
|child Age (DOB) | 5 (01/2021) |
| Coverage | no insurance  |
| Income | $1950/month |
| Other condition | None |
| Other expenses | $1,200 childcare  |

| **Expected amount** | **$6,528/year** |

---

Verify the returned tx_ccs annual benefit is approximately half of what was previously returned
Confirm the value is closer to expected validation amounts
Other test cases are included in the issue attached above.
## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: A secondary formula issue was identified in the upstream PolicyEngine-US `tx_ccs.py `— when a family's childcare charge exceeds the Board's maximum daily rate, the copay is not correctly deducted from the subsidy. This causes a small remaining discrepancy (~1%) between our calculated values and the regulatory-correct result. This has been reported to the PolicyEngine team for a separate fix.
- Future considerations: If other state childcare subsidy programs are added and require a different attending days default, `ChildcareAttendingDaysPerMonthDependency` may need to be made program-specific rather than a single shared default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted childcare attendance calculation to correctly reflect monthly attending days, improving accuracy of childcare benefit computations for compliance with state program requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->