### PR TITLE
MFB-1108: Resolve System Exit Error

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn benefits.wsgi --log-file -
+web: gunicorn benefits.wsgi --log-file - --timeout 120

--- a/integrations/models.py
+++ b/integrations/models.py
@@ -49,7 +49,7 @@ class Link(models.Model):
         ]
         rand_agent_index = random.randint(0, len(user_agents) - 1)
         header = {"User-agent": user_agents[rand_agent_index]}
-        req = requests.get(self.link, headers=header)
+        req = requests.get(self.link, headers=header, timeout=(5, 30))
 
         return req
 

--- a/integrations/util/cache.py
+++ b/integrations/util/cache.py
@@ -22,6 +22,13 @@ class Cache:
             self.save(self.update())
             self.last_update = timezone.now()
             self.invalid = False
+        except (SystemExit, KeyboardInterrupt) as e:
+            # `update()` may issue a network call that hangs (see PolicyEngineBearerTokenCache),
+            # in which case the worker can be torn down mid-fetch and SystemExit is raised here.
+            # That is a BaseException, so `except Exception` below would miss it. Surface it,
+            # then re-raise so the shutdown proceeds.
+            capture_exception(e, level="error")
+            raise
         except Exception as e:
             if settings.DEBUG:
                 print(e)

--- a/programs/models.py
+++ b/programs/models.py
@@ -104,12 +104,12 @@ class FplCache(Cache):
         """
         Request the FPL from the API for the indicated year and household size
         """
-        response = requests.get(self._fpl_url(year, household_size), allow_redirects=False)
+        response = requests.get(self._fpl_url(year, household_size), allow_redirects=False, timeout=(5, 30))
         if "Location" in response.headers:
             new_url = response.headers["Location"].replace("http", "https")
             if "https://" not in new_url:
                 new_url = response.headers["Location"].replace("http", "https")
-            response = requests.get(new_url)
+            response = requests.get(new_url, timeout=(5, 30))
 
         response.raise_for_status()
         data = response.json()["data"]

--- a/programs/programs/policyengine/engines.py
+++ b/programs/programs/policyengine/engines.py
@@ -79,7 +79,7 @@ class PolicyEngineBearerTokenCache(Cache):
             "audience": "https://household.api.policyengine.org",
         }
 
-        res = requests.post(self.domain + self.endpoint, json=payload)
+        res = requests.post(self.domain + self.endpoint, json=payload, timeout=(5, 30))
 
         return res.json()["access_token"]
 

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -53,6 +53,19 @@ def calc_pe_eligibility(
                     "response": getattr(method_instance, "response_json", None),
                 },
             }
