### PR TITLE
MFB-929: WA WIC and WA SNAP -> shown in has_benefits

### DIFF
--- a/programs/management/commands/import_program_config_data/data/wa_snap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_snap_initial_config.json
@@ -26,7 +26,8 @@
     "estimated_application_time": "45 - 90 minutes",
     "estimated_delivery_time": "30 days",
     "estimated_value": "",
-    "website_description": "Monthly assistance to buy food"
+    "website_description": "Monthly assistance to buy food",
+    "show_in_has_benefits_step": true
   },
   "documents": [
     {

--- a/programs/management/commands/import_program_config_data/data/wa_wic_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wic_initial_config.json
@@ -22,7 +22,7 @@
         "website_description": "WIC provides healthy food and nutrition support for pregnant people, new parents, and children under age five",
         "show_on_current_benefits": true,
         "has_calculator": true,
-        "show_in_has_benefits_step": false
+        "show_in_has_benefits_step": true
     },
     "documents": [
         {


### PR DESCRIPTION
Because they provide categorical eligibility for ORCA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * SNAP and WIC programs are now visible in the benefits eligibility assessment step, allowing users to evaluate these programs during the benefits screening process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/benefits-api/pull/1552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->