### PR TITLE
MFB-719: Switch Screen.has_benefit() reads to join table

### DIFF
--- a/programs/programs/il/nurse_family_partnership/tests.py
+++ b/programs/programs/il/nurse_family_partnership/tests.py
@@ -10,6 +10,7 @@ Tests verify:
 from django.test import TestCase
 from programs.programs.il.nurse_family_partnership.calculator import IlNurseFamilyPartnership
 from screener.models import Screen, HouseholdMember, IncomeStream, WhiteLabel
+from screener.tests.helpers import seed_program, sync_current_benefits
 from programs.models import Program, FederalPoveryLimit
 from programs.util import Dependencies
 
@@ -69,8 +70,10 @@ class TestIlNurseFamilyPartnership(TestCase):
 
     def test_household_eligible_with_wic_regardless_of_income(self):
         """Test household is eligible with WIC (presumed eligibility) regardless of income."""
+        seed_program(self.il_white_label, "wic")
         self.screen.has_wic = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         parent = HouseholdMember.objects.create(
             screen=self.screen,

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -7,6 +7,7 @@ by PolicyEngine to determine TX SNAP eligibility and benefit amounts.
 
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Expense
+from screener.tests.helpers import seed_program, sync_current_benefits
 from programs.programs.policyengine.calculators.dependencies import spm
 
 
@@ -451,8 +452,10 @@ class TestSnapDependency(TestCase):
 
     def test_value_returns_1_when_screen_has_snap(self):
         """When user reports having SNAP, send 1 to PE to enable categorical eligibility."""
+        seed_program(self.white_label, "snap")
         self.screen.has_snap = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         dep = spm.Snap(self.screen, None, {})
         self.assertEqual(dep.value(), 1)
@@ -486,8 +489,10 @@ class TestTanfDependency(TestCase):
 
     def test_value_returns_1_when_screen_has_tanf(self):
         """When user reports having TANF, send 1 to PE to enable categorical eligibility."""
+        seed_program(self.white_label, "tanf")
         self.screen.has_tanf = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         dep = spm.Tanf(self.screen, None, {})
         self.assertEqual(dep.value(), 1)

--- a/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
+++ b/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
@@ -14,6 +14,7 @@ from programs.programs.urgent_needs.tx.trust_her import TrustHer
 from programs.programs.urgent_needs.tx.wic import Wic
 from programs.util import Dependencies
 from screener.models import HouseholdMember, Screen, WhiteLabel
+from screener.tests.helpers import seed_program, sync_current_benefits
 from translations.models import Translation
 
 
@@ -63,8 +64,10 @@ class TestSnapEmploymentTraining(TestCase):
         self.assertTrue(self._calc([{"name_abbreviated": "tx_snap", "eligible": True}]))
 
     def test_eligible_when_screen_has_snap(self):
+        seed_program(self.white_label, "tx_snap")
         self.screen.has_snap = True
         self.screen.save()
+        sync_current_benefits(self.screen)
         self.assertTrue(self._calc([]))
 
     def test_not_eligible_without_snap(self):
@@ -93,8 +96,10 @@ class TestDoubleUpFoodBucks(TestCase):
         self.assertTrue(self._calc([{"name_abbreviated": "tx_snap", "eligible": True}]))
 
     def test_eligible_when_screen_has_snap(self):
+        seed_program(self.white_label, "tx_snap")
         self.screen.has_snap = True
         self.screen.save()
+        sync_current_benefits(self.screen)
         self.assertTrue(self._calc([]))
 
     def test_not_eligible_without_snap(self):

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -8,6 +8,7 @@ from programs.programs.wa import wa_calculators
 from programs.programs.wa.nslp.calculator import WaNslp
 from programs.util import Dependencies
 from screener.models import HouseholdMember, IncomeStream, Screen, WhiteLabel
+from screener.tests.helpers import seed_program, sync_current_benefits
 
 
 class TestWaNslp(TestCase):
@@ -149,7 +150,9 @@ class TestWaNslp(TestCase):
         self.assertFalse(result.eligible)
 
     def test_ineligible_already_has_nslp(self):
+        seed_program(self.white_label, "nslp")
         screen = self._screen_base(has_nslp=True)
+        sync_current_benefits(screen)
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=2000, frequency="monthly"

--- a/programs/programs/wa/pe/member.py
+++ b/programs/programs/wa/pe/member.py
@@ -24,7 +24,7 @@ class WaSsi(Ssi):
 
     Duplicate-enrollment filtering ("not already receiving SSI") is enforced
     one layer up via `Screen.has_benefit("wa_ssi")`, which reads from the
-    `ScreenCurrentBenefit` join table.
+    `CurrentBenefit` join table.
 
     See `programs/programs/wa/ssi/spec.md` for the full eligibility criteria,
     PolicyEngine variable mapping, and the 15 reference test scenarios.

--- a/programs/programs/wa/pe/member.py
+++ b/programs/programs/wa/pe/member.py
@@ -23,8 +23,8 @@ class WaSsi(Ssi):
       - the WA state code so PE knows which state to model
 
     Duplicate-enrollment filtering ("not already receiving SSI") is enforced
-    one layer up via `Screen.has_benefit("wa_ssi")` -> `_build_benefit_map`,
-    matching the existing `ssi` and `tx_ssi` mapping.
+    one layer up via `Screen.has_benefit("wa_ssi")`, which reads from the
+    `ScreenCurrentBenefit` join table.
 
     See `programs/programs/wa/ssi/spec.md` for the full eligibility criteria,
     PolicyEngine variable mapping, and the 15 reference test scenarios.

--- a/screener/models.py
+++ b/screener/models.py
@@ -541,12 +541,28 @@ class Screen(models.Model):
         # Serves from prefetch cache when `current_benefits__program` is prefetched
         # (zero queries); otherwise one query on first access, cached thereafter.
         #
-        # Per-instance cache: a Screen loaded *before* a write will not see rows
-        # written after. Callers that mutate has_* columns and then call
-        # has_benefit() on the same instance (admin actions, management commands)
-        # must refetch the screen between write and read. The eligibility hot
-        # path is safe — the view fetches a fresh Screen on every request.
-        # This concern disappears in MFB-720 when has_* writes go away.
+        # ⚠️  STALENESS WARNING — read before reusing this pattern.
+        # This is a per-instance cache. A Screen loaded *before* a write will
+        # NOT see rows written after, even on the same instance. Concretely:
+        #
+        #     screen.has_snap = True
+        #     screen.save()                  # triggers _sync_current_benefits via serializer
+        #     screen.has_benefit("snap")     # ❌ may return False — cache populated pre-write
+        #
+        # Do NOT reach for `del screen._current_benefit_names` to invalidate —
+        # that's a sharp edge that future refactors will silently break. The
+        # supported recovery is to re-fetch the Screen:
+        #
+        #     screen = Screen.objects.get(pk=screen.pk)
+        #     screen.has_benefit("snap")     # ✅
+        #
+        # The eligibility hot path is safe — the view fetches a fresh Screen
+        # on every request. Only admin actions / management commands / tests
+        # that mutate has_* and then read on the same instance are at risk.
+        #
+        # This whole cache (and has_benefit itself) disappears in MFB-720 when
+        # the has_* columns are dropped and current_benefits becomes the only
+        # write target, so we are intentionally NOT adding an invalidation hook.
         return {cb.program.name_abbreviated for cb in self.current_benefits.all()}
 
     def has_benefit(self, name_abbreviated: str) -> bool:

--- a/screener/models.py
+++ b/screener/models.py
@@ -384,10 +384,14 @@ class Screen(models.Model):
         compound conditions (ssi via has_ssi OR sSI income; ma_mass_health via
         has_medicaid OR has_medicaid_hi).
 
-        Only used by `_sync_current_benefits()` to write CurrentBenefit rows
-        during the dual-write phase. Removed in MFB-869 alongside
-        `_sync_current_benefits` once the serializer writes join-table rows
-        directly from the frontend's `current_benefits: [...]` payload.
+        Only used by `_sync_current_benefits()` (and its test-helper mirror in
+        `screener/tests/helpers.py`) to write CurrentBenefit rows during the
+        dual-write phase. `HouseholdMember.has_benefit()` does NOT route through
+        here — it has its own member-level `name_map` keyed off `self.insurance`.
+
+        Removed in MFB-869 alongside `_sync_current_benefits` once the serializer
+        writes join-table rows directly from the frontend's `current_benefits: [...]`
+        payload.
         """
         has_ssi_or_ssi_income = self.has_ssi or self.calc_gross_income("yearly", ("sSI",)) > 0
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -3,6 +3,7 @@ from datetime import date
 from django.db import models
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.utils import timezone
+from django.utils.functional import cached_property
 from decimal import Decimal
 import uuid
 from authentication.models import User
@@ -531,7 +532,13 @@ class Screen(models.Model):
             "nc_cccap": self.has_ccap,
         }
 
-    def has_benefit(self, name_abbreviated: str):
+    @cached_property
+    def _current_benefit_names(self) -> set[str]:
+        # Serves from prefetch cache when `current_benefits__program` is prefetched
+        # (zero queries); otherwise one query on first access, cached thereafter.
+        return {cb.program.name_abbreviated for cb in self.current_benefits.all()}
+
+    def has_benefit(self, name_abbreviated: str) -> bool:
         """
         Returns True if the user has declared they already receive the benefit
         identified by `name_abbreviated`. Drives the "already_has" flag on
@@ -547,13 +554,8 @@ class Screen(models.Model):
         has_medicaid OR has_medicaid_hi) are resolved at write time by
         _sync_current_benefits → _build_benefit_map, so this read path needs
         no special-casing.