+        except (SystemExit, KeyboardInterrupt) as e:
+            # Worker is being torn down: gunicorn's SIGABRT handler (fired when a request
+            # exceeds the worker --timeout, e.g. while a PE HTTP call hangs on DNS) calls
+            # sys.exit(), raising SystemExit. That is a BaseException, so the `except
+            # Exception` below never sees it and the death is invisible in Sentry. Capture
+            # it here for visibility, then re-raise so the shutdown proceeds normally.
+            capture_exception(e, level="error")
+            capture_message(
+                f"Worker exited mid-request while calculating eligibility with the "
+                f"{Method.method_name} method",
+                level="error",
+            )
+            raise
         except Exception as e:
             if settings.DEBUG:
                 print(repr(e))

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -61,8 +61,7 @@ def calc_pe_eligibility(
             # it here for visibility, then re-raise so the shutdown proceeds normally.
             capture_exception(e, level="error")
             capture_message(
-                f"Worker exited mid-request while calculating eligibility with the "
-                f"{Method.method_name} method",
+                f"Worker exited mid-request while calculating eligibility with the " f"{Method.method_name} method",
                 level="error",
             )
             raise

--- a/screener/webhooks.py
+++ b/screener/webhooks.py
@@ -26,7 +26,7 @@ class Hook:
             request_data[key] = value
 
         try:
-            res = requests.post(self.hook.webhook_url, json=request_data)
+            res = requests.post(self.hook.webhook_url, json=request_data, timeout=(5, 30))
             if res.status_code != 200:
                 capture_message(f"{res.text}", level="error")
                 return Exception(f"{res.status_code}: {res.text}")


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

A Sentry alert surfaced an uncaught `SystemExit` killing Gunicorn workers mid-request on
`/api/eligibility`. Root cause analysis traced it to the PolicyEngine eligibility flow:

1. `calc_pe_eligibility()` iterates `pe_engines = [PrivateApiSim, ApiSim]`, trying each in turn.
2. An engine's `requests.post(..., timeout=(5, 30))` can still hang indefinitely, because the
   `requests` connect/read timeout does **not** cover DNS resolution (`socket.getaddrinfo()` is a
   blocking, uninterruptible syscall that runs before the connect timeout starts).
3. When the request exceeds Gunicorn's worker timeout, the Gunicorn master sends `SIGABRT`; the
   worker's abort handler calls `sys.exit()`, raising `SystemExit`.
4. `SystemExit` subclasses `BaseException`, not `Exception`, so the `except Exception` in the engine
   loop never catches it — the worker dies, the fallback retry never runs, **and `capture_exception`
   never fires**, making the failure invisible in Sentry until a worker actually dies.

Two compounding problems were fixed, plus a previously-unnoticed sibling bug (the bearer-token fetch
POST had no timeout at all) and the same hang pattern in other request-path HTTP calls.

- Fixes #[issue-number]  <!-- Sentry-linked issue -->
- Related PR: [link if applicable]

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

**Reported bug — PolicyEngine flow**

- `programs/programs/policyengine/policy_engine.py` — added an `except (SystemExit, KeyboardInterrupt)`
  branch *before* `except Exception` in the engine loop. It now reports the worker teardown to Sentry
  (`capture_exception` + `capture_message`) and then re-raises, so the shutdown proceeds normally but
  the death is no longer invisible.
- `programs/programs/policyengine/engines.py` — the bearer-token fetch
  (`PolicyEngineBearerTokenCache.update()`, reached via `PrivateApiSim.__init__ → token.fetch()`) had
  **no timeout at all**. Added `timeout=(5, 30)` to match the other PE calls.
- `integrations/util/cache.py` — `Cache._update_cache()` wraps the token fetch in `except Exception`,
  the same `BaseException` blind spot. Added a `SystemExit`/`KeyboardInterrupt` capture-and-reraise
  branch.

**Timeout hardening — other unguarded request-path HTTP calls**

- `screener/webhooks.py` — outbound webhook `requests.post` → `timeout=(5, 30)`.
- `programs/models.py` — FPL income-limit fetch (`_fetch_income_limit`, used during eligibility calc),
  both `requests.get` calls → `timeout=(5, 30)`.
- `integrations/models.py` — link-validation `requests.get` → `timeout=(5, 30)`.

**Infra mitigation for the DNS gap**

- `Procfile` — Gunicorn had no `--timeout` (defaulting to 30s, which a single PE call at its own 30s
  read timeout can already exceed). Raised to `--timeout 120` to accommodate the worst-case chain
  (token fetch + `PrivateApiSim` + `ApiSim`).

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - Run the affected test suites:
    ```
    ./venv/bin/python -m pytest \
      programs/programs/policyengine/tests/ \
      screener/tests/test_pe_version_override.py \
      screener/tests/test_models.py \
      programs/programs/tx/pe/tests/test_integration.py -q
    ```
    All 160 tests pass (41 + 119). The TX integration test exercises `calc_pe_eligibility`
    end-to-end via VCR cassettes; the added `timeout=` args do not affect VCR request matching
    (it keys on method/URI/body).
  - Note: `screener/webhooks.py` and `integrations/models.py` have no dedicated test files; those
    edits were validated by syntax/import checks only. The new arg is caught by each call's existing
    `except requests.RequestException` handler, so happy-path behavior is unchanged.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: none
- Production config updates: the `Procfile` `--timeout 120` change takes effect automatically on the
  next deploy (Staging on merge to main, then Production). No manual dyno/worker config change needed.
- Admin updates needed: none
- Notify team/users of: workers now allow up to 120s per request before SIGABRT (was 30s). Watch
  Sentry for the new "Worker exited mid-request while calculating eligibility…" message, which now
  makes these teardowns visible.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
  - The DNS hang is **mitigated, not fully closed.** `requests` timeouts cannot cover
    `socket.getaddrinfo()`, so a truly stuck DNS lookup can still hang up to the new 120s Gunicorn
    ceiling before SIGABRT. The `SystemExit` capture ensures any such death is now visible in Sentry
    rather than silent.
  - Raising `--timeout` to 120s means a worker stuck on a hung lookup is unavailable for up to two
    minutes.
- Future considerations:
  - Move PolicyEngine calls off the synchronous request path (e.g. Celery/async) so a hung upstream
    can't tie up a web worker at all — the durable fix, worth its own ticket.
  - A hard wall-clock timeout (e.g. running the HTTP call in a `ThreadPoolExecutor` with
    `.result(timeout=N)`) would close the DNS gap in code without an infra change, at the cost of a
    leaked thread until the OS resolver gives up.
  - `screener/management/commands/pull_screen.py` still has an unguarded `requests.get`; it was left
    out of scope as a management command (not in the request path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added HTTP request timeouts across integrations and external services to prevent connection hangs
  * Enhanced worker shutdown behavior with improved error handling and reporting during system termination events
  * Optimized server performance with explicit timeout settings on API calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->