### PR TITLE
MFB-1022: LIHEAP estimates too high

### DIFF
--- a/programs/programs/il/pe/spm.py
+++ b/programs/programs/il/pe/spm.py
@@ -52,6 +52,29 @@ class IlTanf(Tanf):
 
 
 class IlLiheap(PolicyEngineSpmCalulator):
+    """
+    Illinois Low Income Home Energy Assistance Program (LIHEAP).
+
+    Delegates the full eligibility and benefit calculation to PolicyEngine's
+    ``il_liheap`` variable (2026 benefit matrix), rather than hard-coding amounts.
+
+    PolicyEngine computes:
+      - Income eligibility: gross income <= higher of 60% SMI or 200% FPL.
+      - Benefit: an annual matrix amount keyed on fuel type, income bracket, and
+        household size, capped at the household's reported heating expense
+        (``min(matrix_amount, heating)``). PE models every IL household as
+        "All Electric" (or "Cash" when heat is included in rent).
+
+    Required PE input is ``heating_expense_person``: our screener captures heating
+    at the household level, so ``HeatingExpensePersonDependency`` assigns the full
+    amount to the head, which PE aggregates to the SPM unit for the cap. Because
+    the benefit is capped at this expense, a household reporting no heating/cooling
+    expense receives $0.
+
+    Households that already receive IL LIHEAP are flagged and handled by the
+    results layer (via ``already_has``), not in this calculator.
+    """
+
     pe_name = "il_liheap"
     pe_inputs = [
         dependency.household.IlStateCodeDependency,
@@ -61,8 +84,3 @@ class IlLiheap(PolicyEngineSpmCalulator):
         dependency.spm.ElectricityExpenseDependency,
     ]
     pe_outputs = [dependency.spm.IlLiheap]
-
-    def household_value(self) -> int:
-        if self.screen.has_benefit("il_liheap"):
-            return 0
-        return int(self.get_variable())

--- a/programs/programs/il/pe/spm.py
+++ b/programs/programs/il/pe/spm.py
@@ -1,10 +1,6 @@
-import logging
-
 from programs.programs.policyengine.calculators.base import PolicyEngineSpmCalulator
 import programs.programs.policyengine.calculators.dependencies as dependency
 from programs.programs.federal.pe.spm import Snap, SchoolLunch, Tanf
-
-logger = logging.getLogger(__name__)
 
 
 class IlSnap(Snap):
@@ -56,72 +52,17 @@ class IlTanf(Tanf):
 
 
 class IlLiheap(PolicyEngineSpmCalulator):
-    """
-    Illinois Low Income Home Energy Assistance Program (LIHEAP)
-
-    Hard-coded annual benefit values based on household size.
-    Eligibility: Income ≤ higher of (60% SMI or 200% FPL)
-    Application period: October 1 to August 15
-
-    Values based on IL 2025 benefit matrix for natural gas households.
-    Source: https://liheapch.acf.gov/docs/2025/benefits-matricies/IL_BenefitMatrix_2025.pdf
-    """
-
-    pe_name = "il_liheap_income_eligible"  # Use income eligibility check instead of full program
+    pe_name = "il_liheap"
     pe_inputs = [
         dependency.household.IlStateCodeDependency,
         *dependency.irs_gross_income,
+        dependency.spm.HasHeatingCoolingExpenseDependency,
+        dependency.member.HeatingExpensePersonDependency,
+        dependency.spm.ElectricityExpenseDependency,
     ]
-    pe_outputs = [dependency.spm.IlLiheapIncomeEligible]
-
-    # Hard-coded annual benefit amounts by household size
-    benefit_amounts = {
-        1: 315,
-        2: 330,
-        3: 340,
-        4: 350,
-        5: 365,
-        6: 375,  # 6+ people
-    }
+    pe_outputs = [dependency.spm.IlLiheap]
 
     def household_value(self) -> int:
-        """
-        Calculate LIHEAP benefit based on hard-coded values by household size.
-
-        Uses PolicyEngine for income eligibility check (60% SMI or 200% FPL),
-        then returns hard-coded benefit amounts.
-
-        Returns annual benefit amount (not monthly).
-        """
-        # Check if user already has IL LIHEAP
         if self.screen.has_benefit("il_liheap"):
             return 0
