### PR TITLE
MFB-1102: send meets_ssi_disability_criteria for SSI (frontier)

### DIFF
--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -141,6 +141,7 @@ class Ssi(PolicyEngineMembersCalculator):
         dependency.member.SsiReportedDependency,
         dependency.member.IsBlindDependency,
         dependency.member.IsDisabledDependency,
+        dependency.member.MeetsSsiDisabilityCriteriaDependency,
         dependency.member.SsiEarnedIncomeDependency,
         dependency.member.SsiUnearnedIncomeDependency,
         dependency.member.AgeDependency,

--- a/programs/programs/policyengine/calculators/dependencies/base.py
+++ b/programs/programs/policyengine/calculators/dependencies/base.py
@@ -12,14 +12,22 @@ class PolicyEngineScreenInput:
     field = ""
     dependencies = tuple()
 
-    # Minimum PolicyEngine package version (major, minor, patch) that defines this
-    # variable. Empty = available in all versions. pe_input() omits a dependency whose
-    # min_pe_version exceeds the resolved request version, so a frontier-only variable
-    # isn't sent to an older model (which would 400 the whole request).
+    # PolicyEngine package-version window (major, minor, patch tuples) in which this
+    # variable exists, so pe_input() never sends a variable to a model that doesn't
+    # define it (which would 400 the whole request). Both bounds are optional:
+    #   min_pe_version  - first version that defines it; () = no floor (always existed)
+    #   max_pe_version  - last version that still defines it; () = no ceiling (current)
+    # Examples:
+    #   new variable (added 1.715.2):     min_pe_version = (1, 715, 2)
+    #   removed variable (dropped after X): max_pe_version = (last version that had it)
+    #   windowed variable (existed A..B):  min_pe_version = A; max_pe_version = B
     #
-    # Scope: this only gates whether a variable is SENT (add/remove across versions).
-    # It does NOT handle a variable whose accepted value/format changes per version
+    # Scope: this gates whether a variable is SENT (add/remove across versions). It does
+    # NOT handle a variable whose accepted value/format changes per version (e.g.
+    # county_str -> county_fips); value() has no access to the resolved version today.
+    # Design that against the first real value-changing migration (MFB-1104).
     min_pe_version: tuple = ()
+    max_pe_version: tuple = ()
 
     def __init__(self, screen: Screen, members: List[HouseholdMember], relationship_map):
         self.screen = screen

--- a/programs/programs/policyengine/calculators/dependencies/base.py
+++ b/programs/programs/policyengine/calculators/dependencies/base.py
@@ -12,6 +12,15 @@ class PolicyEngineScreenInput:
     field = ""
     dependencies = tuple()
 
+    # Minimum PolicyEngine package version (major, minor, patch) that defines this
+    # variable. Empty = available in all versions. pe_input() omits a dependency whose
+    # min_pe_version exceeds the resolved request version, so a frontier-only variable
+    # isn't sent to an older model (which would 400 the whole request).
+    #
+    # Scope: this only gates whether a variable is SENT (add/remove across versions).
+    # It does NOT handle a variable whose accepted value/format changes per version
+    min_pe_version: tuple = ()
+
     def __init__(self, screen: Screen, members: List[HouseholdMember], relationship_map):
         self.screen = screen
         self.members = members

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -136,6 +136,24 @@ class IsDisabledDependency(Member):
         return self.member.disabled or self.member.long_term_disability or self.member.visually_impaired
 
 
