### PR TITLE
MFB-1089: CCCAP eligibility 500s when Google Sheets cache fetch fails

### DIFF
--- a/integrations/services/sheets/sheets.py
+++ b/integrations/services/sheets/sheets.py
@@ -49,13 +49,12 @@ class GoogleSheets:
                 )
                 return result.get("values", [])
             except Exception as exc:
-                is_transient = (
-                    isinstance(exc, (ssl.SSLError, TimeoutError, socket.timeout))
-                    or (isinstance(exc, HttpError) and exc.resp is not None and exc.resp.status in {429, 500, 502, 503, 504})
+                is_transient = isinstance(exc, (ssl.SSLError, TimeoutError, socket.timeout)) or (
+                    isinstance(exc, HttpError) and exc.resp is not None and exc.resp.status in {429, 500, 502, 503, 504}
                 )
                 if attempt == max_attempts - 1 or not is_transient:
                     raise
-                time.sleep(2 ** attempt)
+                time.sleep(2**attempt)
 
     def data_by_column(self, *column_names: str) -> list[dict[str, any]]:
         """

--- a/integrations/services/sheets/sheets.py
+++ b/integrations/services/sheets/sheets.py
@@ -4,6 +4,9 @@ from googleapiclient.discovery import build
 from google.oauth2 import service_account
 import json
 import time
+import socket
+import ssl
+from googleapiclient.errors import HttpError
 from integrations.util.cache import Cache
 
 
@@ -45,10 +48,14 @@ class GoogleSheets:
                     .execute()
                 )
                 return result.get("values", [])
-            except Exception:
-                if attempt == max_attempts - 1:
+            except Exception as exc:
+                is_transient = (
+                    isinstance(exc, (ssl.SSLError, TimeoutError, socket.timeout))
+                    or (isinstance(exc, HttpError) and exc.resp is not None and exc.resp.status in {429, 500, 502, 503, 504})
+                )
+                if attempt == max_attempts - 1 or not is_transient:
                     raise
-                time.sleep(2**attempt)
+                time.sleep(2 ** attempt)
 
     def data_by_column(self, *column_names: str) -> list[dict[str, any]]:
         """

--- a/integrations/services/sheets/sheets.py
+++ b/integrations/services/sheets/sheets.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
 import json
+import time
 from integrations.util.cache import Cache
 
 
@@ -30,12 +31,24 @@ class GoogleSheets:
 
     def data(self) -> list[list[any]]:
         """
-        return a list of rows in the cell range
+        return a list of rows in the cell range, with retry on transient errors.
         """
-        result = self.sheet.values().get(spreadsheetId=self.spreadsheet_id, range=self.cell_range).execute()
-        values = result.get("values", [])
-
-        return values
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                result = (
+                    self.sheet.values()
+                    .get(
+                        spreadsheetId=self.spreadsheet_id,
+                        range=self.cell_range,
+                    )
+                    .execute()
+                )
+                return result.get("values", [])
+            except Exception:
+                if attempt == max_attempts - 1:
+                    raise
+                time.sleep(2**attempt)
 
     def data_by_column(self, *column_names: str) -> list[dict[str, any]]:
         """

--- a/integrations/util/cache.py
+++ b/integrations/util/cache.py
@@ -28,10 +28,6 @@ class Cache:
             level = "error" if self.invalid else "warning"
             capture_exception(e, level=level)
 
-    def is_valid(self) -> bool:
-        """Returns True if the cache has been successfully populated at least once."""
-        return not self.invalid
-
     def save(self, data):
         self.data = data
 

--- a/integrations/util/cache.py
+++ b/integrations/util/cache.py
@@ -25,7 +25,12 @@ class Cache:
         except Exception as e:
             if settings.DEBUG:
                 print(e)
-            capture_exception(e, level="warning")
+            level = "error" if self.invalid else "warning"
+            capture_exception(e, level=level)
+
+    def is_valid(self) -> bool:
+        """Returns True if the cache has been successfully populated at least once."""
+        return not self.invalid
 
     def save(self, data):
         self.data = data

--- a/programs/programs/co/child_care_assistance/calculator.py
+++ b/programs/programs/co/child_care_assistance/calculator.py
@@ -41,15 +41,16 @@ class ChildCareAssistance(ProgramCalculator):
                 county_name = county
         e.condition(in_county_limits, messages.location())
 
-        # income
-        frequency = "yearly"
-        gross_income = self.screen.calc_gross_income(frequency, ["all"], ["cashAssistance"])
-        deductions = self.screen.calc_expenses(frequency, ["childSupport"])
-        net_income = gross_income - deductions
-        fpl_percent = cccap_county_limits[county_name] / 100
-        fpl = self.program.year.as_dict()
-        income_limit = fpl[self.screen.household_size] * fpl_percent
-        e.condition(net_income <= income_limit, messages.income(net_income, income_limit))
+        # income — only calculated if county is in CCCAP limits
+        if in_county_limits:
+            frequency = "yearly"
+            gross_income = self.screen.calc_gross_income(frequency, ["all"], ["cashAssistance"])
+            deductions = self.screen.calc_expenses(frequency, ["childSupport"])
+            net_income = gross_income - deductions
+            fpl_percent = cccap_county_limits[county_name] / 100
+            fpl = self.program.year.as_dict()
+            income_limit = fpl[self.screen.household_size] * fpl_percent
+            e.condition(net_income <= income_limit, messages.income(net_income, income_limit))
 
         # assets
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [MFB-1089](https://linear.app/myfriendben/issue/MFB-1089/cccap-eligibility-500s-when-google-sheets-cache-fetch-fails)

Prod is intermittently throwing KeyError: 'Adams County' (and presumably other CO counties) from the Colorado Child Care Assistance (CCCAP) calculator. Root cause: the Google Sheets-backed FPL limits cache silently falls back to an empty dict {} when the initial sheet fetch fails, and the calculator then unconditionally indexes into it.

## Changes Made

Implemented a 3-layer fix to increase resilience, from highest to lowest priority:

- **Layer 1 - Calculator Guard (calculator.py)**: Added a safety check. If the Google Sheets data is missing or empty, we skip the income calculation entirely. This stops the app from crashing (the 500 error).

- **Layer 2 - Cache Hardening (cache.py):** Updated how we track errors. Now, if the app fails to get the Google Sheets data on its very first try, it triggers a critical "error" alert in instead of a quiet "warning." This way, the team knows right away if the data is completely missing.

- **Layer 3 - Retry Logic (sheets.py):** Added an auto-retry feature. If the app gets a quick network error while trying to talk to Google Sheets, it won't give up immediately. It will wait a second and try again (up to 3 times). This prevents random internet blips from breaking the cache.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:

1. In `calculator.py`, temporarily change line 32 to `cccap_county_limits = {}` to simulate a complete cache failure.
2. Run the local backend `python manage.py runserver` and local frontend.
3. Submit a screener for Colorado (ZIP 80022), 1 adult, 1 child (age 3), and montly $1200 income.
4. Observe that the API returns a `200 OK `(CCCAP simply returns as ineligible due to location) instead of throwing a `500 KeyError`.
5. Remove the temporary `{} `override and run the same test to ensure the happy path (Google Sheets fetch) still works correctly.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added retry logic for external spreadsheet data fetches to reduce transient failures.
  * Fixed child care assistance income eligibility so calculations only apply when county data is supported.

* **Improvements**
  * Improved cache monitoring by reporting error severity based on cache state rather than always as a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->