-
-        # Check PolicyEngine income eligibility (returns True/False)
-        try:
-            income_eligible = self.get_variable()  # il_liheap_income_eligible
-
-            # If not income eligible, return 0
-            if not income_eligible:
-                return 0
-
-            # Check if household has heating/cooling/rent/mortgage expenses
-            has_qualifying_expenses = self.screen.has_expense(["rent", "mortgage"])
-            if not has_qualifying_expenses:
-                return 0
-
-            # Income eligible and has expenses - return hard-coded benefit
-            household_size = self.screen.household_size
-            size_key = min(household_size, 6)
-            benefit = self.benefit_amounts.get(size_key, 0)
-            return benefit
-
-        except KeyError as e:
-            logger.warning(f"PolicyEngine missing expected key for IL LIHEAP screen {self.screen.id}: {e}")
-            return 0
-        except (AttributeError, ValueError) as e:
-            logger.warning(f"Error calculating IL LIHEAP for screen {self.screen.id}: {type(e).__name__}: {e}")
-            return 0
-        except RuntimeError as e:
-            logger.warning(f"PolicyEngine API error for IL LIHEAP screen {self.screen.id}: {e}")
-            return 0
+        return int(self.get_variable())

--- a/programs/programs/il/pe/tests/test_spm.py
+++ b/programs/programs/il/pe/tests/test_spm.py
@@ -163,6 +163,7 @@ class TestIlLiheap(TestCase):
     def test_pe_inputs_includes_heating_expense_person_dependency(self):
         """Test that HeatingExpensePersonDependency is in pe_inputs."""
         from programs.programs.policyengine.calculators.dependencies import member as member_dependency
+
         self.assertIn(member_dependency.HeatingExpensePersonDependency, IlLiheap.pe_inputs)
 
     def test_pe_outputs_includes_il_liheap(self):

--- a/programs/programs/il/pe/tests/test_spm.py
+++ b/programs/programs/il/pe/tests/test_spm.py
@@ -147,34 +147,27 @@ class TestIlLiheap(TestCase):
         self.assertIn("il_liheap", il_spm_calculators)
         self.assertEqual(il_spm_calculators["il_liheap"], IlLiheap)
 
-    def test_pe_name_is_il_liheap_income_eligible(self):
-        """Test that pe_name uses income eligibility check."""
-        self.assertEqual(IlLiheap.pe_name, "il_liheap_income_eligible")
+    def test_pe_name_is_il_liheap(self):
+        """Test that pe_name is il_liheap."""
+        self.assertEqual(IlLiheap.pe_name, "il_liheap")
 
     def test_pe_inputs_includes_il_state_code_dependency(self):
         """Test that IlStateCodeDependency is in pe_inputs."""
         self.assertIn(IlStateCodeDependency, IlLiheap.pe_inputs)
 
-    def test_pe_outputs_includes_il_liheap_income_eligible(self):
-        """Test that IlLiheapIncomeEligible output is in pe_outputs."""
-        self.assertIn(spm_dependency.IlLiheapIncomeEligible, IlLiheap.pe_outputs)
+    def test_pe_inputs_includes_heating_and_electricity_dependencies(self):
+        """Test that energy expense dependencies are in pe_inputs."""
+        self.assertIn(spm_dependency.HasHeatingCoolingExpenseDependency, IlLiheap.pe_inputs)
+        self.assertIn(spm_dependency.ElectricityExpenseDependency, IlLiheap.pe_inputs)
 
-    def test_benefit_amounts_defined_for_household_sizes(self):
-        """Test that benefit amounts are defined for household sizes 1-6."""
-        self.assertIn(1, IlLiheap.benefit_amounts)
-        self.assertIn(2, IlLiheap.benefit_amounts)
-        self.assertIn(3, IlLiheap.benefit_amounts)
-        self.assertIn(4, IlLiheap.benefit_amounts)
-        self.assertIn(5, IlLiheap.benefit_amounts)
-        self.assertIn(6, IlLiheap.benefit_amounts)
+    def test_pe_inputs_includes_heating_expense_person_dependency(self):
+        """Test that HeatingExpensePersonDependency is in pe_inputs."""
+        from programs.programs.policyengine.calculators.dependencies import member as member_dependency
+        self.assertIn(member_dependency.HeatingExpensePersonDependency, IlLiheap.pe_inputs)
 
