### PR TITLE
MFB-869: CB Step 5a — Make join table the primary write target, replace sync

### DIFF
--- a/programs/programs/il/nurse_family_partnership/tests.py
+++ b/programs/programs/il/nurse_family_partnership/tests.py
@@ -10,7 +10,7 @@ Tests verify:
 from django.test import TestCase
 from programs.programs.il.nurse_family_partnership.calculator import IlNurseFamilyPartnership
 from screener.models import Screen, HouseholdMember, IncomeStream, WhiteLabel
-from screener.tests.helpers import seed_program, sync_current_benefits
+from screener.tests.helpers import seed_program, set_current_benefits
 from programs.models import Program, FederalPoveryLimit
 from programs.util import Dependencies
 
@@ -71,9 +71,7 @@ class TestIlNurseFamilyPartnership(TestCase):
     def test_household_eligible_with_wic_regardless_of_income(self):
         """Test household is eligible with WIC (presumed eligibility) regardless of income."""
         seed_program(self.il_white_label, "wic")
-        self.screen.has_wic = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "wic")
 
         parent = HouseholdMember.objects.create(
             screen=self.screen,

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -7,7 +7,7 @@ by PolicyEngine to determine TX SNAP eligibility and benefit amounts.
 
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Expense
-from screener.tests.helpers import seed_program, sync_current_benefits
+from screener.tests.helpers import seed_program, set_current_benefits
 from programs.programs.policyengine.calculators.dependencies import spm
 
 
@@ -453,9 +453,7 @@ class TestSnapDependency(TestCase):
     def test_value_returns_1_when_screen_has_snap(self):
         """When user reports having SNAP, send 1 to PE to enable categorical eligibility."""
         seed_program(self.white_label, "snap")
-        self.screen.has_snap = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "snap")
 
         dep = spm.Snap(self.screen, None, {})
         self.assertEqual(dep.value(), 1)
@@ -490,9 +488,7 @@ class TestTanfDependency(TestCase):
     def test_value_returns_1_when_screen_has_tanf(self):
         """When user reports having TANF, send 1 to PE to enable categorical eligibility."""
         seed_program(self.white_label, "tanf")
-        self.screen.has_tanf = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "tanf")
 
         dep = spm.Tanf(self.screen, None, {})
         self.assertEqual(dep.value(), 1)

--- a/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
+++ b/programs/programs/urgent_needs/tx/test_urgent_needs_functions.py
@@ -14,7 +14,7 @@ from programs.programs.urgent_needs.tx.trust_her import TrustHer
 from programs.programs.urgent_needs.tx.wic import Wic
 from programs.util import Dependencies
 from screener.models import HouseholdMember, Screen, WhiteLabel
-from screener.tests.helpers import seed_program, sync_current_benefits
+from screener.tests.helpers import seed_program, set_current_benefits
 from translations.models import Translation
 
 
@@ -65,9 +65,7 @@ class TestSnapEmploymentTraining(TestCase):
 
     def test_eligible_when_screen_has_snap(self):
         seed_program(self.white_label, "tx_snap")
-        self.screen.has_snap = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "tx_snap")
         self.assertTrue(self._calc([]))
 
     def test_not_eligible_without_snap(self):
@@ -97,9 +95,7 @@ class TestDoubleUpFoodBucks(TestCase):
 
     def test_eligible_when_screen_has_snap(self):
         seed_program(self.white_label, "tx_snap")
-        self.screen.has_snap = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "tx_snap")
         self.assertTrue(self._calc([]))
 
     def test_not_eligible_without_snap(self):

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -8,7 +8,7 @@ from programs.programs.wa import wa_calculators
 from programs.programs.wa.nslp.calculator import WaNslp
 from programs.util import Dependencies
 from screener.models import HouseholdMember, IncomeStream, Screen, WhiteLabel
-from screener.tests.helpers import seed_program, sync_current_benefits
+from screener.tests.helpers import seed_program, set_current_benefits
 
 
 class TestWaNslp(TestCase):
@@ -151,8 +151,8 @@ class TestWaNslp(TestCase):
 
     def test_ineligible_already_has_nslp(self):
         seed_program(self.white_label, "nslp")
-        screen = self._screen_base(has_nslp=True)
-        sync_current_benefits(screen)
+        screen = self._screen_base()
+        set_current_benefits(screen, "nslp")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=2000, frequency="monthly"

--- a/screener/models.py
+++ b/screener/models.py
@@ -380,167 +380,6 @@ class Screen(models.Model):
 
         return False
 