+class MeetsSsiDisabilityCriteriaDependency(Member):
+    """
+    PolicyEngine frontier (policyengine-us 1.715.2) requires this person input to
+    classify someone as SSI-disabled — it no longer falls back to is_disabled /
+    reported SSI receipt. Without it, a disabled non-aged/non-blind person gets
+    ssi: 0 (MFB-1102).
+
+    Source mirrors IsDisabledDependency for now. NOTE: pending PolicyEngine
+    confirmation on whether this should match "meets SSA disability criteria"
+    exactly (e.g. excluding blindness, which SSI treats as a separate category).
+    """
+
+    field = "meets_ssi_disability_criteria"
+
+    def value(self):
+        return self.member.disabled or self.member.long_term_disability or self.member.visually_impaired
+
+
 class MedicalExpenseDependency(Member):
     """
     Medical expenses for PolicyEngine SNAP and other deduction calculations.

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -143,12 +143,16 @@ class MeetsSsiDisabilityCriteriaDependency(Member):
     reported SSI receipt. Without it, a disabled non-aged/non-blind person gets
     ssi: 0 (MFB-1102).
 
-    Source mirrors IsDisabledDependency for now. NOTE: pending PolicyEngine
-    confirmation on whether this should match "meets SSA disability criteria"
-    exactly (e.g. excluding blindness, which SSI treats as a separate category).
+    Source mirrors IsDisabledDependency: SSI eligibility is
+    is_ssi_aged OR is_blind OR is_ssi_disabled (verified in policyengine-us source),
+    so including blindness here only adds to an OR and can never reduce eligibility.
+
+    min_pe_version gates this so it's only sent to models that define the variable —
+    it does not exist in 1.691.1 (current), where sending it 400s the whole request.
     """
 
     field = "meets_ssi_disability_criteria"
+    min_pe_version = (1, 715, 2)
 
     def value(self):
         return self.member.disabled or self.member.long_term_disability or self.member.visually_impaired

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -42,6 +42,44 @@ class TestAgeDependency(TestCase):
         self.assertEqual(dep.field, "is_disabled")
 
 
