### PR TITLE
refactor: rename HouseholdMember.has_benefit() to has_insurance()

### DIFF
--- a/programs/programs/co/denver_sidewalk_rebate/calculator.py
+++ b/programs/programs/co/denver_sidewalk_rebate/calculator.py
@@ -30,7 +30,7 @@ class DenverSidewalkRebate(ProgramCalculator):
                 break
 
         for member in self.screen.household_members.all():
-            if member.has_benefit("co_medicaid"):
+            if member.has_insurance("co_medicaid"):
                 categorical_eligible = True
                 break
 

--- a/programs/programs/co/denver_trash_rebate/calculator.py
+++ b/programs/programs/co/denver_trash_rebate/calculator.py
@@ -30,7 +30,7 @@ class DenverTrashRebate(ProgramCalculator):
                 break
 
         for member in self.screen.household_members.all():
-            if member.has_benefit("co_medicaid"):
+            if member.has_insurance("co_medicaid"):
                 categorical_eligible = True
                 break
 

--- a/programs/programs/co/low_wage_covid_relief/calculator.py
+++ b/programs/programs/co/low_wage_covid_relief/calculator.py
@@ -41,7 +41,7 @@ class LowWageCovidRelief(ProgramCalculator):
         for benefit in LowWageCovidRelief.member_auto_eligible_benefits:
             if has_benefit:
                 break
-            if any(member.has_insurance(benefit) for member in self.screen.household_member.all()):
+            if any(member.has_insurance(benefit) for member in self.screen.household_members.all()):
                 has_benefit = True
 
         # meets income limit

--- a/programs/programs/co/low_wage_covid_relief/calculator.py
+++ b/programs/programs/co/low_wage_covid_relief/calculator.py
@@ -41,7 +41,7 @@ class LowWageCovidRelief(ProgramCalculator):
         for benefit in LowWageCovidRelief.member_auto_eligible_benefits:
             if has_benefit:
                 break
-            if any(member.has_benefit(benefit) for member in self.screen.household_member.all()):
+            if any(member.has_insurance(benefit) for member in self.screen.household_member.all()):
                 has_benefit = True
 
         # meets income limit

--- a/programs/programs/co/utility_bill_pay/calculator.py
+++ b/programs/programs/co/utility_bill_pay/calculator.py
@@ -20,7 +20,7 @@ class UtilityBillPay(ProgramCalculator):
 
         if not presumed_eligibility:
             for benefit in self.member_presumptive_eligibility:
-                if any(member.has_benefit(benefit) for member in self.screen.household_members.all()):
+                if any(member.has_insurance(benefit) for member in self.screen.household_members.all()):
                     presumed_eligibility = True
                     break
 