-    def _build_benefit_map(self) -> dict:
-        """
-        Returns the full name_abbreviated → bool map for this screen, including
-        compound conditions (ssi via has_ssi OR sSI income; ma_mass_health via
-        has_medicaid OR has_medicaid_hi).
-
-        Only used by `_sync_current_benefits()` (and its test-helper mirror in
-        `screener/tests/helpers.py`) to write CurrentBenefit rows during the
-        dual-write phase. `HouseholdMember.has_benefit()` does NOT route through
-        here — it has its own member-level `name_map` keyed off `self.insurance`.
-
-        Removed in MFB-869 alongside `_sync_current_benefits` once the serializer
-        writes join-table rows directly from the frontend's `current_benefits: [...]`
-        payload.
-        """
-        has_ssi_or_ssi_income = self.has_ssi or self.calc_gross_income("yearly", ("sSI",)) > 0
-
-        return {
-            "tanf": self.has_tanf,
-            "nc_tanf": self.has_tanf,
-            "co_tanf": self.has_tanf,
-            "il_tanf": self.has_tanf,
-            "tx_tanf": self.has_tanf,
-            "wic": self.has_wic,
-            "co_wic": self.has_wic,
-            "il_wic": self.has_wic,
-            "nc_wic": self.has_wic,
-            "tx_wic": self.has_wic,
-            "snap": self.has_snap,
-            "sunbucks": self.has_sunbucks,
-            "co_snap": self.has_snap,
-            "nc_snap": self.has_snap,
-            "il_snap": self.has_snap,
-            "tx_snap": self.has_snap,
-            "wa_snap": self.has_snap,
-            "lifeline": self.has_lifeline,
-            "tx_lifeline": self.has_lifeline,
-            "wa_lifeline": self.has_lifeline,
-            "acp": self.has_acp,
-            "eitc": self.has_eitc,
-            "tx_eitc": self.has_eitc,
-            "coeitc": self.has_coeitc,
-            "il_eitc": self.has_il_eitc,
-            "nslp": self.has_nslp,
-            "tx_nslp": self.has_nslp,
-            "wa_nslp": self.has_nslp,
-            "ctc": self.has_ctc,
-            "tx_ctc": self.has_ctc,
-            "wa_ctc": self.has_ctc,
-            "il_ctc": self.has_il_ctc,
-            "il_transit_reduced_fare": self.has_il_transit_reduced_fare,
-            "il_bap": self.has_il_bap,
-            "il_csfp": self.has_csfp,
-            "il_hbwd": self.has_il_hbwd,
-            "il_ccap": self.has_ccap,
-            "cesn_cope": self.has_project_cope,
-            "cesn_heap": self.has_cesn_heap,
-            "rtdlive": self.has_rtdlive,
-            "cccap": self.has_ccap,
-            "mydenver": self.has_mydenver,
-            "ssi": has_ssi_or_ssi_income,
-            "tx_ssi": has_ssi_or_ssi_income,
-            "wa_ssi": has_ssi_or_ssi_income,
-            "tx_csfp": self.has_csfp,
-            "tx_harris_rides": self.has_harris_county_rides,
-            "andcs": self.has_andcs,
-            "co_head_start": self.has_head_start,
-            "cpcr": self.has_cpcr,
-            "cesn_cpcr": self.has_cpcr,
-            "cdhcs": self.has_cdhcs,
-            "dpp": self.has_dpp,
-            "ede": self.has_ede,
-            "erc": self.has_erc,
-            "leap": self.has_leap,
-            "cesn_leap": self.has_leap,
-            "ma_heap": self.has_ma_heap,
-            "il_liheap": self.has_il_liheap,
-            "nc_lieap": self.has_nc_lieap,
-            "oap": self.has_oap,
-            "nccip": self.has_nccip,
-            "nc_scca": self.has_ncscca,
-            "nc_head_start": self.has_head_start,
-            "coctc": self.has_coctc,
-            "upk": self.has_upk,
-            "ssdi": self.has_ssdi,
-            "pell_grant": self.has_pell_grant,
-            "rag": self.has_rag,
-            "co_nfp": self.has_nfp,
-            "il_nfp": self.has_nfp,
-            "fatc": self.has_fatc,
-            "ma_cha": self.has_section_8,
-            "cowap": self.has_cowap,
-            "cesn_cowap": self.has_cowap,
-            "ncwap": self.has_ncwap,
-            "wa_wap": self.has_wa_wap,
-            "ubp": self.has_ubp,
-            "cesn_ubp": self.has_ubp,
-            "nfp": self.has_nfp,
-            "section_8": self.has_section_8,
-            "co_section_8": self.has_section_8,
-            "ma_section_8": self.has_section_8,
-            "aca": self.has_aca,
-            "medicaid": self.has_medicaid,
-            "nc_aca": self.has_aca,
-            "ma_aca": self.has_aca,
-            "tx_aca": self.has_aca,
-            "ma_mbta": self.has_ma_mbta,
-            "ma_snap": self.has_snap,
-            "ma_ccdf": self.has_ccdf,
-            "ma_wic": self.has_wic,
-            "ma_eaedc": self.has_ma_eaedc,
-            "ma_maeitc": self.has_ma_maeitc,
-            "ma_cfc": self.has_ma_macfc,
-            "ma_homebridge": self.has_ma_homebridge,
-            "ma_dhsp_afterschool": self.has_ma_dhsp_afterschool,
-            "ma_door_to_door": self.has_ma_door_to_door,
-            "ma_taxi_discount": self.has_ma_taxi_discount,
-            "ma_cpp": self.has_ma_cpp,
-            "ma_middle_income_rental": self.has_ma_middle_income_rental,
-            "ma_cmsp": self.has_ma_cmsp,
-            "ma_tafdc": self.has_tanf,
-            "ma_mass_health": self.has_medicaid or self.has_medicaid_hi,
-            "ma_head_start": self.has_head_start,
-            "tx_head_start": self.has_head_start,
-            "wa_head_start": self.has_head_start,
-            "ma_csfp": self.has_csfp,
-            "ma_early_head_start": self.has_early_head_start,
-            "tx_early_head_start": self.has_early_head_start,
-            "co_andso": self.has_co_andso,
-            "cesn_andso": self.has_co_andso,
-            "co_care": self.has_co_care,
-            "cesn_care": self.has_co_care,
-            "cfhc": self.has_cfhc,
-            "shitc": self.has_shitc,
-            "nc_medicare_savings": self.has_nc_medicare_savings,
-            "tx_dart": self.has_tx_dart,
-            "ccs": self.has_ccs,
-            "tx_ccs": self.has_ccs,
-            "tx_ssdi": self.has_ssdi,
-            "wa_ssdi": self.has_ssdi,
-            "wa_csfp": self.has_csfp,
-            "wa_eitc": self.has_eitc,
-            "wa_wftc": self.has_eitc,
-            "wa_wic": self.has_wic,
-            "wa_apple_health_medicaid": self.has_medicaid,
-            "wa_apple_health_for_kids": self.has_chp,
-            "wa_hcv": self.has_section_8,
-            "ma_ssp": self.has_ma_ssp,
-            "cesn_snap": self.has_snap,
-            "cesn_tanf": self.has_tanf,
-            "cesn_wic": self.has_wic,
-            "cesn_ssi": has_ssi_or_ssi_income,
-            "cesn_ssdi": self.has_ssdi,
-            "cesn_oap": self.has_oap,
-            "cesn_section_8": self.has_section_8,
-            "cesn_rtdlive": self.has_rtdlive,
-            "cesn_andcs": self.has_andcs,
-            "nc_leap": self.has_leap,
-            "nc_cccap": self.has_ccap,
-        }
-
     @cached_property
     def _current_benefit_names(self) -> set[str]:
         # Serves from prefetch cache when `current_benefits__program` is prefetched
@@ -551,7 +390,7 @@ class Screen(models.Model):
         # NOT see rows written after, even on the same instance. Concretely:
         #
         #     screen.has_snap = True
-        #     screen.save()                  # triggers _sync_current_benefits via serializer
+        #     screen.save()                  # serializer writes the join table
         #     screen.has_benefit("snap")     # ❌ may return False — cache populated pre-write
         #
         # Do NOT reach for `del screen._current_benefit_names` to invalidate —
@@ -563,7 +402,7 @@ class Screen(models.Model):
         #
         # The eligibility hot path is safe — the view fetches a fresh Screen
         # on every request. Only admin actions / management commands / tests
-        # that mutate has_* and then read on the same instance are at risk.
+        # that write current_benefits and then read on the same instance are at risk.
         #
         # This whole cache (and has_benefit itself) disappears in MFB-720 when
         # the has_* columns are dropped and current_benefits becomes the only
@@ -576,16 +415,16 @@ class Screen(models.Model):
         identified by `name_abbreviated`. Drives the "already_has" flag on
         eligibility results so the frontend can filter the program out.
 