+class TestMeetsSsiDisabilityCriteriaDependency(TestCase):
+    """Tests for MeetsSsiDisabilityCriteriaDependency, required by PolicyEngine frontier
+    to classify a person as SSI-disabled (MFB-1102)."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=1,
+            completed=False,
+        )
+
+    def _member(self, **kwargs):
+        return HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40, **kwargs)
+
+    def test_field_name(self):
+        dep = member.MeetsSsiDisabilityCriteriaDependency(self.screen, self._member(), {})
+        self.assertEqual(dep.field, "meets_ssi_disability_criteria")
+
+    def test_true_when_disabled(self):
+        dep = member.MeetsSsiDisabilityCriteriaDependency(self.screen, self._member(disabled=True), {})
+        self.assertTrue(dep.value())
+
+    def test_true_when_long_term_disability(self):
+        dep = member.MeetsSsiDisabilityCriteriaDependency(self.screen, self._member(long_term_disability=True), {})
+        self.assertTrue(dep.value())
+
+    def test_true_when_visually_impaired(self):
+        dep = member.MeetsSsiDisabilityCriteriaDependency(self.screen, self._member(visually_impaired=True), {})
+        self.assertTrue(dep.value())
+
+    def test_falsy_when_none_apply(self):
+        dep = member.MeetsSsiDisabilityCriteriaDependency(self.screen, self._member(), {})
+        self.assertFalse(dep.value())
+
+
 class TestMemberExpenseDependency(TestCase):
     """Tests for member-level expense dependency classes: SnapChildSupportDependency, PropertyTaxExpenseDependency, and MedicalExpenseDependency."""
 

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -104,6 +104,11 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
             "marital_units": {},
         }
     }
+    # Resolve once: used both to gate version-specific inputs below and to set the
+    # top-level "version" field. None => no pin (PolicyEngine's current default).
+    version = pe_versions.determine_pe_version(pe_version)
+    comparable_version = pe_versions.to_comparable_pe_version(version)
+
     members: list[HouseholdMember] = screen.household_members.all()
     relationship_map = screen.relationship_map()
 
@@ -137,6 +142,17 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
 
     for program in programs:
         for Data in program.pe_inputs + program.pe_outputs:
+            # Skip inputs that the resolved model version doesn't define yet — sending
+            # an unknown variable 400s the whole request (e.g. meets_ssi_disability_criteria
+            # on 1.691.1). With no pin (comparable_version is None) we omit gated inputs
+            # too, since the unpinned default is the current model that lacks them.
+            if not pe_versions.version_supports(
+                comparable_version,
+                getattr(Data, "min_pe_version", ()),
+                getattr(Data, "max_pe_version", ()),
+            ):
+                continue
+
             period = program.pe_period
             if hasattr(program, "pe_output_period") and Data in program.pe_outputs:
                 period = program.pe_output_period
@@ -170,7 +186,6 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
         del raw_input["household"]["tax_units"][SECONDARY_TAX_UNIT]
 
     # Inject the resolved version (override > config); None means omit the field.
-    version = pe_versions.determine_pe_version(pe_version)
     if version is not None:
         raw_input["version"] = version
 

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -144,10 +144,17 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
         for Data in program.pe_inputs + program.pe_outputs:
             # Skip inputs that the resolved model version doesn't define yet — sending
             # an unknown variable 400s the whole request (e.g. meets_ssi_disability_criteria
+<<<<<<< HEAD
             # on 1.691.1). With no pin (comparable_version is None) we omit gated inputs
             # too, since the unpinned default is the current model that lacks them.
             if not pe_versions.version_supports(
                 comparable_version,
+=======
+            # on 1.691.1). With no pin (parsed_version is None) we omit gated inputs too,
+            # since the unpinned default is the current model that lacks them.
+            if not _version_supports(
+                parsed_version,
+>>>>>>> c6aff7e3 (MFB-1102: add max_pe_version — full version-window gating (all 3 shapes))
                 getattr(Data, "min_pe_version", ()),
                 getattr(Data, "max_pe_version", ()),
             ):

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -104,8 +104,10 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
             "marital_units": {},
         }
     }
-    # Resolve once: used both to gate version-specific inputs below and to set the
-    # top-level "version" field. None => no pin (PolicyEngine's current default).
+    # Two values from one resolved version, for two consumers:
+    #   version (string)            -> version to send in PE API request body (if None/omitted,
+    #                                   PE defaults to current version)
+    #   comparable_version (tuple)  -> tuple representation to gate which inputs are sent
     version = pe_versions.determine_pe_version(pe_version)
     comparable_version = pe_versions.to_comparable_pe_version(version)
 
@@ -144,17 +146,10 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
         for Data in program.pe_inputs + program.pe_outputs:
             # Skip inputs that the resolved model version doesn't define yet — sending
             # an unknown variable 400s the whole request (e.g. meets_ssi_disability_criteria
-<<<<<<< HEAD
             # on 1.691.1). With no pin (comparable_version is None) we omit gated inputs
             # too, since the unpinned default is the current model that lacks them.
             if not pe_versions.version_supports(
                 comparable_version,
-=======
-            # on 1.691.1). With no pin (parsed_version is None) we omit gated inputs too,
-            # since the unpinned default is the current model that lacks them.
-            if not _version_supports(
-                parsed_version,
->>>>>>> c6aff7e3 (MFB-1102: add max_pe_version — full version-window gating (all 3 shapes))
                 getattr(Data, "min_pe_version", ()),
                 getattr(Data, "max_pe_version", ()),
             ):

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -342,10 +342,9 @@ class TestVersionSupports(TestCase):
     shapes (new / removed / windowed variable) and the asymmetric unknown-version rule."""
 
     def setUp(self):
-        from programs.programs.policyengine import policy_engine
         from programs.programs.policyengine import versions as pe_versions
 
-        self.supports = policy_engine._version_supports
+        self.supports = pe_versions.version_supports
         self.v = pe_versions.to_comparable_pe_version
 
     def test_ungated_always_supported(self):

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -343,9 +343,10 @@ class TestVersionSupports(TestCase):
 
     def setUp(self):
         from programs.programs.policyengine import policy_engine
+        from programs.programs.policyengine import versions as pe_versions
 
         self.supports = policy_engine._version_supports
-        self.v = policy_engine._parse_version
+        self.v = pe_versions.to_comparable_pe_version
 
     def test_ungated_always_supported(self):
         # No bounds => always sent, including on unknown version.

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -335,3 +335,47 @@ class TestPeInputVersionGating(PeInputTestBase):
         # A non-gated input (is_disabled) is sent regardless of version.
         result = pe_input(self.screen, [self.ssi], pe_version=None)
         self.assertIn("is_disabled", result["household"]["people"][self.head_id])