-    def test_benefit_amount_for_single_person(self):
-        """Test that benefit amount for 1 person is $315."""
-        self.assertEqual(IlLiheap.benefit_amounts[1], 315)
-
-    def test_benefit_amount_for_six_plus_people(self):
-        """Test that benefit amount for 6+ people is $375."""
-        self.assertEqual(IlLiheap.benefit_amounts[6], 375)
+    def test_pe_outputs_includes_il_liheap(self):
+        """Test that IlLiheap output dependency is in pe_outputs."""
+        self.assertIn(spm_dependency.IlLiheap, IlLiheap.pe_outputs)
 
     def test_household_value_returns_zero_when_already_has_benefit(self):
         """Test that household_value returns 0 when already has IL LIHEAP."""
@@ -189,45 +182,28 @@ class TestIlLiheap(TestCase):
         self.assertEqual(result, 0)
         mock_screen.has_benefit.assert_called_once_with("il_liheap")
 
-    def test_household_value_returns_zero_when_not_income_eligible(self):
-        """Test that household_value returns 0 when not income eligible."""
+    def test_household_value_returns_zero_when_pe_returns_zero(self):
+        """Test that household_value returns 0 when PE returns 0 (ineligible)."""
         mock_screen = Mock()
         mock_screen.has_benefit = Mock(return_value=False)
 
         calculator = IlLiheap(mock_screen, Mock(), Mock())
         calculator._sim = MagicMock()
-        calculator.get_variable = Mock(return_value=False)
+        calculator.get_variable = Mock(return_value=0)
 
         result = calculator.household_value()
 
         self.assertEqual(result, 0)
 
-    def test_household_value_returns_zero_when_no_qualifying_expenses(self):
-        """Test that household_value returns 0 when no rent/mortgage expenses."""
+    def test_household_value_returns_pe_benefit_amount(self):
+        """Test that household_value returns the dollar amount from PE."""
         mock_screen = Mock()
         mock_screen.has_benefit = Mock(return_value=False)
-        mock_screen.has_expense = Mock(return_value=False)
 
         calculator = IlLiheap(mock_screen, Mock(), Mock())
         calculator._sim = MagicMock()
-        calculator.get_variable = Mock(return_value=True)
+        calculator.get_variable = Mock(return_value=400)
 
         result = calculator.household_value()
 
-        self.assertEqual(result, 0)
-        mock_screen.has_expense.assert_called_once_with(["rent", "mortgage"])
-
-    def test_household_value_returns_benefit_when_eligible(self):
-        """Test that household_value returns correct benefit when eligible."""
-        mock_screen = Mock()
-        mock_screen.has_benefit = Mock(return_value=False)
-        mock_screen.has_expense = Mock(return_value=True)
-        mock_screen.household_size = 3
-
-        calculator = IlLiheap(mock_screen, Mock(), Mock())
-        calculator._sim = MagicMock()
-        calculator.get_variable = Mock(return_value=True)
-
-        result = calculator.household_value()
-
-        self.assertEqual(result, 340)  # Benefit for household size 3
+        self.assertEqual(result, 400)

--- a/programs/programs/il/pe/tests/test_spm.py
+++ b/programs/programs/il/pe/tests/test_spm.py
@@ -170,23 +170,9 @@ class TestIlLiheap(TestCase):
         """Test that IlLiheap output dependency is in pe_outputs."""
         self.assertIn(spm_dependency.IlLiheap, IlLiheap.pe_outputs)
 