-        Reads from the CurrentBenefit join table. The has_* columns are
-        still written by the serializer (Phase 2 dual-write) and synced to the
-        join table on every POST/PATCH via _sync_current_benefits(), so this
-        query is the authoritative read path while rollback remains a single
-        revert.
+        Reads from the CurrentBenefit join table — the primary write target as
+        of Step 5a (MFB-869). The join table is written on every POST/PATCH by
+        the serializer's `_write_current_benefits()`: directly from the
+        frontend's `current_benefits` list, or (backward compat, until Step 6)
+        mirrored from the legacy has_* columns.
 
         Compound conditions (ssi → has_ssi OR sSI income; ma_mass_health →
-        has_medicaid OR has_medicaid_hi) are resolved at write time by
-        _sync_current_benefits → _build_benefit_map, so this read path needs
-        no special-casing.
+        has_medicaid OR has_medicaid_hi) are resolved at write time in the
+        has_* backward-compat path (`_benefit_map_from_has_columns()`), so this
+        read path needs no special-casing.
         """
         return name_abbreviated in self._current_benefit_names
 

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -336,12 +336,25 @@ def _write_current_benefits(screen, current_benefits):
             # Primary path: frontend sent explicit program names. Resolve each in
             # this screen's white label; silently drop any this WL doesn't offer.
             requested = set(current_benefits)
-            program_ids_to_write = list(
-                Program.objects.filter(
-                    white_label=screen.white_label,
-                    name_abbreviated__in=requested,
-                ).values_list("id", flat=True)
-            )
+            resolved = Program.objects.filter(
+                white_label=screen.white_label,
+                name_abbreviated__in=requested,
+            ).values_list("id", "name_abbreviated")
+            program_ids_to_write = [program_id for program_id, _ in resolved]
+
+            # A requested name with no Program in this WL is dropped rather than
+            # erroring (a WL only writes the programs it offers). During the Step 6
+            # FE cutover that's also how a typo'd / stale name_abbreviated vanishes,
+            # so log it — visible in Heroku logs (heroku logs -a cobenefits-api),
+            # not Sentry, since it's info-level and benign.
+            dropped = requested - {name for _, name in resolved}
+            if dropped:
+                logger.info(
+                    "current_benefits: dropped %d name(s) not offered by white_label %s: %s",
+                    len(dropped),
+                    screen.white_label_id,
+                    sorted(dropped),
+                )
 
         CurrentBenefit.objects.filter(screen=screen).delete()
         if program_ids_to_write:

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -138,7 +138,7 @@ class HouseholdMemberSerializer(serializers.ModelSerializer):
         read_only_fields = ("screen", "id")
 
 
-def _benefit_map_from_has_columns(screen) -> dict:
+def _benefit_map_from_has_columns(screen: Screen) -> dict[str, bool]:
     """
     Returns the full `name_abbreviated → bool` map for a screen derived from its
     legacy `has_*` columns, including the fan-out (one `has_*` column → many WL
@@ -309,7 +309,7 @@ def _benefit_map_from_has_columns(screen) -> dict:
 _SSI_BENEFIT_NAMES = frozenset({"ssi", "tx_ssi", "wa_ssi", "cesn_ssi"})
 
 
-def _derived_current_benefit_names(screen) -> set[str]:
+def _derived_current_benefit_names(screen: Screen) -> set[str]:
     """`name_abbreviated` values implied by screen state, independent of the
     frontend's current-benefits toggles.
 
@@ -329,7 +329,7 @@ def _derived_current_benefit_names(screen) -> set[str]:
     return derived
 
 
-def _write_current_benefits(screen, current_benefits):
+def _write_current_benefits(screen: Screen, current_benefits: list[str] | None) -> None:
     """
     Write the CurrentBenefit join table for `screen`, replacing any existing rows.
 

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -137,24 +137,212 @@ class HouseholdMemberSerializer(serializers.ModelSerializer):
         read_only_fields = ("screen", "id")
 
 
-def _sync_current_benefits(screen):
+def _benefit_map_from_has_columns(screen) -> dict:
     """
-    Syncs CurrentBenefit rows for a screen based on has_* column values.
-    Called on every POST/PATCH so the join table stays in sync with the authoritative has_* columns.
-    Reads still come from has_* columns — this is Phase 2 dual-write only.
+    Returns the full `name_abbreviated → bool` map for a screen derived from its
+    legacy `has_*` columns, including the fan-out (one `has_*` column → many WL
+    program variants, e.g. `has_tanf` → tanf / co_tanf / il_tanf / …) and the
+    compound conditions (`ssi` via has_ssi OR sSI income; `ma_mass_health` via
+    has_medicaid OR has_medicaid_hi).
 
-    Uses select_for_update() inside a transaction to serialize concurrent PATCH requests
-    on the same screen and prevent races on the delete+bulk_create. The screen is re-fetched
-    inside the atomic block so program_ids_to_write reflects the post-lock committed state.
+    Only used by the backward-compat write path in `_write_current_benefits()`:
+    when an old frontend PATCHes `has_*` fields (and no `current_benefits` list),
+    we mirror those columns into the CurrentBenefit join table so `has_benefit()`
+    (which reads the join table per Step 3a / MFB-719) stays correct.
+
+    Relocated here from `Screen._build_benefit_map()` in Step 5a (MFB-869). Dies
+    together with the `has_*` write path in Step 6 (MFB-720), once the frontend
+    sends `current_benefits` exclusively.
+    """
+    has_ssi_or_ssi_income = screen.has_ssi or screen.calc_gross_income("yearly", ("sSI",)) > 0
+
+    return {
+        "tanf": screen.has_tanf,
+        "nc_tanf": screen.has_tanf,
+        "co_tanf": screen.has_tanf,
+        "il_tanf": screen.has_tanf,
+        "tx_tanf": screen.has_tanf,
+        "wic": screen.has_wic,
+        "co_wic": screen.has_wic,
+        "il_wic": screen.has_wic,
+        "nc_wic": screen.has_wic,
+        "tx_wic": screen.has_wic,
+        "snap": screen.has_snap,
+        "sunbucks": screen.has_sunbucks,
+        "co_snap": screen.has_snap,
+        "nc_snap": screen.has_snap,
+        "il_snap": screen.has_snap,
+        "tx_snap": screen.has_snap,
+        "wa_snap": screen.has_snap,
+        "lifeline": screen.has_lifeline,
+        "tx_lifeline": screen.has_lifeline,
+        "wa_lifeline": screen.has_lifeline,
+        "acp": screen.has_acp,
+        "eitc": screen.has_eitc,
+        "tx_eitc": screen.has_eitc,
+        "coeitc": screen.has_coeitc,
+        "il_eitc": screen.has_il_eitc,
+        "nslp": screen.has_nslp,
+        "tx_nslp": screen.has_nslp,
+        "wa_nslp": screen.has_nslp,
+        "ctc": screen.has_ctc,
+        "tx_ctc": screen.has_ctc,
+        "wa_ctc": screen.has_ctc,
+        "il_ctc": screen.has_il_ctc,
+        "il_transit_reduced_fare": screen.has_il_transit_reduced_fare,
+        "il_bap": screen.has_il_bap,
+        "il_csfp": screen.has_csfp,
+        "il_hbwd": screen.has_il_hbwd,
+        "il_ccap": screen.has_ccap,
+        "cesn_cope": screen.has_project_cope,
+        "cesn_heap": screen.has_cesn_heap,
+        "rtdlive": screen.has_rtdlive,
+        "cccap": screen.has_ccap,
+        "mydenver": screen.has_mydenver,
+        "ssi": has_ssi_or_ssi_income,
+        "tx_ssi": has_ssi_or_ssi_income,
+        "wa_ssi": has_ssi_or_ssi_income,
+        "tx_csfp": screen.has_csfp,
+        "tx_harris_rides": screen.has_harris_county_rides,
+        "andcs": screen.has_andcs,
+        "co_head_start": screen.has_head_start,
+        "cpcr": screen.has_cpcr,
+        "cesn_cpcr": screen.has_cpcr,
+        "cdhcs": screen.has_cdhcs,
+        "dpp": screen.has_dpp,
+        "ede": screen.has_ede,
+        "erc": screen.has_erc,
+        "leap": screen.has_leap,
+        "cesn_leap": screen.has_leap,
+        "ma_heap": screen.has_ma_heap,
+        "il_liheap": screen.has_il_liheap,
+        "nc_lieap": screen.has_nc_lieap,
+        "oap": screen.has_oap,
+        "nccip": screen.has_nccip,
+        "nc_scca": screen.has_ncscca,
+        "nc_head_start": screen.has_head_start,
+        "coctc": screen.has_coctc,
+        "upk": screen.has_upk,
+        "ssdi": screen.has_ssdi,
+        "pell_grant": screen.has_pell_grant,
+        "rag": screen.has_rag,
+        "co_nfp": screen.has_nfp,
+        "il_nfp": screen.has_nfp,
+        "fatc": screen.has_fatc,
+        "ma_cha": screen.has_section_8,
+        "cowap": screen.has_cowap,
+        "cesn_cowap": screen.has_cowap,
+        "ncwap": screen.has_ncwap,
+        "wa_wap": screen.has_wa_wap,
+        "ubp": screen.has_ubp,
+        "cesn_ubp": screen.has_ubp,
+        "nfp": screen.has_nfp,
+        "section_8": screen.has_section_8,
+        "co_section_8": screen.has_section_8,
+        "ma_section_8": screen.has_section_8,
+        "aca": screen.has_aca,
+        "medicaid": screen.has_medicaid,
+        "nc_aca": screen.has_aca,
+        "ma_aca": screen.has_aca,
+        "tx_aca": screen.has_aca,
+        "ma_mbta": screen.has_ma_mbta,
+        "ma_snap": screen.has_snap,
+        "ma_ccdf": screen.has_ccdf,
+        "ma_wic": screen.has_wic,
+        "ma_eaedc": screen.has_ma_eaedc,
+        "ma_maeitc": screen.has_ma_maeitc,
+        "ma_cfc": screen.has_ma_macfc,
+        "ma_homebridge": screen.has_ma_homebridge,
+        "ma_dhsp_afterschool": screen.has_ma_dhsp_afterschool,
+        "ma_door_to_door": screen.has_ma_door_to_door,
+        "ma_taxi_discount": screen.has_ma_taxi_discount,
+        "ma_cpp": screen.has_ma_cpp,
+        "ma_middle_income_rental": screen.has_ma_middle_income_rental,
+        "ma_cmsp": screen.has_ma_cmsp,
+        "ma_tafdc": screen.has_tanf,
+        "ma_mass_health": screen.has_medicaid or screen.has_medicaid_hi,
+        "ma_head_start": screen.has_head_start,
+        "tx_head_start": screen.has_head_start,
+        "wa_head_start": screen.has_head_start,
+        "ma_csfp": screen.has_csfp,
+        "ma_early_head_start": screen.has_early_head_start,
+        "tx_early_head_start": screen.has_early_head_start,
+        "co_andso": screen.has_co_andso,
+        "cesn_andso": screen.has_co_andso,
+        "co_care": screen.has_co_care,
+        "cesn_care": screen.has_co_care,
+        "cfhc": screen.has_cfhc,
+        "shitc": screen.has_shitc,
+        "nc_medicare_savings": screen.has_nc_medicare_savings,
+        "tx_dart": screen.has_tx_dart,
+        "ccs": screen.has_ccs,
+        "tx_ccs": screen.has_ccs,
+        "tx_ssdi": screen.has_ssdi,
+        "wa_ssdi": screen.has_ssdi,
+        "wa_csfp": screen.has_csfp,
+        "wa_eitc": screen.has_eitc,
+        "wa_wftc": screen.has_eitc,
+        "wa_wic": screen.has_wic,
+        "wa_apple_health_medicaid": screen.has_medicaid,
+        "wa_apple_health_for_kids": screen.has_chp,
+        "wa_hcv": screen.has_section_8,
+        "ma_ssp": screen.has_ma_ssp,
+        "cesn_snap": screen.has_snap,
+        "cesn_tanf": screen.has_tanf,
+        "cesn_wic": screen.has_wic,
+        "cesn_ssi": has_ssi_or_ssi_income,
+        "cesn_ssdi": screen.has_ssdi,
+        "cesn_oap": screen.has_oap,
+        "cesn_section_8": screen.has_section_8,
+        "cesn_rtdlive": screen.has_rtdlive,
+        "cesn_andcs": screen.has_andcs,
+        "nc_leap": screen.has_leap,
+        "nc_cccap": screen.has_ccap,
+    }
+
+
+def _write_current_benefits(screen, current_benefits):
+    """
+    Write the CurrentBenefit join table for `screen`, replacing any existing rows.
+
+    The join table is the primary write target as of Step 5a (MFB-869):
+
+    * New frontend — passes `current_benefits` as a list of `name_abbreviated`
+      strings (e.g. ["tx_snap", "tanf"]). Each is resolved to a Program via the
+      WL-scoped unique (white_label, name_abbreviated) lookup and written directly.
+      Unknown names are skipped (a name the current WL doesn't offer is a no-op,
+      mirroring the old map's behavior of only writing programs in this WL).
+    * Old frontend (backward compat) — passes `current_benefits=None`; we derive
+      the program set from the legacy `has_*` columns via
+      `_benefit_map_from_has_columns()`. Removed in Step 6 (MFB-720).
+
+    Uses select_for_update() inside a transaction to serialize concurrent PATCH
+    requests on the same screen and prevent races on the delete+bulk_create. The
+    screen is re-fetched inside the atomic block so the write reflects the
+    post-lock committed state.
     """
     with transaction.atomic():
         screen = Screen.objects.select_for_update().get(pk=screen.pk)
-        benefit_map = screen._build_benefit_map()
-        program_ids_to_write = [
-            program.id
-            for program in Program.objects.filter(white_label=screen.white_label)
-            if benefit_map.get(program.name_abbreviated, False)
-        ]
+
+        if current_benefits is None:
+            # Backward-compat path: mirror legacy has_* columns into the join table.
+            benefit_map = _benefit_map_from_has_columns(screen)
+            program_ids_to_write = [
+                program.id
+                for program in Program.objects.filter(white_label=screen.white_label)
+                if benefit_map.get(program.name_abbreviated, False)
+            ]
+        else:
+            # Primary path: frontend sent explicit program names. Resolve each in
+            # this screen's white label; silently drop any this WL doesn't offer.
+            requested = set(current_benefits)
+            program_ids_to_write = list(
+                Program.objects.filter(
+                    white_label=screen.white_label,
+                    name_abbreviated__in=requested,
+                ).values_list("id", flat=True)
+            )
+
         CurrentBenefit.objects.filter(screen=screen).delete()
         if program_ids_to_write:
             CurrentBenefit.objects.bulk_create(
@@ -168,6 +356,12 @@ class ScreenSerializer(serializers.ModelSerializer):
     user = UserOffersSerializer(read_only=True)
     white_label = serializers.CharField(source="white_label.code")
     energy_calculator = EnergyCalculatorScreenSerializer(required=False, allow_null=True)
+    # Primary write target for current benefits (Step 5a / MFB-869): a list of
+    # `name_abbreviated` strings the household already receives. Write-only — reads
+    # still surface per-program via the eligibility "already_has" flag. When absent
+    # the legacy has_* columns drive the join-table write (backward compat, removed
+    # in Step 6 / MFB-720).
+    current_benefits = serializers.ListField(child=serializers.CharField(), required=False, write_only=True)
 
     class Meta:
         model = Screen
@@ -198,6 +392,7 @@ class ScreenSerializer(serializers.ModelSerializer):
             "user",
             "external_id",
             "request_language_code",
+            "current_benefits",
             "has_benefits",
             "has_tanf",
             "has_wic",
@@ -335,6 +530,8 @@ class ScreenSerializer(serializers.ModelSerializer):
         household_members = validated_data.pop("household_members")
         expenses = validated_data.pop("expenses")
         energy_calculator_screen = validated_data.pop("energy_calculator", None)
+        # None (key absent) → old frontend, mirror from has_*; a list → new frontend.
+        current_benefits = validated_data.pop("current_benefits", None)
         screen = Screen.objects.create(**validated_data, completed=False)
         screen.set_screen_is_test()
         for member in household_members:
@@ -352,7 +549,7 @@ class ScreenSerializer(serializers.ModelSerializer):
             Expense.objects.create(**expense, screen=screen)
         if energy_calculator_screen is not None:
             EnergyCalculatorScreen.objects.create(**energy_calculator_screen, screen=screen)
-        _sync_current_benefits(screen)
+        _write_current_benefits(screen, current_benefits)
         return screen
 
     def update(self, instance, validated_data):
@@ -362,6 +559,9 @@ class ScreenSerializer(serializers.ModelSerializer):
         household_members = validated_data.pop("household_members")
         expenses = validated_data.pop("expenses")
         energy_calculator_screen = validated_data.pop("energy_calculator", None)
+        # Not a Screen column — pop before the bulk .update(). None (key absent) →
+        # old frontend, mirror from has_*; a list → new frontend writes directly.
+        current_benefits = validated_data.pop("current_benefits", None)
 
         # don't update create only fields
         for field in self.Meta.create_only_fields:
@@ -389,7 +589,7 @@ class ScreenSerializer(serializers.ModelSerializer):
             EnergyCalculatorScreen.objects.create(**energy_calculator_screen, screen=instance)
         instance.refresh_from_db()
         instance.set_screen_is_test()
-        _sync_current_benefits(instance)
+        _write_current_benefits(instance, current_benefits)
         return instance
 
 

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -2,6 +2,7 @@ import logging
 from datetime import date
 from django.db import IntegrityError, transaction
 from django.utils import timezone
+from sentry_sdk import capture_message
 
 logger = logging.getLogger(__name__)
 from programs.models import Program, WarningMessage
@@ -301,6 +302,33 @@ def _benefit_map_from_has_columns(screen) -> dict:
     }
 
 
+# SSI program variants across white labels. An sSI income stream implies SSI
+# receipt regardless of whether the user ticked the tile, so all variants are
+# listed here; the WL-scoped resolve in `_write_current_benefits()` drops the
+# ones a given white label doesn't offer (e.g. `wa_ssi` on a CO screen).
+_SSI_BENEFIT_NAMES = frozenset({"ssi", "tx_ssi", "wa_ssi", "cesn_ssi"})
+
+
+def _derived_current_benefit_names(screen) -> set[str]:
+    """`name_abbreviated` values implied by screen state, independent of the
+    frontend's current-benefits toggles.
+
+    OR'd into the frontend's `current_benefits` list inside `_write_current_benefits()`
+    so the join table reflects benefits the household demonstrably receives even when
+    the tile wasn't ticked (or was explicitly unticked) — preserving the long-standing
+    compound semantics of `Screen.has_benefit()`.
+
+    Today there is one rule: an sSI income stream implies SSI. The `chp` and
+    `ma_mass_health` compounds are deliberately NOT here — those are member-level
+    insurance checks (`HouseholdMember.has_benefit()` / `member.insurance.*`) and never
+    flow through `current_benefits`. Add new derivable compounds here as they appear.
+    """
+    derived: set[str] = set()
+    if screen.calc_gross_income("yearly", ("sSI",)) > 0:
+        derived |= _SSI_BENEFIT_NAMES
+    return derived
+
+
 def _write_current_benefits(screen, current_benefits):
     """
     Write the CurrentBenefit join table for `screen`, replacing any existing rows.
@@ -312,6 +340,9 @@ def _write_current_benefits(screen, current_benefits):
       WL-scoped unique (white_label, name_abbreviated) lookup and written directly.
       Unknown names are skipped (a name the current WL doesn't offer is a no-op,
       mirroring the old map's behavior of only writing programs in this WL).
+      Names derivable from screen state (currently SSI, via an sSI income stream)
+      are OR'd in via `_derived_current_benefit_names()` so the join table keeps
+      the long-standing compound semantics even when the tile wasn't ticked.
     * Old frontend (backward compat) — passes `current_benefits=None`; we derive
       the program set from the legacy `has_*` columns via
       `_benefit_map_from_has_columns()`. Removed in Step 6 (MFB-720).
@@ -333,27 +364,34 @@ def _write_current_benefits(screen, current_benefits):
                 if benefit_map.get(program.name_abbreviated, False)
             ]
         else:
-            # Primary path: frontend sent explicit program names. Resolve each in
-            # this screen's white label; silently drop any this WL doesn't offer.
+            # Primary path: frontend sent explicit program names, plus any names
+            # derivable from screen state (e.g. SSI from an sSI income stream).
+            # Resolve each in this screen's white label; silently drop any this WL
+            # doesn't offer.
             requested = set(current_benefits)
+            derived = _derived_current_benefit_names(screen)
             resolved = Program.objects.filter(
                 white_label=screen.white_label,
-                name_abbreviated__in=requested,
+                name_abbreviated__in=requested | derived,
             ).values_list("id", "name_abbreviated")
             program_ids_to_write = [program_id for program_id, _ in resolved]
 
-            # A requested name with no Program in this WL is dropped rather than
-            # erroring (a WL only writes the programs it offers). During the Step 6
-            # FE cutover that's also how a typo'd / stale name_abbreviated vanishes,
-            # so log it — visible in Heroku logs (heroku logs -a cobenefits-api),
-            # not Sentry, since it's info-level and benign.
+            # A *frontend-requested* name with no Program in this WL is dropped
+            # rather than erroring (a WL only writes the programs it offers). During
+            # the Step 6 FE cutover that's also how a typo'd / stale name_abbreviated
+            # vanishes — a config problem worth surfacing, so report it to Sentry.
+            # capture_message groups identical messages, so a recurring bad name
+            # collapses into one counted issue rather than paging per request; level
+            # is "warning" (not "error") because a dropped name is benign per request.
+            # Derived names (e.g. wa_ssi injected on a CO screen) are excluded — those
+            # are expected cross-WL non-matches, not client errors.
             dropped = requested - {name for _, name in resolved}
             if dropped:
-                logger.info(
-                    "current_benefits: dropped %d name(s) not offered by white_label %s: %s",
-                    len(dropped),
-                    screen.white_label_id,
-                    sorted(dropped),
+                capture_message(
+                    f"current_benefits: dropped {len(dropped)} name(s) not offered by white_label "
+                    f"{screen.white_label_id}: {sorted(dropped)}",
+                    level="warning",
+                    extras={"white_label_id": screen.white_label_id, "dropped": sorted(dropped)},
                 )
 
         CurrentBenefit.objects.filter(screen=screen).delete()
@@ -374,7 +412,16 @@ class ScreenSerializer(serializers.ModelSerializer):
     # still surface per-program via the eligibility "already_has" flag. When absent
     # the legacy has_* columns drive the join-table write (backward compat, removed
     # in Step 6 / MFB-720).
-    current_benefits = serializers.ListField(child=serializers.CharField(), required=False, write_only=True)
+    # Bounded to defend against unbounded/abusive payloads: there are ~130 distinct
+    # name_abbreviated values across all white labels, so 256 is a comfortable ceiling
+    # while still rejecting a degenerate list. Unknown names are dropped in
+    # _write_current_benefits(), so element content needn't be validated here.
+    current_benefits = serializers.ListField(
+        child=serializers.CharField(max_length=64),
+        required=False,
+        write_only=True,
+        max_length=256,
+    )
 
     class Meta:
         model = Screen

--- a/screener/tests/helpers.py
+++ b/screener/tests/helpers.py
@@ -9,10 +9,9 @@ the has_* columns are gone and tests write CurrentBenefit rows directly via
 the new `current_benefits: [...]` serializer payload.
 """
 
-from django.db import transaction
-
 from programs.models import Program
-from screener.models import CurrentBenefit, Screen, WhiteLabel
+from screener.models import Screen, WhiteLabel
+from screener.serializers import _write_current_benefits
 
 
 def seed_program(white_label: WhiteLabel, *name_abbreviateds: str) -> None:
@@ -23,25 +22,27 @@ def seed_program(white_label: WhiteLabel, *name_abbreviateds: str) -> None:
         Program.objects.new_program(white_label.code, name)
 
 
-def sync_current_benefits(screen: Screen) -> None:
-    """Mirror the serializer's dual-write: rebuild CurrentBenefit rows from the
-    current has_* column state on `screen`.
+def set_current_benefits(screen: Screen, *name_abbreviateds: str) -> None:
+    """Write CurrentBenefit join-table rows directly for `screen`, exercising the
+    primary write path (Step 5a / MFB-869) instead of the legacy
+    `has_* = True; sync_current_benefits()` mirror.
 
-    Body is intentionally inlined (rather than calling screener.serializers.
-    _sync_current_benefits) so this helper survives MFB-869, which deletes the
-    serializer function. The helper itself is deleted in MFB-720 once tests
-    can write join-table rows directly.
+    Delegates to the serializer's `_write_current_benefits()` with an explicit
+    `current_benefits` list — the same branch a new-frontend PATCH takes. Each
+    name must already exist as a Program in the screen's white label (call
+    `seed_program()` first). Replaces any existing rows for the screen.
     """
-    with transaction.atomic():
-        screen = Screen.objects.select_for_update().get(pk=screen.pk)
-        benefit_map = screen._build_benefit_map()
-        program_ids_to_write = [
-            program.id
-            for program in Program.objects.filter(white_label=screen.white_label)
-            if benefit_map.get(program.name_abbreviated, False)
-        ]
-        CurrentBenefit.objects.filter(screen=screen).delete()
-        if program_ids_to_write:
-            CurrentBenefit.objects.bulk_create(
-                [CurrentBenefit(screen=screen, program_id=pid) for pid in program_ids_to_write]
-            )
+    _write_current_benefits(screen, list(name_abbreviateds))
+
+
+def sync_current_benefits(screen: Screen) -> None:
+    """Mirror the serializer's backward-compat write: rebuild CurrentBenefit rows
+    from the current has_* column state on `screen`.
+
+    Delegates to the serializer's `_write_current_benefits(..., current_benefits=None)`
+    backward-compat branch — the same code path an old-frontend PATCH takes — so the
+    helper can't drift from production behavior. Tests that still set has_* columns
+    and call this remain valid until Step 6 (MFB-720) drops the has_* write path and
+    removes both the helper and the has_* branch.
+    """
+    _write_current_benefits(screen, None)

--- a/screener/tests/test_models.py
+++ b/screener/tests/test_models.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Expense
 from screener.feature_flags import FeatureFlagConfig
-from screener.tests.helpers import seed_program, sync_current_benefits
+from screener.tests.helpers import seed_program, set_current_benefits, sync_current_benefits
 
 
 class TestScreen(TestCase):
@@ -228,86 +228,75 @@ class TestScreen(TestCase):
 
     # Tests for Screen.has_benefit() method
     #
-    # has_benefit() reads from the CurrentBenefit join table. Tests set
-    # has_* columns (still the canonical write target during the dual-write
-    # phase) and invoke sync_current_benefits() to populate the join table —
-    # mirroring what every POST/PATCH does in production.
+    # has_benefit() reads from the CurrentBenefit join table (the primary write
+    # target as of Step 5a / MFB-869). These tests write join-table rows directly
+    # via set_current_benefits() — the same path a new-frontend `current_benefits`
+    # PATCH takes — instead of the legacy `has_* = True; sync_current_benefits()`
+    # mirror. The fan-out / compound cases below still use the has_* mirror on
+    # purpose, since that logic only lives on the backward-compat write path.
 
     def test_has_benefit_returns_true_when_user_has_snap(self):
-        """has_benefit('tx_snap') is True when has_snap=True and the join table is synced."""
+        """has_benefit('tx_snap') is True when the join table has the row."""
         seed_program(self.white_label, "tx_snap")
-        self.screen.has_snap = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "tx_snap")
 
         self.assertTrue(self.screen.has_benefit("tx_snap"))
 
     def test_has_benefit_returns_false_when_user_does_not_have_snap(self):
-        """has_benefit('tx_snap') is False when has_snap=False."""
+        """has_benefit('tx_snap') is False when no row was written."""
         seed_program(self.white_label, "tx_snap")
-        self.screen.has_snap = False
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("tx_snap"))
 
     def test_has_benefit_returns_true_when_user_has_wa_snap(self):
-        """has_benefit('wa_snap') is True when has_snap=True (multi-WL variant)."""
+        """has_benefit('wa_snap') is True when the join table has the row."""
         seed_program(self.white_label, "wa_snap")
-        self.screen.has_snap = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "wa_snap")
 
         self.assertTrue(self.screen.has_benefit("wa_snap"))
 
     def test_has_benefit_returns_false_when_user_does_not_have_wa_snap(self):
-        """has_benefit('wa_snap') is False when has_snap=False."""
+        """has_benefit('wa_snap') is False when no row was written."""
         seed_program(self.white_label, "wa_snap")
-        self.screen.has_snap = False
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("wa_snap"))
 
     def test_has_benefit_returns_true_for_ma_head_start_when_user_has_head_start(self):
-        """has_benefit('ma_head_start') is True when has_head_start=True."""
+        """has_benefit('ma_head_start') is True when the join table has the row."""
         seed_program(self.white_label, "ma_head_start")
-        self.screen.has_head_start = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "ma_head_start")
 
         self.assertTrue(self.screen.has_benefit("ma_head_start"))
 
     def test_has_benefit_returns_false_for_ma_head_start_when_user_does_not_have_head_start(self):
-        """has_benefit('ma_head_start') is False when has_head_start=False."""
+        """has_benefit('ma_head_start') is False when no row was written."""
         seed_program(self.white_label, "ma_head_start")
-        self.screen.has_head_start = False
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("ma_head_start"))
 
     def test_has_benefit_returns_true_for_ma_early_head_start_when_user_has_early_head_start(self):
-        """has_benefit('ma_early_head_start') is True when has_early_head_start=True."""
+        """has_benefit('ma_early_head_start') is True when the join table has the row."""
         seed_program(self.white_label, "ma_early_head_start")
-        self.screen.has_early_head_start = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "ma_early_head_start")
 
         self.assertTrue(self.screen.has_benefit("ma_early_head_start"))
 
     def test_has_benefit_returns_false_for_ma_early_head_start_when_user_does_not_have_early_head_start(self):
-        """has_benefit('ma_early_head_start') is False when has_early_head_start=False."""
+        """has_benefit('ma_early_head_start') is False when no row was written."""
         seed_program(self.white_label, "ma_early_head_start")
-        self.screen.has_early_head_start = False
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen)
 
         self.assertFalse(self.screen.has_benefit("ma_early_head_start"))
 
-    # Cross-cutting cases — these are the ones MFB-719 specifically wants to
-    # lock in: multi-WL variants over the same column, compound conditions
-    # resolved at write time, and no N+1 on the eligibility read path.
+    # Backward-compat fan-out / compound cases — these specifically lock in the
+    # has_* → join-table mapping that lives on the backward-compat write path
+    # (`_benefit_map_from_has_columns`, exercised via sync_current_benefits()).
+    # They intentionally keep the `has_* = True; sync_current_benefits()` pattern
+    # because that mapping is the thing under test; both go away in Step 6
+    # (MFB-720) when the has_* write path is removed.
 
     def test_has_benefit_multi_wl_variants_resolve_to_same_column(self):
         """