+
+
+class TestVersionSupports(TestCase):
+    """Unit tests for the min/max version window logic, covering all three gating
+    shapes (new / removed / windowed variable) and the asymmetric unknown-version rule."""
+
+    def setUp(self):
+        from programs.programs.policyengine import policy_engine
+
+        self.supports = policy_engine._version_supports
+        self.v = policy_engine._parse_version
+
+    def test_ungated_always_supported(self):
+        # No bounds => always sent, including on unknown version.
+        self.assertTrue(self.supports(None, (), ()))
+        self.assertTrue(self.supports(self.v("1.715.2"), (), ()))
+
+    def test_min_only_new_variable(self):
+        new = (1, 715, 2)  # added at 1.715.2
+        self.assertFalse(self.supports(None, new, ()))  # unknown/current: omit
+        self.assertFalse(self.supports(self.v("1.691.1"), new, ()))  # older: omit
+        self.assertTrue(self.supports(self.v("1.715.2"), new, ()))  # at floor: send
+        self.assertTrue(self.supports(self.v("1.800.0"), new, ()))  # newer: send
+
+    def test_max_only_removed_variable(self):
+        # Variable existed through 1.719.999, removed after.
+        last = (1, 719, 999)
+        self.assertTrue(self.supports(None, (), last))  # unknown/current still has it: send
+        self.assertTrue(self.supports(self.v("1.691.1"), (), last))  # older: send
+        self.assertTrue(self.supports(self.v("1.719.999"), (), last))  # at ceiling: send
+        self.assertFalse(self.supports(self.v("1.720.0"), (), last))  # past removal: omit
+
+    def test_windowed_variable(self):
+        # Existed only 1.700.0 .. 1.715.0.
+        lo, hi = (1, 700, 0), (1, 715, 0)
+        self.assertFalse(self.supports(None, lo, hi))  # unknown fails the floor
+        self.assertFalse(self.supports(self.v("1.699.0"), lo, hi))  # below window
+        self.assertTrue(self.supports(self.v("1.700.0"), lo, hi))  # at floor
+        self.assertTrue(self.supports(self.v("1.710.0"), lo, hi))  # inside
+        self.assertTrue(self.supports(self.v("1.715.0"), lo, hi))  # at ceiling
+        self.assertFalse(self.supports(self.v("1.715.2"), lo, hi))  # above window
+
+    def test_frontier_alias_satisfies_floor(self):
+        self.assertTrue(self.supports(self.v("frontier"), (1, 715, 2), ()))

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -293,3 +293,45 @@ class TestPeInputMultipleCalculators(PeInputTestBase):
         # WIC adds pregnancy/breastfeeding fields to people
         head_id = str(self.head.id)
         self.assertIn("age", people[head_id])
+
+
+class TestPeInputVersionGating(PeInputTestBase):
+    """Tests that version-gated inputs (min_pe_version) are only sent to models that
+    support them. meets_ssi_disability_criteria (min 1.715.2) is the canonical case:
+    it does not exist in the current model (1.691.1) and 400s the whole request there."""
+
+    def setUp(self):
+        super().setUp()
+        from programs.programs.federal.pe.member import Ssi
+
+        self.ssi = Ssi
+        self.head_id = str(self.head.id)
+
+    def _meets_ssi_field_present(self, version):
+        result = pe_input(self.screen, [self.ssi], pe_version=version)
+        return "meets_ssi_disability_criteria" in result["household"]["people"][self.head_id]
+
+    def test_omitted_when_no_version_pinned(self):
+        # No pin => current default model (1.691.1), which lacks the variable.
+        self.assertFalse(self._meets_ssi_field_present(None))
+
+    def test_omitted_on_current_alias(self):
+        self.assertFalse(self._meets_ssi_field_present("current"))
+
+    def test_omitted_on_older_pinned_version(self):
+        self.assertFalse(self._meets_ssi_field_present("1.691.1"))
+
+    def test_sent_on_supporting_version(self):
+        self.assertTrue(self._meets_ssi_field_present("1.715.2"))
+
+    def test_sent_on_newer_version(self):
+        self.assertTrue(self._meets_ssi_field_present("1.800.0"))
+
+    def test_sent_on_frontier_alias(self):
+        # frontier is the newest released model, so gated inputs are sent.
+        self.assertTrue(self._meets_ssi_field_present("frontier"))
+
+    def test_ungated_input_always_present(self):
+        # A non-gated input (is_disabled) is sent regardless of version.
+        result = pe_input(self.screen, [self.ssi], pe_version=None)
+        self.assertIn("is_disabled", result["household"]["people"][self.head_id])