-
-        Callers that check many names per screen should ensure
-        `current_benefits__program` is prefetched to avoid N+1 queries.
         """
-        if hasattr(self, "_prefetched_objects_cache") and "current_benefits" in self._prefetched_objects_cache:
-            return any(cb.program.name_abbreviated == name_abbreviated for cb in self.current_benefits.all())
-        return self.current_benefits.filter(program__name_abbreviated=name_abbreviated).exists()
+        return name_abbreviated in self._current_benefit_names
 
     def set_screen_is_test(self):
         referral_source_tests = ["testorprospect", "test"]

--- a/screener/models.py
+++ b/screener/models.py
@@ -379,11 +379,14 @@ class Screen(models.Model):
 
     def _build_benefit_map(self) -> dict:
         """
-        Builds and returns the full name_abbreviated → bool map for this screen.
+        Returns the full name_abbreviated → bool map for this screen, including
+        compound conditions (ssi via has_ssi OR sSI income; ma_mass_health via
+        has_medicaid OR has_medicaid_hi).
 
-        Callers that need to check many programs should call this once and reuse
-        the result rather than calling has_benefit() in a loop (which rebuilds the
-        dict on every call).
+        Only used by `_sync_current_benefits()` to write ScreenCurrentBenefit
+        rows during the dual-write phase. Removed in MFB-869 alongside
+        `_sync_current_benefits` once the serializer writes join-table rows
+        directly from the frontend's `current_benefits: [...]` payload.
         """
         has_ssi_or_ssi_income = self.has_ssi or self.calc_gross_income("yearly", ("sSI",)) > 0
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -384,8 +384,8 @@ class Screen(models.Model):
         compound conditions (ssi via has_ssi OR sSI income; ma_mass_health via
         has_medicaid OR has_medicaid_hi).
 
-        Only used by `_sync_current_benefits()` to write ScreenCurrentBenefit
-        rows during the dual-write phase. Removed in MFB-869 alongside
+        Only used by `_sync_current_benefits()` to write CurrentBenefit rows
+        during the dual-write phase. Removed in MFB-869 alongside
         `_sync_current_benefits` once the serializer writes join-table rows
         directly from the frontend's `current_benefits: [...]` payload.
         """