@@ -400,9 +389,7 @@ class TestScreen(TestCase):
         other_screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", household_size=1, completed=False
         )
-        other_screen.has_snap = True
-        other_screen.save()
-        sync_current_benefits(other_screen)
+        set_current_benefits(other_screen, "snap")
 
         # self.screen has no current_benefits rows
         self.assertFalse(self.screen.has_benefit("snap"))
@@ -414,10 +401,7 @@ class TestScreen(TestCase):
         the lookup from the in-memory cache.
         """
         seed_program(self.white_label, "snap", "tanf", "wic", "ssi")
-        self.screen.has_snap = True
-        self.screen.has_tanf = True
-        self.screen.save()
-        sync_current_benefits(self.screen)
+        set_current_benefits(self.screen, "snap", "tanf")
 
         prefetched = Screen.objects.prefetch_related("current_benefits__program").get(pk=self.screen.pk)
 

--- a/screener/tests/test_screen_serializer.py
+++ b/screener/tests/test_screen_serializer.py
@@ -14,7 +14,7 @@ serializer `update()` path end to end.
 
 from django.test import TestCase
 
-from screener.models import CurrentBenefit, Screen, WhiteLabel
+from screener.models import CurrentBenefit, HouseholdMember, IncomeStream, Screen, WhiteLabel
 from screener.serializers import ScreenSerializer, _write_current_benefits
 from screener.tests.helpers import seed_program
 
@@ -80,8 +80,6 @@ class WriteCurrentBenefitsTests(TestCase):
 
     def test_backward_compat_path_compound_ssi_via_income(self):
         """current_benefits=None resolves the ssi compound condition from sSI income."""
-        from screener.models import HouseholdMember, IncomeStream
-
         seed_program(self.white_label, "ssi")
         head = HouseholdMember.objects.create(
             screen=self.screen, relationship="headOfHousehold", age=40, has_income=True
@@ -149,3 +147,43 @@ class ScreenSerializerUpdateTests(TestCase):
     def test_current_benefits_is_write_only(self):
         """current_benefits is a write-only field — it is not echoed in serialized output."""
         self.assertNotIn("current_benefits", ScreenSerializer(self.screen).data)
+
+
+class ScreenSerializerCreateTests(TestCase):
+    """End-to-end coverage of `current_benefits` flowing through serializer.create().
+
+    create() pops and writes current_benefits independently of update(), so it
+    needs its own coverage — a regression in one wouldn't be caught by the other.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        seed_program(self.white_label, "snap", "tanf")
+
+    def _base_payload(self, **extra):
+        payload = {
+            "white_label": self.white_label.code,
+            "household_members": [],
+            "expenses": [],
+        }
+        payload.update(extra)
+        return payload
+
+    def _benefit_names(self, screen):
+        return set(CurrentBenefit.objects.filter(screen=screen).values_list("program__name_abbreviated", flat=True))
+
+    def test_create_with_current_benefits_writes_join_table(self):
+        """A POST carrying current_benefits writes the join table directly."""
+        serializer = ScreenSerializer(data=self._base_payload(current_benefits=["snap", "tanf"]))
+        serializer.is_valid(raise_exception=True)
+        screen = serializer.save()
+
+        self.assertEqual(self._benefit_names(screen), {"snap", "tanf"})
+
+    def test_create_without_current_benefits_falls_back_to_has_columns(self):
+        """A POST with no current_benefits key mirrors from has_* (old frontend)."""
+        serializer = ScreenSerializer(data=self._base_payload(has_snap=True))
+        serializer.is_valid(raise_exception=True)
+        screen = serializer.save()
+
+        self.assertEqual(self._benefit_names(screen), {"snap"})