-    def test_household_value_returns_zero_when_already_has_benefit(self):
-        """Test that household_value returns 0 when already has IL LIHEAP."""
-        mock_screen = Mock()
-        mock_screen.has_benefit = Mock(return_value=True)
-
-        calculator = IlLiheap(mock_screen, Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        result = calculator.household_value()
-
-        self.assertEqual(result, 0)
-        mock_screen.has_benefit.assert_called_once_with("il_liheap")
-
     def test_household_value_returns_zero_when_pe_returns_zero(self):
         """Test that household_value returns 0 when PE returns 0 (ineligible)."""
         mock_screen = Mock()
-        mock_screen.has_benefit = Mock(return_value=False)
 
         calculator = IlLiheap(mock_screen, Mock(), Mock())
         calculator._sim = MagicMock()
@@ -199,7 +185,6 @@ class TestIlLiheap(TestCase):
     def test_household_value_returns_pe_benefit_amount(self):
         """Test that household_value returns the dollar amount from PE."""
         mock_screen = Mock()
-        mock_screen.has_benefit = Mock(return_value=False)
 
         calculator = IlLiheap(mock_screen, Mock(), Mock())
         calculator._sim = MagicMock()

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -453,6 +453,10 @@ class IlLiheapIncomeEligible(SpmUnit):
     field = "il_liheap_income_eligible"
 
 
+class IlLiheap(SpmUnit):
+    field = "il_liheap"
+
+
 class MaLiheap(SpmUnit):
     field = "ma_liheap"
 


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- The `IlLiheap` calculator previously used PolicyEngine only for an income eligibility boolean (`il_liheap_income_eligible`), then returned hard-coded annual benefit amounts sourced from the 2025 IL benefit matrix. PolicyEngine now fully implements `il_liheap` and uses the 2026 benefit matrix as its source of truth, making its values more accurate and automatically kept up to date.
- This change removes the hard-coded amounts and delegates the full benefit calculation to PolicyEngine, bringing `IlLiheap` in line with how other state LIHEAP calculators (e.g. `MaHeap`) work.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- `programs/programs/policyengine/calculators/dependencies/spm.py` — Added `IlLiheap(SpmUnit)` dependency class with `field = "il_liheap"` for the PE dollar-amount output
- `programs/programs/il/pe/spm.py` — Refactored `IlLiheap` calculator:
  - Changed `pe_name` from `"il_liheap_income_eligible"` to `"il_liheap"`
  - Added energy expense inputs (`HasHeatingCoolingExpenseDependency`, `HeatingExpensePersonDependency`, `ElectricityExpenseDependency`) required by PE's IL LIHEAP calculation
  - Changed `pe_outputs` to use the new `IlLiheap` dependency
  - Removed `benefit_amounts` hard-coded dict (2025 values)
  - Simplified `household_value()` to return `int(self.get_variable())` directly, delegating eligibility and benefit calculation entirely to PE
- `programs/programs/il/pe/tests/test_spm.py` — Updated `TestIlLiheap` to reflect new calculator behavior:
  - Removed tests for `benefit_amounts`, `il_liheap_income_eligible` pe_name, and the `has_expense(["rent", "mortgage"])` check
  - Added tests for new `pe_name`, updated `pe_outputs`, new energy expense `pe_inputs`, and PE-sourced benefit amount return value

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  1. Run an IL LIHEAP screen for a single-person household with income below the eligibility threshold (e.g. $20,000/year) and confirm a non-zero benefit is returned
  2. Run an IL LIHEAP screen for a household with income above the threshold (e.g. $60,000/year) and confirm the benefit is $0
  3. Run an IL LIHEAP screen for a household that already has `il_liheap` marked as a current benefit and confirm the benefit is $0
  4. Compare returned benefit amounts across household sizes against the [2026 IL LIHEAP benefit matrix](https://liheapch.acf.gov/docs/2026/benefits-matricies/IL_BenefitMatrix_Heat-Cool_2026.pdf#page=2)

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: IL LIHEAP benefit amounts will reflect 2026 values from PolicyEngine rather than the previously hard-coded 2025 matrix values — amounts will generally be higher

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: PolicyEngine's `il_liheap` benefit is capped by actual heating/energy expenses passed in the payload. The `HeatingExpensePersonDependency` assigns the full household heating cost to the head of household (same pattern used by `MaHeap`), since PE aggregates person-level heating expense up to the SPM unit for the payment cap.
- Future considerations: The `IlLiheapIncomeEligible` dependency class (`field = "il_liheap_income_eligible"`) has been left in place in `dependencies/spm.py` in case it is useful for other purposes, but it is no longer referenced by the `IlLiheap` calculator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Illinois LIHEAP calculations now use the updated PolicyEngine-powered rules, with support for heating, cooling, and electricity-related expenses.
  * Added a new LIHEAP result type for Illinois so eligibility and benefit outputs are surfaced more consistently.

* **Bug Fixes**
  * Removed older household calculation logic that could produce inconsistent eligibility and benefit results.
  * Updated tests to reflect the new calculation flow and expected output values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->