@@ -536,6 +536,13 @@ class Screen(models.Model):
     def _current_benefit_names(self) -> set[str]:
         # Serves from prefetch cache when `current_benefits__program` is prefetched
         # (zero queries); otherwise one query on first access, cached thereafter.
+        #
+        # Per-instance cache: a Screen loaded *before* a write will not see rows
+        # written after. Callers that mutate has_* columns and then call
+        # has_benefit() on the same instance (admin actions, management commands)
+        # must refetch the screen between write and read. The eligibility hot
+        # path is safe — the view fetches a fresh Screen on every request.
+        # This concern disappears in MFB-720 when has_* writes go away.
         return {cb.program.name_abbreviated for cb in self.current_benefits.all()}
 
     def has_benefit(self, name_abbreviated: str) -> bool:
@@ -544,7 +551,7 @@ class Screen(models.Model):
         identified by `name_abbreviated`. Drives the "already_has" flag on
         eligibility results so the frontend can filter the program out.
 
-        Reads from the ScreenCurrentBenefit join table. The has_* columns are
+        Reads from the CurrentBenefit join table. The has_* columns are
         still written by the serializer (Phase 2 dual-write) and synced to the
         join table on every POST/PATCH via _sync_current_benefits(), so this
         query is the authoritative read path while rollback remains a single

--- a/screener/models.py
+++ b/screener/models.py
@@ -530,35 +530,27 @@ class Screen(models.Model):
 
     def has_benefit(self, name_abbreviated: str):
         """
-        Maps a program's name_abbreviated to the corresponding has_* field on the Screen model.
+        Returns True if the user has declared they already receive the benefit
+        identified by `name_abbreviated`. Drives the "already_has" flag on
+        eligibility results so the frontend can filter the program out.
 
-        This is used to determine if a user already has a benefit (selected in step 10) so it can be
-        filtered from results on the frontend via the "already_has" flag.
+        Reads from the ScreenCurrentBenefit join table. The has_* columns are
+        still written by the serializer (Phase 2 dual-write) and synced to the
+        join table on every POST/PATCH via _sync_current_benefits(), so this
+        query is the authoritative read path while rollback remains a single
+        revert.
 
-        Map Structure:
-            Key: Program name_abbreviated (from program registration, e.g., co/__init__.py)
-            Value: Boolean field on Screen model indicating user has that benefit
+        Compound conditions (ssi → has_ssi OR sSI income; ma_mass_health →
+        has_medicaid OR has_medicaid_hi) are resolved at write time by
+        _sync_current_benefits → _build_benefit_map, so this read path needs
+        no special-casing.
 
-        Common Pattern:
-            Multiple program variants (e.g., different states or screener types) map to the same field:
-            - "snap", "co_snap", "il_snap" → all map to self.has_snap (same real-world benefit)
-            - "leap", "cesn_leap" → both map to self.has_leap (same benefit, different flows)
-
-        Adding New Mappings:
-            1. Ensure the benefit key exists in white_label config's category_benefits (e.g., "leap")
-            2. Ensure updateScreen.ts maps formData.benefits.{key} → has_{key}
-            3. Add all program name_abbreviated variants that represent the same benefit
-
-        Example Flow:
-            Config (co.py): "leap": {"name": "LEAP", ...}
-            → User checks LEAP in step 10
-            → Frontend: formData.benefits.leap = true
-            → API (updateScreen.ts): has_leap = formData.benefits.leap
-            → Database: screen.has_leap = True
-            → This method: has_benefit("leap") → returns self.has_leap (True)
-            → Serializer: "already_has": True → Frontend filters out LEAP from results
+        Callers that check many names per screen should ensure
+        `current_benefits__program` is prefetched to avoid N+1 queries.
         """
-        return self._build_benefit_map().get(name_abbreviated, False)
+        if hasattr(self, "_prefetched_objects_cache") and "current_benefits" in self._prefetched_objects_cache:
+            return any(cb.program.name_abbreviated == name_abbreviated for cb in self.current_benefits.all())
+        return self.current_benefits.filter(program__name_abbreviated=name_abbreviated).exists()
 
     def set_screen_is_test(self):
         referral_source_tests = ["testorprospect", "test"]

--- a/screener/tests/helpers.py
+++ b/screener/tests/helpers.py
@@ -15,11 +15,12 @@ from programs.models import Program
 from screener.models import CurrentBenefit, Screen, WhiteLabel
 
 
-def seed_program(white_label: WhiteLabel, name_abbreviated: str) -> Program:
-    """Create a Program (with required Translation FKs) so the join-table read
-    path can resolve `program__name_abbreviated=name`. Thin wrapper around the
-    canonical `Program.objects.new_program` manager method."""
-    return Program.objects.new_program(white_label.code, name_abbreviated)
+def seed_program(white_label: WhiteLabel, *name_abbreviateds: str) -> None:
+    """Create one or more Programs (with required Translation FKs) so the
+    join-table read path can resolve `program__name_abbreviated=name`. Thin
+    wrapper around the canonical `Program.objects.new_program` manager method."""
+    for name in name_abbreviateds:
+        Program.objects.new_program(white_label.code, name)
 
 
 def sync_current_benefits(screen: Screen) -> None:

