### PR TITLE
MFB-1110: CESN UBP honors household-level Medicaid for presumptive eligibility

### DIFF
--- a/programs/migrations/0157_recreate_cesn_medicaid_tracking_program.py
+++ b/programs/migrations/0157_recreate_cesn_medicaid_tracking_program.py
@@ -1,6 +1,5 @@
 from django.db import migrations
 
-
 # Re-create the CESN Medicaid tracking-only program.
 #
 # History: cesn_medicaid was created in 0137_create_tracking_programs, then

--- a/programs/migrations/0157_recreate_cesn_medicaid_tracking_program.py
+++ b/programs/migrations/0157_recreate_cesn_medicaid_tracking_program.py
@@ -1,0 +1,99 @@
+from django.db import migrations
+
+
+# Re-create the CESN Medicaid tracking-only program.
+#
+# History: cesn_medicaid was created in 0137_create_tracking_programs, then
+# removed — audited out of the has-benefits step in 0142 and deleted in
+# 0143_delete_cesn_chp_medicaid (alongside cesn_chp). cesn_chp stays removed
+# because CHP+ is captured per-member via member.insurance.chp; CESN Medicaid,
+# however, has no insurance step (CESN does not collect health insurance), so it
+# must be captured at the household level via the "already has benefits" step.
+#
+# This program is tracking-only (has_calculator=False). It exists so a CESN user
+# can declare they already receive Medicaid; that declaration sets Screen.has_medicaid,
+# which drives presumptive eligibility for Utility Bill Pay (cesn_ubp) — see MFB-1110.
+#
+# NOTE: cesn_chp is intentionally NOT re-added.
+
+PROGRAM = {
+    "white_label_code": "cesn",
+    "name_abbreviated": "cesn_medicaid",
+    "name_text": "Health First Colorado (Medicaid)",
+    "description_text": "Free / low-cost public health insurance",
+    "base_program": "medicaid",
+}
+
+
+def create_cesn_medicaid(apps, schema_editor):
+    """
+    Mirrors programs/migrations/0137_create_tracking_programs.py. Uses real model
+    imports because Program.objects.new_program() handles the Translation FK
+    creation that historical models can't support.
+    """
+    from programs.models import Program
+    from screener.models import WhiteLabel
+    from translations.models import Translation
+
+    p = PROGRAM
+
+    # Skip if white label doesn't exist (e.g. in CI test databases).
+    if not WhiteLabel.objects.filter(code=p["white_label_code"]).exists():
+        return
+
+    existing = Program.objects.filter(
+        white_label__code=p["white_label_code"],
+        name_abbreviated=p["name_abbreviated"],
+    ).first()
+
+    if existing:
+        program = existing
+        program.active = False
+        program.has_calculator = False
+        program.show_in_has_benefits_step = True
+        program.base_program = p.get("base_program")
+        program.save()
+    else:
+        program = Program.objects.new_program(
+            white_label=p["white_label_code"],
+            name_abbreviated=p["name_abbreviated"],
+        )
+        program.active = False
+        program.has_calculator = False
+        program.show_in_has_benefits_step = True
+        program.base_program = p.get("base_program")
+        program.save()
+
+    # add_translation calls set_current_language() before saving, which is required
+    # for parler to write to the correct language row in a migration context.
+    Translation.objects.add_translation(
+        f"program.{p['name_abbreviated']}_{program.id}-name",
+        default_message=p["name_text"],
+    )
+    Translation.objects.add_translation(
+        f"program.{p['name_abbreviated']}_{program.id}-description_short",
+        default_message=p["description_text"],
+    )
+    Translation.objects.add_translation(
+        f"program.{p['name_abbreviated']}_{program.id}-website_description",
+        default_message=p["description_text"],
+    )
+
+
+def delete_cesn_medicaid(apps, schema_editor):
+    Program = apps.get_model("programs", "Program")
+    Program.objects.filter(
+        white_label__code=PROGRAM["white_label_code"],
+        name_abbreviated=PROGRAM["name_abbreviated"],
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0156_deactivate_co_my_spark"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_cesn_medicaid, delete_cesn_medicaid),
+    ]

