### PR TITLE
Add catch-up safety net to weekly on-call rotation

### DIFF
--- a/.github/oncall/README.md
+++ b/.github/oncall/README.md
@@ -33,6 +33,11 @@ Grab its ID: open the group, and the URL ends in something like
    - `chat:write` — post the handoff message
    - `channels:manage` — set the topic of a public channel
      (use `groups:write` instead if the channel is private)
+   - `channels:history` — read recent messages so the daily catch-up run can
+     tell whether this week's handoff was already announced
+     (use `groups:history` instead if the channel is private). If this scope
+     is missing the script still works — it just falls back to posting, which
+     may duplicate the announcement on catch-up days.
 3. **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-...`).
    This is your `SLACK_BOT_TOKEN`.
 4. Invite the bot to your channel: in the channel, `/invite @YourAppName`.
@@ -89,6 +94,20 @@ The script computes whole weeks elapsed since `anchor_monday` and indexes into
 `members` with modulo, so it's **stateless and idempotent** — running it twice
 in a week (e.g. the two DST-spanning cron entries) just re-applies the same
 assignment. No database, no drift.
+
+### Catch-up safety net
+
+GitHub Actions' `schedule` trigger is **best-effort**: under load it delays
+runs and sometimes drops them entirely, so the Monday fire can silently never
+happen. To cover that, the workflow also runs mid-morning Tue–Fri. On those
+catch-up runs the script re-applies the (idempotent) usergroup + topic, and
+posts the handoff announcement **only if it wasn't already posted this week**
+(checked via `conversations.history`). So a missed Monday self-heals by the
+next morning without re-spamming the channel on weeks Monday worked fine.
+
+If GitHub ever drops a run, you can also force one immediately: **Actions →
+Weekly On-Call Rotation → Run workflow**, or `gh workflow run
+oncall-rotation.yml --ref main`.
 
 ## Changing the rotation
 

--- a/.github/oncall/rotate_oncall.py
+++ b/.github/oncall/rotate_oncall.py
@@ -10,8 +10,9 @@ Designed to run weekly via GitHub Actions, but works locally too.
 
 Required environment variables:
   SLACK_BOT_TOKEN     Bot token (xoxb-...) with scopes:
-                        usergroups:write, chat:write, channels:manage
-                        (groups:write for private channels)
+                        usergroups:write, chat:write, channels:manage,
+                        channels:history
+                        (groups:write / groups:history for private channels)
   SLACK_USERGROUP_ID  The user group ID to update (e.g. S01ABC2DEF).
   SLACK_CHANNEL_ID    Channel to announce in + set topic on (e.g. C01ABC2DEF).
 
@@ -120,6 +121,37 @@ def slack_post(method: str, token: str, payload: dict) -> dict:
     return body
 
 
+def already_announced_this_week(token: str, channel: str, ref: date) -> bool:
+    """True if the handoff for `ref`'s week was already posted in `channel`.
+
+    Lets a daily catch-up cron re-apply the (idempotent) usergroup + topic
+    updates without re-spamming the announcement. We look at messages posted
+    since this week's Monday and match our handoff marker (":pager: *On-call
+    this week:*"). conversations.history needs `channels:history` (public) /
+    `groups:history` (private); if that scope is missing or the call fails we
+    return False and fall back to posting — better a duplicate than silence.
+    """
+    week_monday = ref.fromordinal(ref.toordinal() - ref.weekday())
+    oldest = datetime(week_monday.year, week_monday.month, week_monday.day).timestamp()
+    req = urllib.request.Request(
+        f"{SLACK_API}/conversations.history?channel={channel}&oldest={oldest:.0f}&limit=200",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+    except urllib.error.URLError:
+        return False
+    if not body.get("ok"):
+        print(
+            f"Warning: conversations.history failed ({body.get('error')}); " "will post announcement (may duplicate).",
+            file=sys.stderr,
+        )
+        return False
+    return any(":pager: *On-call this week:*" in (m.get("text") or "") for m in body.get("messages", []))
+
+
 def main() -> int:
     config = load_config()
     ref = today()
@@ -173,18 +205,24 @@ def main() -> int:
     if missing:
         sys.exit(f"Missing required env vars: {', '.join(missing)}")
 
-    # 1. Point the user group at the current on-call person.
+    # 1. Point the user group at the current on-call person. Idempotent, so we
+    #    always re-apply it — a catch-up run self-heals a missed Monday.
     slack_post(
         "usergroups.users.update",
         token,
         {"usergroup": usergroup, "users": on_call["slack_id"]},
     )
-    # 2. Announce the handoff (blocks for layout, text for the notification).
-    slack_post(
-        "chat.postMessage",
-        token,
-        {"channel": channel, "text": fallback, "blocks": blocks},
-    )
+    # 2. Announce the handoff — but only once per week. The daily catch-up cron
+    #    re-runs this script; without this guard it would re-post every weekday.
+    if already_announced_this_week(token, channel, ref):
+        print(f"Handoff for week of {ref} already announced; skipping post.")
+    else:
+        # blocks for layout, text for the notification.
+        slack_post(
+            "chat.postMessage",
+            token,
+            {"channel": channel, "text": fallback, "blocks": blocks},
+        )
     # 3. Update the channel topic (best effort; don't fail the run on topic error).
     try:
         slack_post(

--- a/.github/workflows/oncall-rotation.yml
+++ b/.github/workflows/oncall-rotation.yml
@@ -12,6 +12,13 @@ on:
     # re-applies the same assignment harmlessly.
     - cron: "0 15 * * 1"
     - cron: "0 16 * * 1"
+    # Catch-up safety net. GitHub's scheduled-workflow trigger is best-effort
+    # and silently drops runs under load — the Monday fire can simply never
+    # happen. So we also run mid-morning Tue–Fri: the script re-applies the
+    # (idempotent) usergroup + topic, and posts the handoff announcement only
+    # if it wasn't already posted this week, so a missed Monday self-heals
+    # without spamming the channel on the days Monday worked fine.
+    - cron: "30 16 * * 2-5"
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Why

The weekly on-call rotation **did not fire on Monday 2026-06-08** — the first scheduled Monday after the workflow merged (#1554). Investigation showed:

- The workflow is `active`, on `main`, correctly configured. Not a fork.
- It has **zero `schedule`-event runs ever** — the only runs in history are the manual `workflow_dispatch` runs from launch day (2026-06-01).
- No workflow in the repo has fired on `schedule` recently.

This is the well-known GitHub Actions behavior: the `schedule` trigger is **best-effort** and silently delays or **drops** runs under load. We cant make GitHubs cron reliable, so we add a catch-up layer.

## What

- **Daily catch-up cron** (`30 16 * * 2-5`, Tue–Fri ~10:30 Denver) in addition to the two Monday DST-spanning crons. A missed Monday now self-heals by the next morning.
- **`already_announced_this_week()` guard**: the announcement `chat.postMessage` only fires if this weeks handoff isnt already in the channel (checked via `conversations.history` + the `:pager: *On-call this week:*` marker). So catch-up runs on weeks where Monday worked dont re-spam the channel.
- The **usergroup + topic updates stay unconditional** — theyre idempotent, so re-applying them daily is harmless and self-healing.
- Graceful degradation: if the history scope is missing or the call errors, we **fall back to posting** (a duplicate beats silence) and log a warning.

## New requirement

Adds a bot scope: **`channels:history`** (or `groups:history` for a private channel). Documented in the README and module docstring. Add it under the Slack apps **OAuth & Permissions** and reinstall. Until then, behavior degrades gracefully to "may post a duplicate on catch-up days."

## Testing

- `black --check` clean.
- Dry run unaffected (`ONCALL_DRY_RUN=1 ONCALL_TODAY=2026-06-08` → Elliott, prev David).
- Unit-tested `already_announced_this_week()` for three cases: handoff present → `True`, unrelated messages → `False`, `missing_scope` → `False` (fall back to post).
- Todays handoff was already fixed via a manual dispatch (run 27151775521).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