--- a/screener/tests/helpers.py
+++ b/screener/tests/helpers.py
@@ -1,13 +1,18 @@
 """
 Shared fixtures for tests that exercise Screen.has_benefit() — which now reads
-from the ScreenCurrentBenefit join table. Use seed_program() to create the
-Program row a join-table lookup will need, then call sync_current_benefits()
-after setting has_* columns (mirroring the serializer dual-write).
+from the CurrentBenefit join table. Use seed_program() to create the Program
+row a join-table lookup will need, then call sync_current_benefits() after
+setting has_* columns (mirroring what the serializer does on every POST/PATCH).
+
+Lifecycle: both helpers are transitional and will be removed in MFB-720 once
+the has_* columns are gone and tests write CurrentBenefit rows directly via
+the new `current_benefits: [...]` serializer payload.
 """
 
+from django.db import transaction
+
 from programs.models import Program
-from screener.models import Screen, WhiteLabel
-from screener.serializers import _sync_current_benefits
+from screener.models import CurrentBenefit, Screen, WhiteLabel
 
 
 def seed_program(white_label: WhiteLabel, name_abbreviated: str) -> Program:
@@ -18,6 +23,24 @@ def seed_program(white_label: WhiteLabel, name_abbreviated: str) -> Program:
 
 
 def sync_current_benefits(screen: Screen) -> None:
-    """Mirror what the serializer does on every POST/PATCH — write join-table
-    rows reflecting the current has_* column state."""
-    _sync_current_benefits(screen)
+    """Mirror the serializer's dual-write: rebuild CurrentBenefit rows from the
+    current has_* column state on `screen`.
+
+    Body is intentionally inlined (rather than calling screener.serializers.
+    _sync_current_benefits) so this helper survives MFB-869, which deletes the
+    serializer function. The helper itself is deleted in MFB-720 once tests
+    can write join-table rows directly.
+    """
+    with transaction.atomic():
+        screen = Screen.objects.select_for_update().get(pk=screen.pk)
+        benefit_map = screen._build_benefit_map()
+        program_ids_to_write = [
+            program.id
+            for program in Program.objects.filter(white_label=screen.white_label)
+            if benefit_map.get(program.name_abbreviated, False)
+        ]
+        CurrentBenefit.objects.filter(screen=screen).delete()
+        if program_ids_to_write:
+            CurrentBenefit.objects.bulk_create(
+                [CurrentBenefit(screen=screen, program_id=pid) for pid in program_ids_to_write]
+            )

--- a/screener/tests/helpers.py
+++ b/screener/tests/helpers.py
@@ -8,40 +8,13 @@ after setting has_* columns (mirroring the serializer dual-write).
 from programs.models import Program
 from screener.models import Screen, WhiteLabel
 from screener.serializers import _sync_current_benefits
-from translations.models import Translation
 
 
-REQUIRED_TRANSLATION_FIELDS = (
-    "name",
-    "description_short",
-    "description",
-    "learn_more_link",
-    "apply_button_link",
-    "apply_button_description",
-    "estimated_delivery_time",
-    "estimated_application_time",
-    "estimated_value",
-    "website_description",
-)
-
-
-def seed_program(white_label: WhiteLabel, name_abbreviated: str, **overrides) -> Program:
-    """Create a Program with all required Translation FKs filled. Used so the
-    join-table read path can resolve `program__name_abbreviated=name`."""
-    label = f"seed-{white_label.code}-{name_abbreviated}"
-    defaults = {
-        field: Translation.objects.add_translation(f"program.{label}-{field}", default_message="")
-        for field in REQUIRED_TRANSLATION_FIELDS
-    }
-    defaults.update(
-        white_label=white_label,
-        name_abbreviated=name_abbreviated,
-        external_name=label,
-        active=True,
-        show_in_has_benefits_step=True,
-    )
-    defaults.update(overrides)
-    return Program.objects.create(**defaults)
+def seed_program(white_label: WhiteLabel, name_abbreviated: str) -> Program:
+    """Create a Program (with required Translation FKs) so the join-table read
+    path can resolve `program__name_abbreviated=name`. Thin wrapper around the
+    canonical `Program.objects.new_program` manager method."""
+    return Program.objects.new_program(white_label.code, name_abbreviated)
 
 
 def sync_current_benefits(screen: Screen) -> None:

--- a/screener/tests/helpers.py
+++ b/screener/tests/helpers.py
@@ -1,0 +1,50 @@
+"""
+Shared fixtures for tests that exercise Screen.has_benefit() — which now reads
+from the ScreenCurrentBenefit join table. Use seed_program() to create the
+Program row a join-table lookup will need, then call sync_current_benefits()
+after setting has_* columns (mirroring the serializer dual-write).
+"""
+
+from programs.models import Program
+from screener.models import Screen, WhiteLabel
+from screener.serializers import _sync_current_benefits
+from translations.models import Translation
+
+
+REQUIRED_TRANSLATION_FIELDS = (
+    "name",
+    "description_short",
+    "description",
+    "learn_more_link",
+    "apply_button_link",
+    "apply_button_description",
+    "estimated_delivery_time",
+    "estimated_application_time",
+    "estimated_value",
+    "website_description",
+)
+
+
+def seed_program(white_label: WhiteLabel, name_abbreviated: str, **overrides) -> Program:
+    """Create a Program with all required Translation FKs filled. Used so the
+    join-table read path can resolve `program__name_abbreviated=name`."""
+    label = f"seed-{white_label.code}-{name_abbreviated}"
+    defaults = {
+        field: Translation.objects.add_translation(f"program.{label}-{field}", default_message="")
+        for field in REQUIRED_TRANSLATION_FIELDS
+    }
+    defaults.update(
+        white_label=white_label,
+        name_abbreviated=name_abbreviated,
+        external_name=label,
+        active=True,
+        show_in_has_benefits_step=True,
+    )
+    defaults.update(overrides)
+    return Program.objects.create(**defaults)
+
+
+def sync_current_benefits(screen: Screen) -> None:
+    """Mirror what the serializer does on every POST/PATCH — write join-table
+    rows reflecting the current has_* column state."""
+    _sync_current_benefits(screen)