--- a/programs/programs/policyengine/tests/test_versions.py
+++ b/programs/programs/policyengine/tests/test_versions.py
@@ -1,0 +1,52 @@
+"""Tests for the shared PolicyEngine version rules (programs/programs/policyengine/versions.py).
+This is the single source of truth used by the config model, the ?pe_version override
+validator, and the input-gating parser."""
+
+from django.test import SimpleTestCase
+
+from programs.programs.policyengine import versions as v
+
+
+class TestIsValidVersionNumber(SimpleTestCase):
+    def test_accepts_exact_version(self):
+        self.assertTrue(v.is_valid_version_number("1.715.2"))
+        self.assertTrue(v.is_valid_version_number("1.800.0"))
+
+    def test_rejects_aliases_and_garbage(self):
+        for value in ("frontier", "current", "1.7", "1.715", "v1.715.2", "1.715.2-beta", "xcZX", ""):
+            self.assertFalse(v.is_valid_version_number(value), value)
+
+
+class TestIsValidOverride(SimpleTestCase):
+    def test_accepts_aliases(self):
+        self.assertTrue(v.is_valid_override("current"))
+        self.assertTrue(v.is_valid_override("frontier"))
+
+    def test_accepts_version_number(self):
+        self.assertTrue(v.is_valid_override("1.715.2"))
+
+    def test_rejects_garbage_and_typos(self):
+        for value in ("banana", "fronteir", "1.7", "v1.715.2", "1.715.2 "):
+            self.assertFalse(v.is_valid_override(value), value)
+
+
+class TestToComparablePeVersion(SimpleTestCase):
+    def test_version_number_to_tuple(self):
+        self.assertEqual(v.to_comparable_pe_version("1.715.2"), (1, 715, 2))
+
+    def test_frontier_is_latest(self):
+        # frontier compares greater than any real version (satisfies any floor).
+        self.assertEqual(v.to_comparable_pe_version("frontier"), v.LATEST)
+        self.assertGreater(v.to_comparable_pe_version("frontier"), (1, 715, 2))
+
+    def test_current_none_and_unparseable_are_none(self):
+        # "current"/None/non-numeric map to None (treated as the current default model).
+        for value in ("current", None, "banana"):
+            self.assertIsNone(v.to_comparable_pe_version(value), value)
+
+    def test_parser_is_lenient_validation_is_upstream(self):
+        # The parser only needs a comparable tuple; it does NOT enforce MAJOR.MINOR.PATCH
+        # (that's is_valid_version_number's job, applied before a value reaches here).
+        # So a malformed-but-numeric "1.7" still parses to (1, 7).
+        self.assertEqual(v.to_comparable_pe_version("1.7"), (1, 7))
+        self.assertFalse(v.is_valid_version_number("1.7"))

--- a/programs/programs/policyengine/tests/test_versions.py
+++ b/programs/programs/policyengine/tests/test_versions.py
@@ -36,7 +36,7 @@ class TestToComparablePeVersion(SimpleTestCase):
 
     def test_frontier_is_latest(self):
         # frontier compares greater than any real version (satisfies any floor).
