### PR TITLE
MFB-928: Small bug fix to point to `wa_snap` instead of `snap`

### DIFF
--- a/programs/programs/wa/udp/calculator.py
+++ b/programs/programs/wa/udp/calculator.py
@@ -124,7 +124,7 @@ class WaUdp(ProgramCalculator):
 
         # Financial pathway: SSI categorical (Criterion 4) OR SNAP streamlined (Criterion 5)
         # OR standard income test (Criteria 2+3)
-        if self._has_ssi_recipient() or self.screen.has_benefit("snap"):
+        if self._has_ssi_recipient() or self.screen.has_benefit("wa_snap"):
             e.condition(True, messages.presumed_eligibility())
         else:
             adult_income = self._adult_income_yearly()

--- a/programs/programs/wa/udp/tests/test_udp.py
+++ b/programs/programs/wa/udp/tests/test_udp.py
@@ -34,7 +34,7 @@ def make_calculator(
     mock_screen.zipcode = zipcode
     mock_screen.county = county
     mock_screen.household_size = household_size
-    mock_screen.has_benefit = Mock(side_effect=lambda b: has_snap if b == "snap" else False)
+    mock_screen.has_benefit = Mock(side_effect=lambda b: has_snap if b == "wa_snap" else False)
     mock_screen.household_members.all = Mock(
         return_value=members if members is not None else [make_member(age=35, yearly_income=24_000)]
     )


### PR DESCRIPTION
Pointing calculator to wa_snap instead of snap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SNAP eligibility requirements to recognize additional benefit statuses. Households with these benefits will now qualify as presumed eligible under the streamlined financial pathway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->