--- a/screener/tests/test_models.py
+++ b/screener/tests/test_models.py
@@ -233,13 +233,9 @@ class TestScreen(TestCase):
     # phase) and invoke sync_current_benefits() to populate the join table —
     # mirroring what every POST/PATCH does in production.
 
-    def _seed_programs(self, *name_abbreviateds: str):
-        for name in name_abbreviateds:
-            seed_program(self.white_label, name)
-
     def test_has_benefit_returns_true_when_user_has_snap(self):
         """has_benefit('tx_snap') is True when has_snap=True and the join table is synced."""
-        self._seed_programs("tx_snap")
+        seed_program(self.white_label, "tx_snap")
         self.screen.has_snap = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -248,7 +244,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_false_when_user_does_not_have_snap(self):
         """has_benefit('tx_snap') is False when has_snap=False."""
-        self._seed_programs("tx_snap")
+        seed_program(self.white_label, "tx_snap")
         self.screen.has_snap = False
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -257,7 +253,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_true_when_user_has_wa_snap(self):
         """has_benefit('wa_snap') is True when has_snap=True (multi-WL variant)."""
-        self._seed_programs("wa_snap")
+        seed_program(self.white_label, "wa_snap")
         self.screen.has_snap = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -266,7 +262,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_false_when_user_does_not_have_wa_snap(self):
         """has_benefit('wa_snap') is False when has_snap=False."""
-        self._seed_programs("wa_snap")
+        seed_program(self.white_label, "wa_snap")
         self.screen.has_snap = False
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -275,7 +271,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_true_for_ma_head_start_when_user_has_head_start(self):
         """has_benefit('ma_head_start') is True when has_head_start=True."""
-        self._seed_programs("ma_head_start")
+        seed_program(self.white_label, "ma_head_start")
         self.screen.has_head_start = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -284,7 +280,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_false_for_ma_head_start_when_user_does_not_have_head_start(self):
         """has_benefit('ma_head_start') is False when has_head_start=False."""
-        self._seed_programs("ma_head_start")
+        seed_program(self.white_label, "ma_head_start")
         self.screen.has_head_start = False
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -293,7 +289,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_true_for_ma_early_head_start_when_user_has_early_head_start(self):
         """has_benefit('ma_early_head_start') is True when has_early_head_start=True."""
-        self._seed_programs("ma_early_head_start")
+        seed_program(self.white_label, "ma_early_head_start")
         self.screen.has_early_head_start = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -302,7 +298,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_returns_false_for_ma_early_head_start_when_user_does_not_have_early_head_start(self):
         """has_benefit('ma_early_head_start') is False when has_early_head_start=False."""
-        self._seed_programs("ma_early_head_start")
+        seed_program(self.white_label, "ma_early_head_start")
         self.screen.has_early_head_start = False
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -319,7 +315,7 @@ class TestScreen(TestCase):
         is True for both keys, validating that name fan-out works at the
         program-FK level on the join table.
         """
-        self._seed_programs("snap", "co_snap")
+        seed_program(self.white_label, "snap", "co_snap")
         self.screen.has_snap = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -329,7 +325,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_multi_wl_variants_tanf(self):
         """Same fan-out check for has_tanf → tanf / co_tanf / il_tanf."""
-        self._seed_programs("tanf", "co_tanf", "il_tanf")
+        seed_program(self.white_label, "tanf", "co_tanf", "il_tanf")
         self.screen.has_tanf = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -340,7 +336,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_compound_ssi_via_has_ssi_column(self):
         """ssi resolves True when has_ssi=True (one half of the OR)."""
-        self._seed_programs("ssi", "tx_ssi", "cesn_ssi")
+        seed_program(self.white_label, "ssi", "tx_ssi", "cesn_ssi")
         self.screen.has_ssi = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -355,7 +351,7 @@ class TestScreen(TestCase):
         even when has_ssi=False. This is the case that would silently break
         without the compound-at-write-time path.
         """