--- a/programs/programs/co/energy_calculator/utility_bill_pay/calculator.py
+++ b/programs/programs/co/energy_calculator/utility_bill_pay/calculator.py
@@ -5,6 +5,12 @@ from programs.programs.co.utility_bill_pay.calculator import UtilityBillPay
 
 class EnergyCalculatorUtilityBillPay(UtilityBillPay):
     dependencies = [*UtilityBillPay.dependencies, "energy_calculator"]
+    # CESN does not collect health insurance, so the base member-level Medicaid
+    # check (member_presumptive_eligibility) never fires. CESN instead collects
+    # Medicaid at the household level via the "already has benefits" step, so add
+    # it to the household-level presumptive set here. Only regular Medicaid has a
+    # household-level field; chp/emergency_medicaid remain member-level only.
+    presumptive_eligibility = (*UtilityBillPay.presumptive_eligibility, "medicaid")
     electricity_providers = ["co-xcel-energy", "co-black-hills-energy"]
     gas_providers = [
         "co-atmos-energy",

--- a/programs/programs/co/energy_calculator/utility_bill_pay/tests.py
+++ b/programs/programs/co/energy_calculator/utility_bill_pay/tests.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from programs.programs.calc import Eligibility
+from programs.programs.co.energy_calculator.utility_bill_pay.calculator import (
+    EnergyCalculatorUtilityBillPay,
+)
+from programs.programs.co.utility_bill_pay.calculator import UtilityBillPay
+
+
+class TestEnergyCalculatorUtilityBillPayPresumptiveMedicaid(SimpleTestCase):
+    """
+    CESN does not collect health insurance, so the base member-level Medicaid
+    check never fires for CESN. CESN collects Medicaid at the household level via
+    the "already has benefits" step, so the CESN UBP calculator adds "medicaid" to
+    the household-level `presumptive_eligibility` tuple. These tests exercise that
+    household-level branch directly (calling household_eligible) rather than the
+    full calc() pipeline, which needs a Program row + dependency wiring.
+    """
+
+    def _build_calculator(self, has_benefit_names):
+        """
+        Build an EnergyCalculatorUtilityBillPay with a stubbed screen.
+
+        - screen.has_benefit returns True only for names in `has_benefit_names`
+          (the household-level "already has benefits" signal).
+        - household_members is empty so the member-level insurance branch is a
+          no-op (mirrors CESN, which never collects insurance).
+        - the utility-provider check the CESN subclass adds is forced True so we
+          isolate the presumptive logic.
+        """
+        screen = MagicMock()
+        screen.has_benefit.side_effect = lambda name: name in has_benefit_names
+        screen.household_members.all.return_value = []
+        screen.energy_calculator.has_utility_provider.return_value = True
+
+        calculator = EnergyCalculatorUtilityBillPay(
+            screen=screen,
+            program=MagicMock(),
+            data={},
+            missing_dependencies=MagicMock(),
+        )
+        return calculator
+
+    def test_medicaid_in_household_presumptive_tuple(self):
+        # The CESN subclass extends the base household-level tuple with "medicaid".
+        self.assertIn("medicaid", EnergyCalculatorUtilityBillPay.presumptive_eligibility)
+        for benefit in UtilityBillPay.presumptive_eligibility:
+            self.assertIn(benefit, EnergyCalculatorUtilityBillPay.presumptive_eligibility)
+
+    def test_base_co_ubp_does_not_include_medicaid(self):
+        # The plain `co` white label must be unaffected: base stays member-level only.
+        self.assertNotIn("medicaid", UtilityBillPay.presumptive_eligibility)
+
+    def test_household_with_medicaid_is_presumptively_eligible(self):
+        calculator = self._build_calculator(has_benefit_names={"medicaid"})
+
+        e = Eligibility()
+        calculator.household_eligible(e)
+
+        # Presumed eligible via household Medicaid; income/expense test is skipped.
+        self.assertTrue(e.eligible)
+
+    def test_household_without_medicaid_is_not_presumptively_eligible(self):
+        # No presumptive benefit and no household members -> falls through to the
+        # income/expense path, which fails with an empty stubbed screen.
+        calculator = self._build_calculator(has_benefit_names=set())
+
+        e = Eligibility()
+        calculator.household_eligible(e)
+
+        self.assertFalse(e.eligible)


### PR DESCRIPTION
## Context & Motivation

A CESN partner asked why Medicaid is not in CESN's "already has benefits" list. Investigation found that Medicaid *is* relevant to CESN results, but the current logic can never act on it for CESN.

The Utility Bill Pay calculator (`cesn_ubp` → `EnergyCalculatorUtilityBillPay`, extending base `UtilityBillPay`) treats Medicaid as a presumptive-eligibility pathway — a household with Medicaid is presumed eligible regardless of income. But that check runs through **member-level insurance**:

```python
member_presumptive_eligibility = ("co_medicaid", "emergency_medicaid", "chp")
# resolved via member.has_benefit(...) -> member.insurance.medicaid
```

CESN does **not** collect health insurance (`health_insurance_options = {"you": {}, "them": {}}` in `configuration/white_labels/cesn.py`), so `member.insurance.medicaid` is always `False` for CESN screens — the Medicaid presumptive pathway is dead for CESN.

CESN *can* collect Medicaid at the **household level** via the "already has benefits" step (`Screen.has_medicaid` → `Screen.has_benefit("medicaid")`), independent of the insurance step. The base calculator's household-level presumptive check is `presumptive_eligibility` (resolved via `self.screen.has_benefit(...)`).

- Frontend PR: MyFriendBen/benefits-calculator#2121
- Linear: MFB-1110

## Changes Made

- **Calculator** (`energy_calculator/utility_bill_pay/calculator.py`): add `"medicaid"` to the household-level `presumptive_eligibility` tuple on the **CESN subclass `EnergyCalculatorUtilityBillPay` only**. Base `UtilityBillPay` (plain `co`) is **left unchanged** — non-CESN white labels intentionally check Medicaid at the member/insurance level only and don't show Medicaid on their already-has step.
- **Migration 0157** (`0157_recreate_cesn_medicaid_tracking_program.py`): re-create the `cesn_medicaid` tracking-only program (`has_calculator=False`, `show_in_has_benefits_step=True`, `base_program=medicaid`). It was created in 0137, then audited out in 0142 and deleted in 0143 alongside `cesn_chp`. CHP+ stays removed (captured per-member via insurance); CESN Medicaid must be household-level because CESN has no insurance step. `cesn_chp` is intentionally NOT re-added.
- **Tests** (`energy_calculator/utility_bill_pay/tests.py`): cover the household-level presumptive branch and guard that base `co` does not include `"medicaid"`.
- Scope: only regular Medicaid (`has_medicaid`) is honored at the household level. `chp` / `emergency_medicaid` have no household field and remain member-level only (no effect for CESN). Confirmed acceptable.

## Testing

- Migrations to run: `python manage.py migrate programs` (applies 0157, re-creates the `cesn_medicaid` program + translations)
- Configuration updates needed: none — the program re-add IS the config (tile is data-driven from `getHasBenefitsPrograms`)
- Environment variables/settings to add: none
- Manual testing steps:
  - `python manage.py test programs.programs.co.energy_calculator.utility_bill_pay` (4 tests pass)
  - After migrate + FE PR #2121: on a CESN screen, confirm a "Health First Colorado (Medicaid)" tile shows on the already-has step; a household selecting it is eligible for Utility Bill Pay without meeting the income test. Confirm the 5 UBP-dependent CESN programs (xceleap, bheap, gas affordability variants, cngba, poipp) reflect the change.

## Deployment

- Post-deployment scripts needed: migration 0157 runs automatically on release (creates the `cesn_medicaid` program). Verify the program exists per env.
- Production config: none beyond the migration
- Admin updates needed: confirm `cesn_medicaid` is present + `show_in_has_benefits_step=True` after deploy
- Notify team/users of: CESN partner who raised the question; coordinate with FE PR #2121 (deploy this first)

## Notes for Reviewers

- Known limitations: regular Medicaid only at the household level for CESN; CHP+ / Emergency Medicaid remain member-level (no household field).
- Future considerations: MFB-720 drops the `has_*` columns; `Screen.has_benefit("medicaid")` already reads the join table, so it continues working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)