-        self.assertEqual(v.to_comparable_pe_version("frontier"), v.LATEST)
+        self.assertEqual(v.to_comparable_pe_version("frontier"), v.NEWEST_VERSION)
         self.assertGreater(v.to_comparable_pe_version("frontier"), (1, 715, 2))
 
     def test_current_none_and_unparseable_are_none(self):

--- a/programs/programs/policyengine/versions.py
+++ b/programs/programs/policyengine/versions.py
@@ -73,3 +73,22 @@ def determine_pe_version(pe_version_override: Optional[str] = None) -> Optional[
 
     # Read-only accessor: must not write a row on the eligibility hot path.
     return PolicyEngineConfig.current_version() or None
+
+
+def version_supports(comparable_version: Optional[tuple], min_pe_version: tuple, max_pe_version: tuple) -> bool:
+    """Whether a request at comparable_version may send an input that exists in the
+    version window [min_pe_version, max_pe_version] (each bound optional, from a
+    dependency's min_pe_version/max_pe_version). Ungated inputs (both empty) are always
+    sent. comparable_version is the output of to_comparable_pe_version().
+
+    comparable_version is None for an unknown/current/unpinned request. We treat that
+    asymmetrically: it FAILS any min floor (don't send a not-yet-existing variable to
+    the current model) but SATISFIES any max ceiling (a variable that still exists on
+    the current model should keep being sent until we pin a version past its removal)."""
+    if min_pe_version:
+        if comparable_version is None or comparable_version < min_pe_version:
+            return False
+    if max_pe_version:
+        if comparable_version is not None and comparable_version > max_pe_version:
+            return False
+    return True

--- a/validations/management/commands/import_validations/data/wa_ssi.json
+++ b/validations/management/commands/import_validations/data/wa_ssi.json
@@ -63,6 +63,39 @@
     }
   },
   {
+    "notes": "WA SSI - Disabled non-aged/non-blind, no income (MFB-1102 frontier guard): a 45yo with disabled=true, under 65 and not blind, qualifies via the disability pathway and receives the full FBR of $994/month = $11,928/year. This is the case that breaks on frontier without meets_ssi_disability_criteria — PE no longer infers SSI-disability from is_disabled, so omitting that input would zero out ssi here. Guards the MFB-1102 fix.",
+    "household": {
+      "white_label": "wa",
+      "is_test": true,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "zipcode": "98101",
+      "county": "King",
+      "household_size": 1,
+      "household_assets": 0,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "age": 45,
+          "birth_year": 1981,
+          "birth_month": 1,
+          "disabled": true,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_ssi",
+      "eligible": true,
+      "value": 11928
+    }
+  },
+  {
     "notes": "WA SSI - Edge case (income exclusion methodology): long-term disabled adult with $400/mo wages tests the $20 general + $65 earned + 1/2 earned exclusion formula. Math: $400 - $20 - $65 = $315; 1/2 of $315 = $157.50 countable income. SSI = $994 - $157.50 = $836.50/month = $10,038/year (estimated_value is stored as an annual figure; truncated to int per validate.py). Earnings well below 2026 SGA threshold ($1,690/mo non-blind), so disability path is preserved.",
     "household": {
       "white_label": "wa",

--- a/validations/management/commands/import_validations/data/wa_ssi.json
+++ b/validations/management/commands/import_validations/data/wa_ssi.json
@@ -63,39 +63,6 @@
     }
   },
   {
-    "notes": "WA SSI - Disabled non-aged/non-blind, no income (MFB-1102 frontier guard): a 45yo with disabled=true, under 65 and not blind, qualifies via the disability pathway and receives the full FBR of $994/month = $11,928/year. This is the case that breaks on frontier without meets_ssi_disability_criteria — PE no longer infers SSI-disability from is_disabled, so omitting that input would zero out ssi here. Guards the MFB-1102 fix.",
-    "household": {
-      "white_label": "wa",
-      "is_test": true,
-      "agree_to_tos": true,
-      "is_13_or_older": true,
-      "zipcode": "98101",
-      "county": "King",
-      "household_size": 1,
-      "household_assets": 0,
-      "household_members": [
-        {
-          "relationship": "headOfHousehold",
-          "age": 45,
-          "birth_year": 1981,
-          "birth_month": 1,
-          "disabled": true,
-          "has_income": false,
-          "income_streams": [],
-          "insurance": {
-            "none": true
-          }
-        }
-      ],
-      "expenses": []
-    },
-    "expected_results": {
-      "program_name": "wa_ssi",
-      "eligible": true,
-      "value": 11928
-    }
-  },
-  {
     "notes": "WA SSI - Edge case (income exclusion methodology): long-term disabled adult with $400/mo wages tests the $20 general + $65 earned + 1/2 earned exclusion formula. Math: $400 - $20 - $65 = $315; 1/2 of $315 = $157.50 countable income. SSI = $994 - $157.50 = $836.50/month = $10,038/year (estimated_value is stored as an annual figure; truncated to int per validate.py). Earnings well below 2026 SGA threshold ($1,690/mo non-blind), so disability path is preserved.",
     "household": {
       "white_label": "wa",


### PR DESCRIPTION
## Context & Motivation

Part of the PolicyEngine frontier migration ([MFB-1100](https://linear.app/myfriendben/issue/MFB-1100/migrate-to-policyengine-frontier-api)) — sub-issue [MFB-1102](https://linear.app/myfriendben/issue/MFB-1102/pe-frontier-send-meets-ssi-disability-criteria-for-ssi-ssi-recipient). The one confirmed code break in the migration.

On the frontier model (policyengine-us 1.715.2, promoted to default June 10), SSI disability classification **no longer falls back** to `is_disabled` / reported SSI receipt. Without sending `meets_ssi_disability_criteria`, a disabled non-aged/non-blind person gets `is_ssi_disabled: false` → `ssi: 0`, with downstream effects on SSI-recipient Medicaid (non-zero in MA/CO/NC/IL/WA), SNAP categorical eligibility, and SSI-linked state supplements.

This does not fix a current bug — current prod (1.691.1) still works. It **prevents disabled members' SSI (and downstream programs) from dropping to zero once we move to frontier** (which we control via the version pin — see Deployment).

- Targets the integration branch `caton/mfb-1100-frontier-integration` (builds on MFB-1112's version config), not `main`.

## Changes Made

- **`MeetsSsiDisabilityCriteriaDependency`** (`meets_ssi_disability_criteria`, person-level), added to the `Ssi` calculator's `pe_inputs`. Value mirrors `IsDisabledDependency` (`disabled OR long_term_disability OR visually_impaired`).
- **Scope is the `Ssi` calculator only** — verified from policyengine-us source that the *only* non-test consumer of this variable (for our states) is `is_ssi_disabled`; the Medicaid `SSI_RECIPIENT` and SNAP categorical paths are downstream of `ssi`/`is_ssi_eligible` and do not read it independently, so no Medicaid/SNAP/state-supplement calculator changes are needed.
- **Including blindness is verified safe**: SSI eligibility is `is_ssi_aged OR is_blind OR is_ssi_disabled` (PE source), so the flag can only add to an OR, never reduce eligibility.
- **Version gating** — `meets_ssi_disability_criteria` does **not exist in the current model (1.691.1)**; sending it 400s the whole `/calculate` request. Added a reusable `min_pe_version` marker on the dependency base class: `pe_input()` resolves the request version once and omits any dependency whose `min_pe_version` exceeds it. This makes the change **safe to ship dormant** — the input is omitted unless the version is explicitly pinned to ≥ 1.715.2 (or `frontier`). See Deployment for the activation caveat.
- Dependency unit tests + version-gating tests (no static validation scenario — the frontier *outcome* check is homed in MFB-1103; see Testing).

## Testing

Migrations to run: none.

Coverage is intentionally split across three layers — a static validation in standard CI can't honestly test the frontier *outcome* (CI runs against the current model 1.691.1, where the old `is_disabled` fallback masks the change), so the behavioral check is homed in MFB-1103 instead.

**Layer 1 — automated, in this PR (CI on every push):**
- Dependency tests: `MeetsSsiDisabilityCriteriaDependency.value()` returns the correct boolean (disabled / long-term / visually-impaired / none) and emits field `meets_ssi_disability_criteria`.
- Version-window gating tests (`test_pe_input.py`): variable is **sent** at ≥1.715.2 / `frontier`, **omitted** on current / older / unpinned; min/max/window logic correct incl. the unknown-version asymmetry.
- Full policyengine + federal suites green (no regression from the new input or the gate).
- These prove the **mechanics** (we emit the right field, gated correctly) — not the PE-computed outcome.

**Layer 2 — manual, against the live PolicyEngine API (verified once this session):**
- **No pin / `current`:** variable omitted, status **200**, SSI computes (no 400). ✅
- **`1.715.2` WITH the variable (the fix):** present, status **200**, disabled CO member gets `ssi = 11604`. ✅
- **`1.715.2` WITHOUT the variable (the regression we prevent):** same household, variable stripped → status **200**, `ssi = 0`. ✅ This is the load-bearing proof — same version, same household, the only difference is the variable, and it's the difference between `11604` and `0`. (Confirms the fix is necessary, not cosmetic — the matching `11604` between current and frontier-with-fix could otherwise mask a no-op.)
- Sending the variable on the **current model (1.691.1)** → **400** *"Variable meets_ssi_disability_criteria … is not available …"* — why the gate omits it below 1.715.2.
- Not repeatable in CI (needs live auth + network + the version pin).

**Layer 3 — deferred to [MFB-1103](https://linear.app/myfriendben/issue/MFB-1103/pe-frontier-regression-diff-assets-snap-abawd-tx-ccs-ma-eaedc) (regression diff):**
- The repeatable behavioral check — disabled member gets non-zero SSI **on frontier**, plus the downstream SSI-recipient Medicaid amounts (MA/CO/NC/IL/WA) — runs there via `?pe_version=1.715.2` before/after diffs, the only context that actually exercises frontier.

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none on merge. Shipping this code while prod is on the current model is safe — the gate omits the variable.
- **Activation requires an explicit pin to ≥ 1.715.2** via MFB-1112's `PolicyEngineConfig`. ⚠️ This is **mandatory, not "or wait for June 10."** An unpinned request resolves to `version=None`, which the gate treats as below the floor → the variable stays **omitted even after PE flips its server-side default to frontier on June 10**. So if we reach June 10 unpinned, frontier becomes the served model but `meets_ssi_disability_criteria` is still omitted → disabled members' `ssi` drops to 0 — the exact bug this PR prevents. The pin must land **before** June 10; the default flip is not an activation path. (This is the safer design — activation is under our control, not tied to PE's release calendar.)
- Notify team/users of: the cutover sequencing (this fix activates only when the version is pinned ≥ 1.715.2)

## Notes for Reviewers

- **Hard version coupling:** unlike MFB-1112 (whose config defaults to a no-op), this variable is itself incompatible with the current model. The `min_pe_version` gate is what makes it dormant-safe — without it, merging to prod on the current model would 400 every SSI calc. Please sanity-check the gate logic in `pe_input` / `pe_versions.version_supports` (the version helpers now live in the shared `programs/programs/policyengine/versions.py` module, added in MFB-1112).
- **Reusable pattern + its boundary:** the gate is an optional `[min_pe_version, max_pe_version]` window on the dependency base class, covering all three add/remove shapes — new variable (`min`), removed variable (`max`), windowed (`both`). Unknown/unpinned version fails any floor but satisfies any ceiling (new vars stay off until opted in; still-present vars stay on until pinned past removal). It only gates SEND/OMIT — it does **not** handle a variable whose value/format changes per version (e.g. `county_str`→`county_fips`); that mechanism is deferred to MFB-1104 and the limitation is documented in `dependencies/base.py`. The min/max window comparison itself lives in `versions.version_supports`.
- **Scope confirmed from source, not assumed:** the value logic (include blindness) and breadth (Ssi-only) were both verified against the policyengine-us source rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