-        self._seed_programs("ssi")
+        seed_program(self.white_label, "ssi")
         self.screen.has_ssi = False
         self.screen.save()
         IncomeStream.objects.create(
@@ -371,7 +367,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_compound_ma_mass_health_via_has_medicaid(self):
         """ma_mass_health resolves True when has_medicaid=True."""
-        self._seed_programs("ma_mass_health")
+        seed_program(self.white_label, "ma_mass_health")
         self.screen.has_medicaid = True
         self.screen.save()
         sync_current_benefits(self.screen)
@@ -380,7 +376,7 @@ class TestScreen(TestCase):
 
     def test_has_benefit_compound_ma_mass_health_via_has_medicaid_hi(self):
         """ma_mass_health resolves True when only has_medicaid_hi=True."""
-        self._seed_programs("ma_mass_health")
+        seed_program(self.white_label, "ma_mass_health")
         self.screen.has_medicaid = False
         self.screen.has_medicaid_hi = True
         self.screen.save()
@@ -398,7 +394,9 @@ class TestScreen(TestCase):
         a CurrentBenefit on a different screen with the same program must
         not leak through.
         """
-        self._seed_programs("snap")
+        seed_program(self.white_label, "snap")
+        # zipcode is arbitrary — isolation is enforced by the screen FK on
+        # CurrentBenefit, not by anything zip-dependent.
         other_screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", household_size=1, completed=False
         )
@@ -415,7 +413,7 @@ class TestScreen(TestCase):
         N times must not issue N additional queries. The prefetch path serves
         the lookup from the in-memory cache.
         """
-        self._seed_programs("snap", "tanf", "wic", "ssi")
+        seed_program(self.white_label, "snap", "tanf", "wic", "ssi")
         self.screen.has_snap = True
         self.screen.has_tanf = True
         self.screen.save()

--- a/screener/tests/test_models.py
+++ b/screener/tests/test_models.py
@@ -228,7 +228,7 @@ class TestScreen(TestCase):
 
     # Tests for Screen.has_benefit() method
     #
-    # has_benefit() reads from the ScreenCurrentBenefit join table. Tests set
+    # has_benefit() reads from the CurrentBenefit join table. Tests set
     # has_* columns (still the canonical write target during the dual-write
     # phase) and invoke sync_current_benefits() to populate the join table —
     # mirroring what every POST/PATCH does in production.

--- a/screener/tests/test_models.py
+++ b/screener/tests/test_models.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Expense
 from screener.feature_flags import FeatureFlagConfig
+from screener.tests.helpers import seed_program, sync_current_benefits
 
 
 class TestScreen(TestCase):
@@ -226,86 +227,208 @@ class TestScreen(TestCase):
         self.assertEqual(result, 0)
 
     # Tests for Screen.has_benefit() method
+    #
+    # has_benefit() reads from the ScreenCurrentBenefit join table. Tests set
+    # has_* columns (still the canonical write target during the dual-write
+    # phase) and invoke sync_current_benefits() to populate the join table —
+    # mirroring what every POST/PATCH does in production.
+
+    def _seed_programs(self, *name_abbreviateds: str):
+        for name in name_abbreviateds:
+            seed_program(self.white_label, name)
 
     def test_has_benefit_returns_true_when_user_has_snap(self):
-        """
-        Test that has_benefit('tx_snap') returns True when user has SNAP.
-
-        When screen.has_snap is True, has_benefit('tx_snap') should return True,
-        indicating the user already receives this benefit and it should be filtered
-        from eligibility results.
-        """
+        """has_benefit('tx_snap') is True when has_snap=True and the join table is synced."""
+        self._seed_programs("tx_snap")
         self.screen.has_snap = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertTrue(self.screen.has_benefit("tx_snap"))
 
     def test_has_benefit_returns_false_when_user_does_not_have_snap(self):
-        """
-        Test that has_benefit('tx_snap') returns False when user does not have SNAP.
-
-        When screen.has_snap is False, has_benefit('tx_snap') should return False,
-        indicating the user does not currently receive this benefit and it should
-        appear in eligibility results.
-        """
+        """has_benefit('tx_snap') is False when has_snap=False."""
+        self._seed_programs("tx_snap")
         self.screen.has_snap = False
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("tx_snap"))
 
     def test_has_benefit_returns_true_when_user_has_wa_snap(self):
-        """
-        Test that has_benefit('wa_snap') returns True when user has SNAP.
-        """
+        """has_benefit('wa_snap') is True when has_snap=True (multi-WL variant)."""
+        self._seed_programs("wa_snap")
         self.screen.has_snap = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertTrue(self.screen.has_benefit("wa_snap"))
 
     def test_has_benefit_returns_false_when_user_does_not_have_wa_snap(self):
-        """
-        Test that has_benefit('wa_snap') returns False when user does not have SNAP.
-        """
+        """has_benefit('wa_snap') is False when has_snap=False."""
+        self._seed_programs("wa_snap")
         self.screen.has_snap = False
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("wa_snap"))
 
     def test_has_benefit_returns_true_for_ma_head_start_when_user_has_head_start(self):
-        """
-        Test that has_benefit('ma_head_start') returns True when user has Head Start.
-        """
+        """has_benefit('ma_head_start') is True when has_head_start=True."""
+        self._seed_programs("ma_head_start")
         self.screen.has_head_start = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertTrue(self.screen.has_benefit("ma_head_start"))
 
     def test_has_benefit_returns_false_for_ma_head_start_when_user_does_not_have_head_start(self):
-        """
-        Test that has_benefit('ma_head_start') returns False when user does not have Head Start.
-        """
+        """has_benefit('ma_head_start') is False when has_head_start=False."""
+        self._seed_programs("ma_head_start")
         self.screen.has_head_start = False
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("ma_head_start"))
 
     def test_has_benefit_returns_true_for_ma_early_head_start_when_user_has_early_head_start(self):
-        """
-        Test that has_benefit('ma_early_head_start') returns True when user has Early Head Start.
-        """
+        """has_benefit('ma_early_head_start') is True when has_early_head_start=True."""
+        self._seed_programs("ma_early_head_start")
         self.screen.has_early_head_start = True
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertTrue(self.screen.has_benefit("ma_early_head_start"))
 
     def test_has_benefit_returns_false_for_ma_early_head_start_when_user_does_not_have_early_head_start(self):
-        """
-        Test that has_benefit('ma_early_head_start') returns False when user does not have Early Head Start.
-        """
+        """has_benefit('ma_early_head_start') is False when has_early_head_start=False."""
+        self._seed_programs("ma_early_head_start")
         self.screen.has_early_head_start = False
         self.screen.save()
