### PR TITLE
MFB-1031: Increase Texas Home Exemptions value to 2x current amount

### DIFF
--- a/programs/programs/tx/hse/calculator.py
+++ b/programs/programs/tx/hse/calculator.py
@@ -18,9 +18,9 @@ class TxHse(ProgramCalculator):
     https://statutes.capitol.texas.gov/Docs/TX/htm/TX.11.htm#11.13
 
     Benefit amount:
-    - $400/year (estimated typical tax savings for a low-income TX homeowner
+    - $800/year (estimated typical tax savings for a low-income TX homeowner
       with a ~$120K home value under the general homestead exemption)
-    - $600/year for seniors (age 65+) or people with disabilities (estimated
+    - $1200/year for seniors (age 65+) or people with disabilities (estimated
       typical savings under the general + senior/disabled exemption combined)
     Note: actual savings vary by taxing unit and appraised value.
 
@@ -33,8 +33,8 @@ class TxHse(ProgramCalculator):
     Source: https://statutes.capitol.texas.gov/?tab=1&code=TX&chapter=TX.11&artSec=
     """
 
-    amount = 400
-    senior_disabled_amount = 600
+    amount = 800
+    senior_disabled_amount = 1200
     senior_age = 65
     blind_senior_age = 55
     dependencies: ClassVar[list[str]] = ["age"]

--- a/programs/programs/tx/hse/calculator.py
+++ b/programs/programs/tx/hse/calculator.py
@@ -19,7 +19,7 @@ class TxHse(ProgramCalculator):
 
     Benefit amount:
     - $800/year (estimated typical tax savings for a low-income TX homeowner
-      with a ~$120K home value under the general homestead exemption)
+      under the general homestead exemption)
     - $1200/year for seniors (age 65+) or people with disabilities (estimated
       typical savings under the general + senior/disabled exemption combined)
     Note: actual savings vary by taxing unit and appraised value.

--- a/programs/programs/tx/hse/tests/test_tx_hse.py
+++ b/programs/programs/tx/hse/tests/test_tx_hse.py
@@ -6,9 +6,9 @@ Eligibility:
 - Texas residency is handled by the TX white label (not tested here)
 
 Benefit value:
-- $600 if any household member is age 65+, has long_term_disability, has disabled
+- $1200 if any household member is age 65+, has long_term_disability, has disabled
   status (unable to work now or in the future), or is age 55+ and visually impaired
-- $400 otherwise
+- $800 otherwise
 """
 
 from django.test import TestCase
@@ -58,11 +58,11 @@ class TestTxHseClassAttributes(TestCase):
         self.assertIn("tx_hse", tx_calculators)
         self.assertEqual(tx_calculators["tx_hse"], TxHse)
 
-    def test_base_amount_is_400(self):
-        self.assertEqual(TxHse.amount, 400)
+    def test_base_amount_is_800(self):
+        self.assertEqual(TxHse.amount, 800)
 
-    def test_senior_disabled_amount_is_600(self):
-        self.assertEqual(TxHse.senior_disabled_amount, 600)
+    def test_senior_disabled_amount_is_1200(self):
+        self.assertEqual(TxHse.senior_disabled_amount, 1200)
 
     def test_senior_age_is_65(self):
         self.assertEqual(TxHse.senior_age, 65)
@@ -85,79 +85,79 @@ class TestTxHseEligibility(TestCase):
 
 
 class TestTxHseValue(TestCase):
-    def test_non_senior_non_disabled_gets_400(self):
+    def test_non_senior_non_disabled_gets_800(self):
         members = [make_member(age=40)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
-    def test_member_age_65_gets_600(self):
+    def test_member_age_65_gets_1200(self):
         members = [make_member(age=65)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_member_age_80_gets_600(self):
+    def test_member_age_80_gets_1200(self):
         members = [make_member(age=80)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_member_age_64_gets_400(self):
+    def test_member_age_64_gets_800(self):
         members = [make_member(age=64)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
-    def test_disabled_member_gets_600(self):
+    def test_disabled_member_gets_1200(self):
         members = [make_member(age=40, disabled=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_visually_impaired_age_55_gets_600(self):
+    def test_visually_impaired_age_55_gets_1200(self):
         members = [make_member(age=55, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_visually_impaired_age_60_gets_600(self):
+    def test_visually_impaired_age_60_gets_1200(self):
         members = [make_member(age=60, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_visually_impaired_under_55_gets_400(self):
+    def test_visually_impaired_under_55_gets_800(self):
         members = [make_member(age=40, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
-    def test_visually_impaired_age_54_gets_400(self):
+    def test_visually_impaired_age_54_gets_800(self):
         members = [make_member(age=54, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
-    def test_long_term_disability_gets_600(self):
+    def test_long_term_disability_gets_1200(self):
         members = [make_member(age=40, long_term_disability=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_mixed_household_with_senior_gets_600(self):
+    def test_mixed_household_with_senior_gets_1200(self):
         members = [make_member(age=40), make_member(age=70)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_mixed_household_no_senior_no_disability_gets_400(self):
+    def test_mixed_household_no_senior_no_disability_gets_800(self):
         members = [make_member(age=30), make_member(age=50)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
-    def test_zero_member_household_gets_400(self):
+    def test_zero_member_household_gets_800(self):
         calc = make_calculator(members=[])
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
     def test_member_with_none_age_does_not_raise(self):
         members = [make_member(age=None)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 400)
+        self.assertEqual(calc.household_value(), 800)
 
-    def test_senior_and_disabled_member_gets_600(self):
+    def test_senior_and_disabled_member_gets_1200(self):
         members = [make_member(age=70, disabled=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 600)
+        self.assertEqual(calc.household_value(), 1200)
 
 
 class TestTxHseCalc(TestCase):
@@ -165,15 +165,15 @@ class TestTxHseCalc(TestCase):
         calc = make_calculator(has_mortgage=True, members=[make_member(age=40)])
         e = calc.calc()
         self.assertTrue(e.eligible)
-        self.assertEqual(e.value, 400)
+        self.assertEqual(e.value, 800)
 
     def test_calc_ineligible_without_mortgage(self):
         calc = make_calculator(has_mortgage=False, members=[make_member(age=40)])
         e = calc.calc()
         self.assertFalse(e.eligible)
 
-    def test_calc_eligible_senior_gets_600(self):
+    def test_calc_eligible_senior_gets_1200(self):
         calc = make_calculator(has_mortgage=True, members=[make_member(age=65)])
         e = calc.calc()
         self.assertTrue(e.eligible)
-        self.assertEqual(e.value, 600)
+        self.assertEqual(e.value, 1200)


### PR DESCRIPTION
## Context & Motivation

- Fixes [MFB-1031](https://linear.app/myfriendben/issue/MFB-1031/increase-texas-home-exemptions-value-to-2x-current-amount)
- Doubles the estimated annual benefit values for the Texas Homestead Exemption program per product request.

## Changes Made

- `TxHse.amount`: $400 → $800 (base exemption for non-senior/non-disabled homeowners)
- `TxHse.senior_disabled_amount`: $600 → $1200 (exemption for seniors 65+ or people with disabilities)
- Updated all corresponding test assertions and test names to reflect the new values
- Updated docstring and test module docstring to reflect new amounts

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps: Run `python manage.py test programs.programs.tx.hse`

## Deployment

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: Updated benefit estimate amounts shown to TX homeowners

## Notes for Reviewers

- Known limitations: Amounts are still estimates; actual savings vary by taxing unit and appraised value (noted in docstring)
- Future considerations: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Texas Homestead Exemption calculator with increased annual tax savings benefits: standard eligibility now yields $800/year (previously $400/year), while senior and disability-qualified cases receive $1200/year (previously $600/year).

* **Tests**
  * Updated test fixtures and assertions to validate new benefit amount calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->