--- a/programs/programs/il/medicaid/aca_adults/calculator.py
+++ b/programs/programs/il/medicaid/aca_adults/calculator.py
@@ -51,4 +51,4 @@ class AcaAdults(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
         e.condition(not (is_caretaker and has_children))
 
         # Must not have Medicaid
-        e.condition(not member.has_benefit("medicaid"))
+        e.condition(not member.has_insurance("medicaid"))

--- a/programs/programs/il/medicaid/all_kids/calculator.py
+++ b/programs/programs/il/medicaid/all_kids/calculator.py
@@ -20,7 +20,7 @@ class AllKids(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
         e.condition(member.age <= self.max_age)
 
         # Must not have Medicaid
-        e.condition(not member.has_benefit("medicaid"))
+        e.condition(not member.has_insurance("medicaid"))
 
         # Must not already have All Kids (chp)
-        e.condition(not member.has_benefit("chp"))
+        e.condition(not member.has_insurance("chp"))

--- a/programs/programs/il/medicaid/family_care/calculator.py
+++ b/programs/programs/il/medicaid/family_care/calculator.py
@@ -36,4 +36,4 @@ class FamilyCare(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
         e.condition(is_pregnant or (has_qualifying_children and is_caretaker))
 
         # Must not have Medicaid
-        e.condition(not member.has_benefit("medicaid"))
+        e.condition(not member.has_insurance("medicaid"))

--- a/programs/programs/il/medicaid/moms_and_babies/calculator.py
+++ b/programs/programs/il/medicaid/moms_and_babies/calculator.py
@@ -45,7 +45,7 @@ class MomsAndBabies(ProgramCalculator, IlMedicaidFplIncomeCheckMixin):
         e.condition(is_eligible_adult or (is_eligible_newborn and household_has_eligible_adult))
 
         # Must not have Medicaid
-        e.condition(not member.has_benefit("medicaid"))
+        e.condition(not member.has_insurance("medicaid"))
 
     def member_value(self, member: HouseholdMember) -> int:
         if self._is_eligible_newborn(member):

--- a/programs/programs/nc/sun_bucks/calculator.py
+++ b/programs/programs/nc/sun_bucks/calculator.py
@@ -27,4 +27,4 @@ class SunBucks(ProgramCalculator):
         # age eligibility
         e.condition(SunBucks.min_age <= member.age <= SunBucks.max_age)
 
-        e.condition(not member.has_benefit("medicaid"))
+        e.condition(not member.has_insurance("medicaid"))

--- a/programs/programs/tx/ccad/calculator.py
+++ b/programs/programs/tx/ccad/calculator.py
@@ -32,7 +32,7 @@ class TxCcad(ProgramCalculator):
                     continue
                 member = member_e.member
                 has_ssi = member.calc_gross_income("yearly", ["sSI"]) > 0
-                has_medicaid = member.has_benefit("medicaid")
+                has_medicaid = member.has_insurance("medicaid")
                 if has_ssi or has_medicaid:
                     presumed_eligible = True
                     break

--- a/programs/programs/tx/ccad/tests/test_ccad.py
+++ b/programs/programs/tx/ccad/tests/test_ccad.py
@@ -48,7 +48,7 @@ def make_member(age, disabled=False, long_term_disability=False, visually_impair
     member.has_disability = Mock(return_value=disabled or long_term_disability or visually_impaired)
     # Argument-sensitive: only return ssi_income when called as calc_gross_income("yearly", ["sSI"])
     member.calc_gross_income = Mock(side_effect=lambda period, types: ssi_income if types == ["sSI"] else 0)
-    member.has_benefit = Mock(side_effect=lambda b: medicaid if b == "medicaid" else False)
+    member.has_insurance = Mock(side_effect=lambda b: medicaid if b == "medicaid" else False)
     return member
 
 

--- a/programs/programs/tx/pe/member.py
+++ b/programs/programs/tx/pe/member.py
@@ -195,7 +195,7 @@ class TxMedicaidForParentsAndCaretakers(Medicaid):
                 continue
 
             # Check if child has Medicaid already
-            if member.has_benefit("medicaid"):
+            if member.has_insurance("medicaid"):
                 return True
 
             # Check if child qualifies for Medicaid (PE value > 0)

--- a/programs/programs/tx/pe/tests/test_member.py
+++ b/programs/programs/tx/pe/tests/test_member.py
@@ -1185,7 +1185,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 10
-        mock_child.has_benefit = Mock(return_value=True)  # Child has Medicaid
+        mock_child.has_insurance = Mock(return_value=True)  # Child has Medicaid
 
         # Create a mock screen with the child
         mock_screen = Mock()
@@ -1226,7 +1226,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 10
-        mock_child.has_benefit = Mock(return_value=False)  # Child doesn't have Medicaid yet
+        mock_child.has_insurance = Mock(return_value=False)  # Child doesn't have Medicaid yet
 
         # Create a mock screen with the child
         mock_screen = Mock()
@@ -1265,7 +1265,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 5
-        mock_child.has_benefit = Mock(return_value=True)
+        mock_child.has_insurance = Mock(return_value=True)
 
         # Create a mock screen
         mock_screen = Mock()
@@ -1330,7 +1330,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 10
-        mock_child.has_benefit = Mock(return_value=True)
+        mock_child.has_insurance = Mock(return_value=True)
 
         # Create a mock screen
         mock_screen = Mock()
@@ -1369,7 +1369,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 8
-        mock_child.has_benefit = Mock(return_value=True)
+        mock_child.has_insurance = Mock(return_value=True)
 
         # Create a mock screen
         mock_screen = Mock()
@@ -1431,7 +1431,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 10
-        mock_child.has_benefit = Mock(return_value=True)
+        mock_child.has_insurance = Mock(return_value=True)
 
         # Create a mock screen with the child
         mock_screen = Mock()
@@ -1448,7 +1448,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
 
         # Should return True
         self.assertTrue(result)
-        mock_child.has_benefit.assert_called_once_with("medicaid")
+        mock_child.has_insurance.assert_called_once_with("medicaid")
 
     def test_has_child_with_medicaid_returns_true_for_child_qualifying_via_pe(self):
         """
@@ -1458,7 +1458,7 @@ class TestTxMedicaidForParentsAndCaretakers(TestCase):
         mock_child = Mock()
         mock_child.id = 2
         mock_child.age = 12
-        mock_child.has_benefit = Mock(return_value=False)  # Doesn't have it yet
+        mock_child.has_insurance = Mock(return_value=False)  # Doesn't have it yet
 
         # Create a mock screen with the child
         mock_screen = Mock()

--- a/programs/programs/wa/hcv/tests/test_wa_hcv.py
+++ b/programs/programs/wa/hcv/tests/test_wa_hcv.py
@@ -27,7 +27,7 @@ def make_member(
     member.long_term_disability = long_term_disability
     member.has_disability = Mock(return_value=(disabled or visually_impaired or long_term_disability))
     member.calc_gross_income = Mock(return_value=income)
-    member.has_benefit = Mock(return_value=False)
+    member.has_insurance = Mock(return_value=False)
 
     insurance = Mock()
     insurance.has_insurance_types = Mock(return_value=bool(insurance_types))

--- a/programs/programs/wa/orca_lift/calculator.py
+++ b/programs/programs/wa/orca_lift/calculator.py
@@ -45,7 +45,7 @@ class WaOrcaLift(ProgramCalculator):
             self.screen.has_benefit("wa_snap")
             or self.screen.has_benefit("wa_wic")
             or any(
-                member.has_benefit("wa_apple_health_medicaid") or member.has_benefit("wa_apple_health_for_kids")
+                member.has_insurance("wa_apple_health_medicaid") or member.has_insurance("wa_apple_health_for_kids")
                 for member in self.screen.household_members.all()
             )
         )

--- a/programs/programs/wa/orca_lift/tests/test_wa_orca_lift.py
+++ b/programs/programs/wa/orca_lift/tests/test_wa_orca_lift.py
@@ -23,14 +23,14 @@ def make_member(age=35, birth_year_month=None, yearly_income=24_000, insurance_m
 
     member.calc_gross_income = Mock(side_effect=calc_gross_income)
 
-    def has_benefit(name):
+    def has_insurance(name):
         if name == "wa_apple_health_medicaid":
             return insurance_medicaid
         if name == "wa_apple_health_for_kids":
             return insurance_chp
         return False
 
-    member.has_insurance = Mock(side_effect=has_benefit)
+    member.has_insurance = Mock(side_effect=has_insurance)
     return member
 
 

--- a/programs/programs/wa/orca_lift/tests/test_wa_orca_lift.py
+++ b/programs/programs/wa/orca_lift/tests/test_wa_orca_lift.py
@@ -30,7 +30,7 @@ def make_member(age=35, birth_year_month=None, yearly_income=24_000, insurance_m
             return insurance_chp
         return False
 
-    member.has_benefit = Mock(side_effect=has_benefit)
+    member.has_insurance = Mock(side_effect=has_benefit)
     return member
 
 

--- a/programs/programs/wa/wap/calculator.py
+++ b/programs/programs/wa/wap/calculator.py
@@ -43,7 +43,7 @@ class WaWap(ProgramCalculator):
         )
 
         categorically_eligible = has_wa_wap_eligible_benefit or any(
-            member.has_benefit("wa_apple_health_medicaid") or member.has_benefit("wa_apple_health_for_kids")
+            member.has_insurance("wa_apple_health_medicaid") or member.has_insurance("wa_apple_health_for_kids")
             for member in self.screen.household_members.all()
         )
 

--- a/programs/programs/wa/wap/tests/test_wa_wap.py
+++ b/programs/programs/wa/wap/tests/test_wa_wap.py
@@ -17,7 +17,7 @@ def make_member(insurance_medicaid=False, insurance_chp=False):
             return insurance_chp
         return False
 
-    member.has_benefit = Mock(side_effect=has_benefit)
+    member.has_insurance = Mock(side_effect=has_benefit)
     return member
 
 

--- a/programs/programs/wa/wap/tests/test_wa_wap.py
+++ b/programs/programs/wa/wap/tests/test_wa_wap.py
@@ -10,14 +10,14 @@ def make_member(insurance_medicaid=False, insurance_chp=False):
     member = Mock()
     member.age = 40
 
-    def has_benefit(name):
+    def has_insurance(name):
         if name == "wa_apple_health_medicaid":
             return insurance_medicaid
         if name == "wa_apple_health_for_kids":
             return insurance_chp
         return False
 
-    member.has_insurance = Mock(side_effect=has_benefit)
+    member.has_insurance = Mock(side_effect=has_insurance)
     return member
 
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -363,15 +363,8 @@ class Screen(models.Model):
 
         return unit
 
-    def has_insurance_types(self, types, strict=True):
-        for member in self.household_members.all():
-            if not hasattr(member, "insurance"):
-                continue
-
-            if member.insurance.has_insurance_types(types, strict):
-                return True
-
-        return False
+    def has_insurance_types(self, types, strict=True) -> bool:
+        return any(member.has_insurance_types(types, strict) for member in self.household_members.all())
 
     def has_benefit_from_list(self, names: list[str]):
         for program in names:
@@ -765,14 +758,10 @@ class HouseholdMember(models.Model):
     def has_insurance(self, name_abbreviated: str) -> bool:
         return self.has_insurance_types((name_abbreviated,), strict=False)
 
-    def has_insurance_types(self, types, strict=True):
+    def has_insurance_types(self, types, strict=True) -> bool:
         if not hasattr(self, "insurance"):
             return False
-
-        if self.insurance.has_insurance_types(types, strict):
-            return True
-
-        return False
+        return self.insurance.has_insurance_types(types, strict)
 
     @property
     def birth_year(self) -> Optional[int]:
@@ -964,7 +953,7 @@ class Insurance(models.Model):
     # NOTE: Massachusetts combines Medicaid and CHIP into one program called MassHealth
     mass_health = models.BooleanField(default=False)
 
-    def has_insurance_types(self, types, strict=True):
+    def has_insurance_types(self, types, strict=True) -> bool:
         if "none" in types:
             types = (*types, "dont_know")
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -388,8 +388,8 @@ class Screen(models.Model):
 
         Only used by `_sync_current_benefits()` (and its test-helper mirror in
         `screener/tests/helpers.py`) to write CurrentBenefit rows during the
-        dual-write phase. `HouseholdMember.has_benefit()` does NOT route through
-        here — it has its own member-level `name_map` keyed off `self.insurance`.
+        dual-write phase. `HouseholdMember.has_insurance()` does NOT route through
+        here — it delegates directly to `has_insurance_types()` on the member's Insurance row.
 
         Removed in MFB-869 alongside `_sync_current_benefits` once the serializer
         writes join-table rows directly from the frontend's `current_benefits: [...]`
@@ -763,11 +763,8 @@ class HouseholdMember(models.Model):
     def is_in_tax_unit(self):
         return self.is_head() or self.is_spouse() or self.is_dependent()
 
-    def has_benefit(self, name_abbreviated: str):
-
-        has_insurance = self.has_insurance_types((name_abbreviated,), strict=False)
-
-        return has_insurance
+    def has_insurance(self, name_abbreviated: str) -> bool:
+        return self.has_insurance_types((name_abbreviated,), strict=False)
 
     def has_insurance_types(self, types, strict=True):
         if not hasattr(self, "insurance"):

--- a/screener/models.py
+++ b/screener/models.py
@@ -388,8 +388,7 @@ class Screen(models.Model):
 
         Only used by `_sync_current_benefits()` (and its test-helper mirror in
         `screener/tests/helpers.py`) to write CurrentBenefit rows during the
-        dual-write phase. `HouseholdMember.has_insurance()` does NOT route through
-        here — it delegates directly to `has_insurance_types()` on the member's Insurance row.
+        dual-write phase.
 
         Removed in MFB-869 alongside `_sync_current_benefits` once the serializer
         writes join-table rows directly from the frontend's `current_benefits: [...]`

--- a/screener/views.py
+++ b/screener/views.py
@@ -436,7 +436,7 @@ def eligibility_results(screen: Screen, batch=False):
                         "frontend_id": str(member_eligibility.member.frontend_id),
                         "eligible": member_eligibility.eligible,
                         "value": member_eligibility.value,
-                        "already_has": member_eligibility.member.has_benefit(program.name_abbreviated),
+                        "already_has": member_eligibility.member.has_insurance(program.name_abbreviated),
                     }
                 )
 


### PR DESCRIPTION
## Context & Motivation

- Fixes [#mfb-1084](https://linear.app/myfriendben/issue/MFB-1084/rename-householdmemberhas-benefit-has-insurance-and-remove-redundant)
- Related PR: N/A

`HouseholdMember.has_benefit()` was misnamed — it only ever checks insurance state on the member's 'Insurance` row and has no connection to the `CurrentBenefit` join table that `Screen.has_benefit()` reads from. The shared name caused confusion: readers assumed the member version was the screen version scoped to a single member, which is not the case.

## Changes Made

- Renamed `HouseholdMember.has_benefit()` → `has_insurance()` in `screener/models.py`
- Collapsed the method body to a one-liner and added `-> bool` return annotation
- Updated the stale `_build_benefit_map` docstring (removed reference to the now-deleted `name_map`)
- Updated all 14 member-level call sites across `screener/views.py` and program calculators (CO, TX, NC, IL, WA)
- Updated all affected test mocks in `tx/pe`, `tx/ccad`, `wa/wap`, `wa/hcv`, and `wa/orca_lift`
- `Screen.has_benefit()` is unchanged — it remains the authoritative read path for the `CurrentBenefit` join table
-  Added bool return type to Insurance, HouseholdMember, and Screen. Simplify delegate bodies and make Screen.has_insurance_types() go through member.has_insurance_types() instead of bypassing it to call
member.insurance directly, making the layering consistent.

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  1. Run the full test suite: `pytest`
  2. Confirm no `has_benefit` member-level call sites remain:
     `grep -rn "\.has_benefit(" --include="*.py"` should return only `Screen.has_benefit` references
  3. Run eligibility on a screen with `medicaid=True` and confirm `already_has` still filters Medicaid-gated programs correctly

## Deployment

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None — purely internal rename, no API or data changes

## Notes for Reviewers

- `Screen.has_benefit()` was intentionally left untouched — it is a separate
  method reading from the `CurrentBenefit` join table and is out of scope per the ticket
- Known limitations: None
- Future considerations: None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched program eligibility to rely on per-member insurance checks instead of prior benefit checks across many assistance programs; updated core member insurance behavior and related docstring.
* **Views**
  * Results now report whether a household member already has insurance for a program when showing eligibility.
* **Tests**
  * Updated test fixtures to reflect the new per-member insurance check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->