+        sync_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("ma_early_head_start"))
+
+    # Cross-cutting cases — these are the ones MFB-719 specifically wants to
+    # lock in: multi-WL variants over the same column, compound conditions
+    # resolved at write time, and no N+1 on the eligibility read path.
+
+    def test_has_benefit_multi_wl_variants_resolve_to_same_column(self):
+        """
+        Both 'snap' and 'co_snap' point at has_snap. After sync, has_benefit
+        is True for both keys, validating that name fan-out works at the
+        program-FK level on the join table.
+        """
+        self._seed_programs("snap", "co_snap")
+        self.screen.has_snap = True
+        self.screen.save()
+        sync_current_benefits(self.screen)
+
+        self.assertTrue(self.screen.has_benefit("snap"))
+        self.assertTrue(self.screen.has_benefit("co_snap"))
+
+    def test_has_benefit_multi_wl_variants_tanf(self):
+        """Same fan-out check for has_tanf → tanf / co_tanf / il_tanf."""
+        self._seed_programs("tanf", "co_tanf", "il_tanf")
+        self.screen.has_tanf = True
+        self.screen.save()
+        sync_current_benefits(self.screen)
+
+        self.assertTrue(self.screen.has_benefit("tanf"))
+        self.assertTrue(self.screen.has_benefit("co_tanf"))
+        self.assertTrue(self.screen.has_benefit("il_tanf"))
+
+    def test_has_benefit_compound_ssi_via_has_ssi_column(self):
+        """ssi resolves True when has_ssi=True (one half of the OR)."""
+        self._seed_programs("ssi", "tx_ssi", "cesn_ssi")
+        self.screen.has_ssi = True
+        self.screen.save()
+        sync_current_benefits(self.screen)
+
+        self.assertTrue(self.screen.has_benefit("ssi"))
+        self.assertTrue(self.screen.has_benefit("tx_ssi"))
+        self.assertTrue(self.screen.has_benefit("cesn_ssi"))
+
+    def test_has_benefit_compound_ssi_via_ssi_income(self):
+        """
+        ssi resolves True via reported sSI income (the other half of the OR),
+        even when has_ssi=False. This is the case that would silently break
+        without the compound-at-write-time path.
+        """
+        self._seed_programs("ssi")
+        self.screen.has_ssi = False
+        self.screen.save()
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="sSI",
+            amount=500,
+            frequency="monthly",
+        )
+        sync_current_benefits(self.screen)
+
+        self.assertTrue(self.screen.has_benefit("ssi"))
+
+    def test_has_benefit_compound_ma_mass_health_via_has_medicaid(self):
+        """ma_mass_health resolves True when has_medicaid=True."""
+        self._seed_programs("ma_mass_health")
+        self.screen.has_medicaid = True
+        self.screen.save()
+        sync_current_benefits(self.screen)
+
+        self.assertTrue(self.screen.has_benefit("ma_mass_health"))
+
+    def test_has_benefit_compound_ma_mass_health_via_has_medicaid_hi(self):
+        """ma_mass_health resolves True when only has_medicaid_hi=True."""
+        self._seed_programs("ma_mass_health")
+        self.screen.has_medicaid = False
+        self.screen.has_medicaid_hi = True
+        self.screen.save()
+        sync_current_benefits(self.screen)
+
+        self.assertTrue(self.screen.has_benefit("ma_mass_health"))
+
+    def test_has_benefit_unknown_program_returns_false(self):
+        """Unknown name_abbreviated returns False (no row in join table)."""
+        self.assertFalse(self.screen.has_benefit("not_a_real_program"))
+
+    def test_has_benefit_only_matches_screen_owned_rows(self):
+        """
+        has_benefit only returns True for rows on this screen's join table —
+        a CurrentBenefit on a different screen with the same program must
+        not leak through.
+        """
+        self._seed_programs("snap")
+        other_screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="78701", household_size=1, completed=False
+        )
+        other_screen.has_snap = True
+        other_screen.save()
+        sync_current_benefits(other_screen)
+
+        # self.screen has no current_benefits rows
+        self.assertFalse(self.screen.has_benefit("snap"))
+
+    def test_has_benefit_no_n_plus_one_with_prefetch(self):
+        """
+        When current_benefits__program is prefetched, calling has_benefit()
+        N times must not issue N additional queries. The prefetch path serves
+        the lookup from the in-memory cache.
+        """
+        self._seed_programs("snap", "tanf", "wic", "ssi")
+        self.screen.has_snap = True
+        self.screen.has_tanf = True
+        self.screen.save()
+        sync_current_benefits(self.screen)
+
+        prefetched = Screen.objects.prefetch_related("current_benefits__program").get(pk=self.screen.pk)
+
+        # 0 queries: prefetch already loaded current_benefits + program
+        with self.assertNumQueries(0):
+            self.assertTrue(prefetched.has_benefit("snap"))
+            self.assertTrue(prefetched.has_benefit("tanf"))
+            self.assertFalse(prefetched.has_benefit("wic"))
+            self.assertFalse(prefetched.has_benefit("ssi"))
 
     # Tests for Screen.other_tax_unit_structure() method
 

--- a/screener/views.py
+++ b/screener/views.py
@@ -146,6 +146,7 @@ class EligibilityTranslationView(views.APIView):
             "household_members__energy_calculator",
             "expenses",
             "energy_calculator",
+            "current_benefits__program",
         ).get(uuid=id)
 
         is_admin = request.query_params.get("admin")


### PR DESCRIPTION
## Context & Motivation