--- a/screener/tests/test_screen_serializer.py
+++ b/screener/tests/test_screen_serializer.py
@@ -1,0 +1,151 @@
+"""
+Tests for the ScreenSerializer current-benefits write path (Step 5a / MFB-869).
+
+The CurrentBenefit join table is the primary write target. Two write paths feed it:
+
+* New frontend — `current_benefits: ["snap", "tanf"]` (list of name_abbreviated),
+  written directly via a WL-scoped Program lookup.
+* Old frontend (backward compat) — legacy `has_*` columns, mirrored into the join
+  table through `_benefit_map_from_has_columns()`. Removed in Step 6 (MFB-720).
+
+These cover `_write_current_benefits()` (the shared helper) directly and the
+serializer `update()` path end to end.
+"""
+
+from django.test import TestCase
+
+from screener.models import CurrentBenefit, Screen, WhiteLabel
+from screener.serializers import ScreenSerializer, _write_current_benefits
+from screener.tests.helpers import seed_program
+
+
+class WriteCurrentBenefitsTests(TestCase):
+    """Direct coverage of the `_write_current_benefits()` helper."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="78701", household_size=1, completed=False
+        )
+        seed_program(self.white_label, "snap", "tanf", "wic")
+
+    def _benefit_names(self, screen):
+        return set(CurrentBenefit.objects.filter(screen=screen).values_list("program__name_abbreviated", flat=True))
+
+    def test_new_path_writes_requested_programs(self):
+        """An explicit current_benefits list writes exactly those join-table rows."""
+        _write_current_benefits(self.screen, ["snap", "tanf"])
+
+        self.assertEqual(self._benefit_names(self.screen), {"snap", "tanf"})
+
+    def test_new_path_empty_list_clears_rows(self):
+        """An empty current_benefits list removes all rows (deselect-all)."""
+        _write_current_benefits(self.screen, ["snap"])
+        _write_current_benefits(self.screen, [])
+
+        self.assertEqual(self._benefit_names(self.screen), set())
+
+    def test_new_path_replaces_existing_rows(self):
+        """A second write replaces the prior set rather than appending."""
+        _write_current_benefits(self.screen, ["snap", "tanf"])
+        _write_current_benefits(self.screen, ["wic"])
+
+        self.assertEqual(self._benefit_names(self.screen), {"wic"})
+
+    def test_new_path_skips_unknown_program_names(self):
+        """Names with no Program in this WL are silently dropped, not errored."""
+        _write_current_benefits(self.screen, ["snap", "not_a_real_program"])
+
+        self.assertEqual(self._benefit_names(self.screen), {"snap"})
+
+    def test_new_path_is_white_label_scoped(self):
+        """A program name that exists only in another WL is not written."""
+        other_wl = WhiteLabel.objects.create(name="Other", code="other", state_code="OT")
+        seed_program(other_wl, "other_only")
+
+        _write_current_benefits(self.screen, ["snap", "other_only"])
+
+        self.assertEqual(self._benefit_names(self.screen), {"snap"})
+
+    def test_backward_compat_path_mirrors_has_columns(self):
+        """current_benefits=None mirrors the legacy has_* columns (fan-out included)."""
+        seed_program(self.white_label, "co_snap")
+        self.screen.has_snap = True
+        self.screen.save()
+
+        _write_current_benefits(self.screen, None)
+
+        # has_snap fans out to every snap variant Program in this WL.
+        self.assertEqual(self._benefit_names(self.screen), {"snap", "co_snap"})
+
+    def test_backward_compat_path_compound_ssi_via_income(self):
+        """current_benefits=None resolves the ssi compound condition from sSI income."""
+        from screener.models import HouseholdMember, IncomeStream
+
+        seed_program(self.white_label, "ssi")
+        head = HouseholdMember.objects.create(
+            screen=self.screen, relationship="headOfHousehold", age=40, has_income=True
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=head, type="sSI", amount=500, frequency="monthly"
+        )
+
+        _write_current_benefits(self.screen, None)
+
+        self.assertIn("ssi", self._benefit_names(self.screen))
+
+
+class ScreenSerializerUpdateTests(TestCase):
+    """End-to-end coverage of `current_benefits` flowing through serializer.update()."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="78701", household_size=1, completed=False
+        )
+        seed_program(self.white_label, "snap", "tanf")
+
+    def _base_payload(self, **extra):
+        payload = {
+            "white_label": self.white_label.code,
+            "household_members": [],
+            "expenses": [],
+        }
+        payload.update(extra)
+        return payload
+
+    def _benefit_names(self):
+        return set(
+            CurrentBenefit.objects.filter(screen=self.screen).values_list("program__name_abbreviated", flat=True)
+        )
+
+    def test_update_with_current_benefits_writes_join_table(self):
+        """A PATCH carrying current_benefits writes the join table directly."""
+        serializer = ScreenSerializer(self.screen, data=self._base_payload(current_benefits=["snap", "tanf"]))
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.assertEqual(self._benefit_names(), {"snap", "tanf"})
+
+    def test_update_without_current_benefits_falls_back_to_has_columns(self):
+        """A PATCH with no current_benefits key mirrors from has_* (old frontend)."""
+        serializer = ScreenSerializer(self.screen, data=self._base_payload(has_snap=True))
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.assertEqual(self._benefit_names(), {"snap"})
+
+    def test_update_current_benefits_takes_precedence_over_has_columns(self):
+        """When both are sent, the explicit current_benefits list is authoritative."""
+        serializer = ScreenSerializer(
+            self.screen,
+            data=self._base_payload(current_benefits=["tanf"], has_snap=True),
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.assertEqual(self._benefit_names(), {"tanf"})
+
+    def test_current_benefits_is_write_only(self):
+        """current_benefits is a write-only field — it is not echoed in serialized output."""
+        self.assertNotIn("current_benefits", ScreenSerializer(self.screen).data)

--- a/screener/tests/test_screen_serializer.py
+++ b/screener/tests/test_screen_serializer.py
@@ -67,6 +67,59 @@ class WriteCurrentBenefitsTests(TestCase):
 
         self.assertEqual(self._benefit_names(self.screen), {"snap"})
 
+    def test_new_path_injects_ssi_from_income_without_tile(self):
+        """sSI income implies SSI even when the user didn't tick the SSI tile."""
+        seed_program(self.white_label, "ssi")
+        head = HouseholdMember.objects.create(
+            screen=self.screen, relationship="headOfHousehold", age=40, has_income=True
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=head, type="sSI", amount=500, frequency="monthly"
+        )
+
+        # Frontend sends SNAP only — no SSI tile — but sSI income is present.
+        _write_current_benefits(self.screen, ["snap"])
+
+        self.assertEqual(self._benefit_names(self.screen), {"snap", "ssi"})
+
+    def test_new_path_income_wins_over_explicit_deselect(self):
+        """An explicit deselect can't remove SSI when sSI income is present (OR semantics)."""
+        seed_program(self.white_label, "ssi")
+        head = HouseholdMember.objects.create(
+            screen=self.screen, relationship="headOfHousehold", age=40, has_income=True
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=head, type="sSI", amount=500, frequency="monthly"
+        )
+
+        # Deselect-all: empty list, yet income still forces SSI on.
+        _write_current_benefits(self.screen, [])
+
+        self.assertEqual(self._benefit_names(self.screen), {"ssi"})
+
+    def test_new_path_no_ssi_without_income_or_tile(self):
+        """No SSI tile and no sSI income → SSI is not written."""
+        seed_program(self.white_label, "ssi")
+
+        _write_current_benefits(self.screen, ["snap"])
+
+        self.assertEqual(self._benefit_names(self.screen), {"snap"})
+
+    def test_new_path_derived_ssi_variant_not_in_other_wl(self):
+        """Derived SSI variants for other WLs (e.g. wa_ssi) aren't written to this WL."""
+        seed_program(self.white_label, "ssi")  # this WL only offers "ssi"
+        head = HouseholdMember.objects.create(
+            screen=self.screen, relationship="headOfHousehold", age=40, has_income=True
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=head, type="sSI", amount=500, frequency="monthly"
+        )
+
+        _write_current_benefits(self.screen, [])
+
+        # Only the variant this WL offers is written; tx_ssi / wa_ssi / cesn_ssi are dropped.
+        self.assertEqual(self._benefit_names(self.screen), {"ssi"})
+
     def test_backward_compat_path_mirrors_has_columns(self):
         """current_benefits=None mirrors the legacy has_* columns (fan-out included)."""
         seed_program(self.white_label, "co_snap")


### PR DESCRIPTION
## Context & Motivation

Part of the **New Current Benefits Workflow** milestone (`has_*` columns → `CurrentBenefit` join table). This is **Step 5a**, the backend-only step that makes the join table the primary write target.

The old `_sync_current_benefits()` read the `has_*` columns back, deleted all `CurrentBenefit` rows, and recreated them — a one-directional mirror (`has_*` → join table) that was a Phase 2 transitional mechanism. It can't survive the `has_*` columns being dropped, and it prevents the join table from being written independently. This ticket replaces it with direct writes.

- Implements [MFB-869](https://linear.app/myfriendben/issue/MFB-869/cb-step-5a-make-join-table-the-primary-write-target-replace-sync)
- Blocked by [MFB-719](https://linear.app/myfriendben/issue/MFB-719/cb-step-3a-switch-has-benefit-reads-to-join-table-benefits-api) (Step 3a, done) — `has_benefit()` already reads the join table
- Blocks [MFB-720](https://linear.app/myfriendben/issue/MFB-720/cb-step-6-update-api-contract-migrate-fe-to-new-shape-benefits-api) (Step 6, coordinated BE+FE deploy that drops `has_*`)

## Changes Made

**Serializer — new primary write path**
- `ScreenSerializer` now accepts `current_benefits: ["snap", "tanf"]` (write-only list of `name_abbreviated`). Each name is resolved to a `Program` via the WL-scoped `(white_label, name_abbreviated)` unique lookup and written directly to the join table. Names with no Program in the screen's white label are silently skipped.
- Wired through both `create()` and `update()`.
- **Backward compatibility:** when `current_benefits` is absent (old frontend), the serializer falls back to mirroring the legacy `has_*` columns into the join table — including the fan-out (`has_tanf` → tanf / co_tanf / il_tanf / …) and compound conditions (`ssi` via has_ssi OR sSI income; `ma_mass_health` via has_medicaid OR has_medicaid_hi).
- When both are sent, `current_benefits` is authoritative.

**Cleanup**
- Deleted `serializers._sync_current_benefits()` → replaced by `_write_current_benefits(screen, current_benefits)`.
- Deleted `Screen._build_benefit_map()` → its `has_*` → `name_abbreviated` mapping relocated to `serializers._benefit_map_from_has_columns()`, used only by the backward-compat path. Both this helper and the `has_*` write path are removed in Step 6 (MFB-720).
- `has_benefit()` still reads from the join table (unchanged from Step 3a); docstrings updated to drop references to the deleted sync function.

**Test migration**
- Migrated the test files that used the `has_* = True; sync_current_benefits()` dual-write pattern to direct join-table writes via a new `set_current_benefits()` test helper (exercises the new primary path):
  - `screener/tests/test_models.py`
  - `programs/programs/policyengine/calculators/dependencies/tests/test_spm.py`
  - `programs/programs/il/nurse_family_partnership/tests.py`
  - `programs/programs/urgent_needs/tx/test_urgent_needs_functions.py`
  - `programs/programs/wa/nslp/tests.py`
- The fan-out / compound `has_benefit` tests in `test_models.py` intentionally **keep** the `has_*` mirror pattern, since that mapping is the behavior under test until Step 6.
- `sync_current_benefits()` test helper now delegates to the serializer's backward-compat branch so it can't drift from production. (Helper itself is removed in Step 6 / MFB-720.)
- Added `screener/tests/test_screen_serializer.py` covering both write paths, precedence, WL-scoping, unknown-name skip, empty-list deselect-all, and write-only output.

## Testing

- Migrations to run: none (no schema changes — `has_*` columns and the `CurrentBenefit` table are unchanged)
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - `pytest screener/` → 202 passed
  - Migrated calculator/dependency suites + serializer/model tests → 195 passed
  - `black --check` clean; full project test collection (1903 tests) has no import errors
  - Old-frontend smoke: PATCH a screen with `has_snap: true` and no `current_benefits` → join table gets the snap variant rows; `already_has` still works on results
  - New-frontend smoke: PATCH with `current_benefits: ["snap"]` → join table has exactly the snap row

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: nothing required — this is backward compatible. The live frontend continues sending `has_*` and keeps working unchanged. The new `current_benefits` payload is consumed by the frontend in Step 6 (MFB-720), which is the coordinated BE+FE deploy that drops `has_*` acceptance.

## Notes for Reviewers

- **Backward compat is deliberate and temporary.** Because this ships before the Step 6 FE switch, the API must keep accepting `has_*`. The `_benefit_map_from_has_columns()` helper is the relocated `_build_benefit_map` body verbatim (model-attr references rebased to the `screen` arg) and is deleted in Step 6.
- Known limitations: the new `current_benefits` path does not reverse-map into the `has_*` columns. It doesn't need to — `has_benefit()` reads the join table, and the remaining dbt mart was already swapped to the join table in Step 4 (MFB-867). The `has_*` columns are dropped in Step 7a (MFB-878).
- Future considerations: single-benefit toggle endpoint for the results page is split out to [MFB-1094](https://linear.app/myfriendben/issue/MFB-1094) (independent of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Screen updates now accept an explicit list of current benefits on write, improving how selected benefits are recorded.

* **Refactor**
  * Benefit storage/lookup was reworked to rely on the canonical join-table path, improving consistency for compound and derived benefits (e.g., SSI variants).

* **Tests**
  * Test suite updated and expanded to validate the new write path, white-label scoping, and backward-compat fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->