Step 3a of the [New Current Benefits Workflow](https://linear.app/myfriendben/issue/MFB-719) milestone. Step 2 (MFB-718) ships dual-write to the `ScreenCurrentBenefit` join table. This PR is the read-side flip: `Screen.has_benefit()` now queries the join table instead of routing through `_build_benefit_map()`, which was assembling a name→has_* dict on every call.

The `has_*` columns are still written by the serializer and synced to the join table on every POST/PATCH via `_sync_current_benefits()`, so this change is reversible by reverting this commit — the source data stays intact.

Linear: [MFB-719](https://linear.app/myfriendben/issue/MFB-719/cb-step-3a-switch-has_benefit-reads-to-join-table-benefits-api)
Blocked by: MFB-718 (shipped)
Blocks: MFB-869 (Step 5 — flip writes)

## Changes Made

- `Screen.has_benefit()` now reads from `CurrentBenefit` via a `@cached_property` set of `name_abbreviated` strings. With `current_benefits__program` prefetched: 0 queries per call. Without prefetch: one query on first access (loads the set once), 0 thereafter for the lifetime of the instance.
- `EligibilityTranslationView.get()` adds `current_benefits__program` to its `prefetch_related` so the per-program `already_has` lookup loop in `eligibility_results()` runs from cache.
- `_build_benefit_map()` is **kept** — it is still used by `_sync_current_benefits()` (the dual-write path) and by the new test helper's inlined dual-write body. It will be removed in MFB-869 once writes flip. Docstring updated to reflect this lifecycle.
- `HouseholdMember.has_benefit()` (insurance / member-level) is **unchanged** — `chp`, `medicaid`, `emergency_medicaid` etc. still go through `self.insurance.*`. (Follow-up cleanup tracked separately in MFB-1084: rename to `has_insurance()` and drop redundant `name_map`.)
- New shared test helper `screener/tests/helpers.py` with `seed_program(white_label, *names)` and `sync_current_benefits(screen)`. The helper's sync body is **inlined** (does not import the serializer's private `_sync_current_benefits`) so it owns its behavior and survives MFB-869 cleanup. Module docstring spells out the MFB-720 end-of-life.
- Existing model tests for `has_benefit()` updated to exercise the real write→sync→read pipeline.
- New tests added covering:
  - Compound `ssi` via `has_ssi` column
  - Compound `ssi` via reported sSI income (the case that would silently break without write-time compounds)
  - Compound `ma_mass_health` via `has_medicaid` and via `has_medicaid_hi`
  - Multi-WL variants: `snap` / `co_snap` and `tanf` / `co_tanf` / `il_tanf` all resolve correctly from the same underlying `has_*` column
  - Unknown `name_abbreviated` returns `False`
  - Cross-screen isolation (rows on screen A do not leak to screen B)
  - `assertNumQueries(0)` after `prefetch_related('current_benefits__program')` — locks in the no-N+1 contract
- Four downstream test files updated to use the new helper (they previously set `has_*=True` and called `has_benefit()` indirectly, which no longer works without a join-table row):
  - `programs/programs/policyengine/calculators/dependencies/tests/test_spm.py`
  - `programs/programs/il/nurse_family_partnership/tests.py`
  - `programs/programs/urgent_needs/tx/test_urgent_needs_functions.py`
  - `programs/programs/wa/nslp/tests.py`

## Testing

- Migrations to run: none (join table and dual-write already shipped in Steps 1 & 2)
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. Run `pytest -q -m "not integration"` — full suite passes (1608 passed, 19 skipped). Pre-existing collection failures in `validations/management/commands/tests/` (missing `jsonschema`) and `translations/management/commands/tests/test_check_readability.py` (missing `textstat`) are unrelated.
  2. Submit a screen with `current_benefits: ["snap"]` and verify the results page filters SNAP via the `already_has` flag.
  3. Submit a screen with `has_ssi=false` plus a reported sSI income stream and verify SSI is still filtered (compound condition).
  4. Verify multi-WL variants (e.g. CO screen with `has_snap=true`) filter both `snap` and `co_snap` entries from results.

## Deployment

- Post-deployment scripts needed: none — Step 2 backfill is already in place.
- Production config updates: none.
- Admin updates needed: none.
- Notify team/users of: nothing user-visible. This is an internal read-path swap.

## Notes for Reviewers

- The `_build_benefit_map()` dict is intentionally left in place. Removing it is Step 5 (MFB-869) — it gets dropped together with `_sync_current_benefits` once writes flip. Step 6 (MFB-720) then drops the `has_*` columns and deletes the test helper.
- The code now carries inline lifecycle markers pointing at MFB-869 (delete `_build_benefit_map` + `_sync_current_benefits`) and MFB-720 (drop `has_*` columns, delete the test helper). MFB-869 and MFB-720 ticket descriptions were updated in lockstep to reference the exact files/symbols that need cleanup.
- Rollback path: `git revert` this commit. The `has_*` columns are still being written, so the previous behavior returns immediately.
- **Known limitations:**
  - **Cache staleness on the same instance.** `Screen.has_benefit()` is backed by a `@cached_property` set. A Screen loaded *before* a write will not see rows written after, even on the same instance. The eligibility hot path is safe — the view fetches a fresh Screen on every request. Ad-hoc admin actions or management commands that mutate `has_*` columns and then call `has_benefit()` on the same instance must refetch the screen between write and read. The staleness concern is called out inline in `screener/models.py` and disappears in MFB-720 when `has_*` writes go away.
  - **One query per Screen without prefetch.** Callers that load a Screen without `prefetch_related('current_benefits__program')` will issue one query on the first `has_benefit()` call (set fetch); subsequent calls on the same instance are 0 queries. Audited callers — the only N-per-screen caller is `eligibility_results()`, which now prefetches.
- Future considerations: MFB-869 makes the join table the primary write target and replaces `_sync_current_benefits()` with direct join-table writes from the serializer. MFB-720 drops the `has_*` columns and deletes the test helper. MFB-1084 (out-of-band) renames the member-level `has_benefit` to `has_insurance` to remove the cross-domain naming collision.