### PR TITLE
Migrate raw has_* calculator reads to the join table (WaNslp + SNAP-student + Energy EBT) — pre-req for MFB-720

### DIFF
--- a/programs/programs/co/energy_calculator/energy_ebt/calculator.py
+++ b/programs/programs/co/energy_calculator/energy_ebt/calculator.py
@@ -14,5 +14,6 @@ class EnergyCalculatorEnergyEbt(ProgramCalculator):
 
         # no LEAP
         cesn_leap = self.data.get("cesn_leap")
-        can_get_leap = self.screen.has_leap or (cesn_leap is not None and cesn_leap.eligible)
+        already_has_leap = self.screen.has_benefit_from_list(["leap", "cesn_leap", "nc_leap"])
+        can_get_leap = already_has_leap or (cesn_leap is not None and cesn_leap.eligible)
         e.condition(not can_get_leap)

--- a/programs/programs/co/energy_calculator/energy_ebt/calculator.py
+++ b/programs/programs/co/energy_calculator/energy_ebt/calculator.py
@@ -14,6 +14,6 @@ class EnergyCalculatorEnergyEbt(ProgramCalculator):
 
         # no LEAP
         cesn_leap = self.data.get("cesn_leap")
-        already_has_leap = self.screen.has_benefit_from_list(["leap", "cesn_leap", "nc_leap"])
+        already_has_leap = self.screen.has_benefit("cesn_leap")
         can_get_leap = already_has_leap or (cesn_leap is not None and cesn_leap.eligible)
         e.condition(not can_get_leap)

--- a/programs/programs/helpers.py
+++ b/programs/programs/helpers.py
@@ -3,6 +3,9 @@ from screener.models import Screen, HouseholdMember
 
 STATE_MEDICAID_OPTIONS = ("co_medicaid", "nc_medicaid", "il_medicaid")
 
+# name_abbreviated variants of TANF across white labels.
+TANF_BENEFITS = ["tanf", "nc_tanf", "co_tanf", "il_tanf", "tx_tanf", "ma_tafdc", "cesn_tanf"]
+
 
 def medicaid_eligible(data: dict[str, Eligibility]):
     for name in STATE_MEDICAID_OPTIONS:
@@ -35,7 +38,7 @@ def snap_ineligible_student(screen: Screen, member: HouseholdMember) -> bool:
         return False
 
     # Exemption 6: Household currently receives TANF
-    if screen.has_tanf:
+    if screen.has_benefit_from_list(TANF_BENEFITS):
         return False
 
     return True

--- a/programs/programs/helpers.py
+++ b/programs/programs/helpers.py
@@ -3,9 +3,6 @@ from screener.models import Screen, HouseholdMember
 
 STATE_MEDICAID_OPTIONS = ("co_medicaid", "nc_medicaid", "il_medicaid")
 
-# name_abbreviated variants of TANF across white labels.
-TANF_BENEFITS = ["tanf", "nc_tanf", "co_tanf", "il_tanf", "tx_tanf", "ma_tafdc", "cesn_tanf", "wa_tanf"]
-
 
 def medicaid_eligible(data: dict[str, Eligibility]):
     for name in STATE_MEDICAID_OPTIONS:
@@ -38,7 +35,7 @@ def snap_ineligible_student(screen: Screen, member: HouseholdMember) -> bool:
         return False
 
     # Exemption 6: Household currently receives TANF
-    if screen.has_benefit_from_list(TANF_BENEFITS):
+    if screen.has_base_benefit("tanf"):
         return False
 
     return True

--- a/programs/programs/helpers.py
+++ b/programs/programs/helpers.py
@@ -4,7 +4,7 @@ from screener.models import Screen, HouseholdMember
 STATE_MEDICAID_OPTIONS = ("co_medicaid", "nc_medicaid", "il_medicaid")
 
 # name_abbreviated variants of TANF across white labels.
-TANF_BENEFITS = ["tanf", "nc_tanf", "co_tanf", "il_tanf", "tx_tanf", "ma_tafdc", "cesn_tanf"]
+TANF_BENEFITS = ["tanf", "nc_tanf", "co_tanf", "il_tanf", "tx_tanf", "ma_tafdc", "cesn_tanf", "wa_tanf"]
 
 
 def medicaid_eligible(data: dict[str, Eligibility]):

--- a/programs/programs/nc/pe/tests/test_member.py
+++ b/programs/programs/nc/pe/tests/test_member.py
@@ -3,6 +3,7 @@ Unit tests for member-level PolicyEngine dependency classes.
 """
 
 from django.test import TestCase
+from programs.models import Program
 from screener.models import Screen, HouseholdMember, WhiteLabel
 from programs.programs.policyengine.calculators.dependencies.member import NcSnapIneligibleStudentDependency
 from screener.tests.helpers import seed_program, set_current_benefits
@@ -116,8 +117,13 @@ class TestNcSnapIneligibleStudentDependency(TestCase):
     # ── Federal E6: TANF ──────────────────────────────────────────────────────
 
     def test_tanf_household_is_exempt(self):
-        """Student in a household receiving TANF/Work First is exempt (E6)."""
+        """Student in a household receiving TANF/Work First is exempt (E6).
+
+        E6 keys off `Program.base_program == "tanf"`, so the seeded nc_tanf
+        program must carry that grouping.
+        """
         seed_program(self.white_label, "nc_tanf")
+        Program.objects.filter(white_label=self.white_label, name_abbreviated="nc_tanf").update(base_program="tanf")
         set_current_benefits(self.screen, "nc_tanf")
 
         member = HouseholdMember.objects.create(

--- a/programs/programs/nc/pe/tests/test_member.py
+++ b/programs/programs/nc/pe/tests/test_member.py
@@ -5,6 +5,7 @@ Unit tests for member-level PolicyEngine dependency classes.
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel
 from programs.programs.policyengine.calculators.dependencies.member import NcSnapIneligibleStudentDependency
+from screener.tests.helpers import seed_program, set_current_benefits
 
 
 class TestNcSnapIneligibleStudentDependency(TestCase):
@@ -116,8 +117,8 @@ class TestNcSnapIneligibleStudentDependency(TestCase):
 
     def test_tanf_household_is_exempt(self):
         """Student in a household receiving TANF/Work First is exempt (E6)."""
-        self.screen.has_tanf = True
-        self.screen.save()
+        seed_program(self.white_label, "nc_tanf")
+        set_current_benefits(self.screen, "nc_tanf")
 
         member = HouseholdMember.objects.create(
             screen=self.screen, relationship="headOfHousehold", age=25, student=True, student_full_time=True

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -1,4 +1,4 @@
-from programs.programs.helpers import snap_ineligible_student, TANF_BENEFITS
+from programs.programs.helpers import snap_ineligible_student
 from .base import Member
 
 
@@ -383,7 +383,7 @@ class NcSnapIneligibleStudentDependency(SnapIneligibleStudentDependency):
         if single_parent and screen.num_children(age_max=11) > 0:
             return False
 
-        if screen.has_benefit_from_list(TANF_BENEFITS):
+        if screen.has_base_benefit("tanf"):
             return False
 
         # NC Step 3: employment exemptions

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -1,4 +1,4 @@
-from programs.programs.helpers import snap_ineligible_student
+from programs.programs.helpers import snap_ineligible_student, TANF_BENEFITS
 from .base import Member
 
 
@@ -383,7 +383,7 @@ class NcSnapIneligibleStudentDependency(SnapIneligibleStudentDependency):
         if single_parent and screen.num_children(age_max=11) > 0:
             return False
 
-        if screen.has_tanf:
+        if screen.has_benefit_from_list(TANF_BENEFITS):
             return False
 
         # NC Step 3: employment exemptions

--- a/programs/programs/tests/test_helpers.py
+++ b/programs/programs/tests/test_helpers.py
@@ -7,6 +7,7 @@ NC-specific exemptions are tested in test_member.py via NcSnapIneligibleStudentD
 """
 
 from django.test import TestCase
+from programs.models import Program
 from screener.models import Screen, HouseholdMember, WhiteLabel
 from programs.programs.helpers import snap_ineligible_student
 from screener.tests.helpers import seed_program, set_current_benefits
@@ -167,9 +168,30 @@ class TestSnapIneligibleStudentHelper(TestCase):
         self.assertTrue(result)
 
     def test_snap_ineligible_student_returns_false_for_tanf_household(self):
-        """Test that student in a household receiving TANF is exempt (Exemption 6)."""
+        """Test that student in a household receiving TANF is exempt (Exemption 6).
+
+        E6 keys off `Program.base_program == "tanf"`, so the seeded program must
+        carry that grouping.
+        """
         seed_program(self.white_label, "tanf")
+        Program.objects.filter(white_label=self.white_label, name_abbreviated="tanf").update(base_program="tanf")
         set_current_benefits(self.screen, "tanf")
+
+        member = HouseholdMember.objects.create(
+            screen=self.screen, relationship="headOfHousehold", age=25, student=True
+        )
+
+        result = snap_ineligible_student(self.screen, member)
+        self.assertFalse(result)
+
+    def test_snap_ineligible_student_exemption_matches_any_tanf_variant(self):
+        """A prefixed TANF variant (e.g. wa_tanf) with base_program="tanf" still
+        triggers Exemption 6 — has_base_benefit groups by base_program, so a newly
+        added state variant is covered without editing any name list. (wa_tanf was
+        the variant the old hand-maintained TANF list missed.)"""
+        seed_program(self.white_label, "wa_tanf")
+        Program.objects.filter(white_label=self.white_label, name_abbreviated="wa_tanf").update(base_program="tanf")
+        set_current_benefits(self.screen, "wa_tanf")
 
         member = HouseholdMember.objects.create(
             screen=self.screen, relationship="headOfHousehold", age=25, student=True

--- a/programs/programs/tests/test_helpers.py
+++ b/programs/programs/tests/test_helpers.py
@@ -9,6 +9,7 @@ NC-specific exemptions are tested in test_member.py via NcSnapIneligibleStudentD
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel
 from programs.programs.helpers import snap_ineligible_student
+from screener.tests.helpers import seed_program, set_current_benefits
 
 
 class TestSnapIneligibleStudentHelper(TestCase):
@@ -167,8 +168,8 @@ class TestSnapIneligibleStudentHelper(TestCase):
 
     def test_snap_ineligible_student_returns_false_for_tanf_household(self):
         """Test that student in a household receiving TANF is exempt (Exemption 6)."""
-        self.screen.has_tanf = True
-        self.screen.save()
+        seed_program(self.white_label, "tanf")
+        set_current_benefits(self.screen, "tanf")
 
         member = HouseholdMember.objects.create(
             screen=self.screen, relationship="headOfHousehold", age=25, student=True

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -12,7 +12,8 @@ class WaNslp(ProgramCalculator):
     Estimates free or reduced-price school lunch eligibility using OSPI 2025–26
     income guidelines (not raw FPL math), frequency-matched income comparison
     when a single pay frequency applies, and screenable categorical pathways
-    (SNAP/Basic Food, TANF, Head Start flags, foster-child proxy).
+    (SNAP/Basic Food, TANF, Head Start, foster-child proxy) read from the
+    household's current benefits.
 
     Value: $828/year per likely eligible student ($4.60 × 180 days, SY 2025–26).
 
@@ -126,12 +127,25 @@ class WaNslp(ProgramCalculator):
         gross = Decimal(str(self.screen.calc_gross_income("yearly", ["all"])))
         return gross <= red_ann
 
+    # name_abbreviated values that count as each categorical benefit. The current
+    # benefits step records the white-label-specific variant the user selected
+    # (e.g. wa_snap on a WA screen), so we check every variant. Read via the
+    # CurrentBenefit join table (has_benefit_from_list), not the legacy has_*
+    # columns — those are no longer written as of the Step 6 cutover (MFB-720).
+    _SNAP_NAMES = ("snap", "co_snap", "il_snap", "ma_snap", "nc_snap", "tx_snap", "cesn_snap", "wa_snap")
+    _TANF_NAMES = ("tanf", "co_tanf", "il_tanf", "nc_tanf", "tx_tanf", "cesn_tanf", "wa_tanf")
+    _HEAD_START_NAMES = ("head_start", "co_head_start", "ma_head_start", "tx_head_start", "wa_head_start")
+    _EARLY_HEAD_START_NAMES = ("early_head_start", "ma_early_head_start", "tx_early_head_start")
+
     def _household_categorical(self) -> bool:
-        if self.screen.has_snap or self.screen.has_tanf:
-            return True
-        if self.screen.has_head_start or self.screen.has_early_head_start:
-            return True
-        return False
+        return self.screen.has_benefit_from_list(
+            [
+                *self._SNAP_NAMES,
+                *self._TANF_NAMES,
+                *self._HEAD_START_NAMES,
+                *self._EARLY_HEAD_START_NAMES,
+            ]
+        )
 
     def _foster_school_age_categorical(self) -> bool:
         for m in self.screen.household_members.all():

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -127,25 +127,13 @@ class WaNslp(ProgramCalculator):
         gross = Decimal(str(self.screen.calc_gross_income("yearly", ["all"])))
         return gross <= red_ann
 
-    # name_abbreviated values that count as each categorical benefit. The current
-    # benefits step records the white-label-specific variant the user selected
-    # (e.g. wa_snap on a WA screen), so we check every variant. Read via the
+    # The WA programs that confer NSLP categorical eligibility. Read from the
     # CurrentBenefit join table (has_benefit_from_list), not the legacy has_*
     # columns — those are no longer written as of the Step 6 cutover (MFB-720).
-    _SNAP_NAMES = ("snap", "co_snap", "il_snap", "ma_snap", "nc_snap", "tx_snap", "cesn_snap", "wa_snap")
-    _TANF_NAMES = ("tanf", "co_tanf", "il_tanf", "nc_tanf", "tx_tanf", "cesn_tanf", "wa_tanf")
-    _HEAD_START_NAMES = ("head_start", "co_head_start", "ma_head_start", "tx_head_start", "wa_head_start")
-    _EARLY_HEAD_START_NAMES = ("early_head_start", "ma_early_head_start", "tx_early_head_start")
+    _CATEGORICAL_BENEFITS = ("wa_snap", "wa_tanf", "wa_head_start")
 
     def _household_categorical(self) -> bool:
-        return self.screen.has_benefit_from_list(
-            [
-                *self._SNAP_NAMES,
-                *self._TANF_NAMES,
-                *self._HEAD_START_NAMES,
-                *self._EARLY_HEAD_START_NAMES,
-            ]
-        )
+        return self.screen.has_benefit_from_list(list(self._CATEGORICAL_BENEFITS))
 
     def _foster_school_age_categorical(self) -> bool:
         for m in self.screen.household_members.all():

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -29,6 +29,9 @@ class WaNslp(ProgramCalculator):
 
     ANNUAL_VALUE_PER_CHILD = 828
 
+    # WA programs whose receipt confers NSLP categorical eligibility.
+    presumptive_eligibility = ["wa_snap", "wa_tanf", "wa_head_start"]
+
     # OSPI / USDA Child Nutrition income guidelines, Jul 2025 – Jun 2026 (reduced-price cap).
     _RED_ANN = {
         1: 28_953,
@@ -127,18 +130,6 @@ class WaNslp(ProgramCalculator):
         gross = Decimal(str(self.screen.calc_gross_income("yearly", ["all"])))
         return gross <= red_ann
 
-    # WA programs whose receipt confers NSLP categorical eligibility.
-    _CATEGORICAL_BENEFITS = ("wa_snap", "wa_tanf", "wa_head_start")
-
-    def _household_categorical(self) -> bool:
-        return self.screen.has_benefit_from_list(list(self._CATEGORICAL_BENEFITS))
-
-    def _foster_school_age_categorical(self) -> bool:
-        for m in self.screen.household_members.all():
-            if m.relationship == "fosterChild" and self._is_school_meal_proxy_student(m):
-                return True
-        return False
-
     def member_eligible(self, e: MemberEligibility):
         e.condition(self._is_school_meal_proxy_student(e.member))
 
@@ -146,7 +137,12 @@ class WaNslp(ProgramCalculator):
         gross_for_message = int(self.screen.calc_gross_income("yearly", ["all"]))
         income_limit_message = self._reduced_annual_limit()
 
-        categorical = self._household_categorical() or self._foster_school_age_categorical()
+        # Categorical eligibility: the household receives a qualifying benefit, or a
+        # school-age foster child is present (a foster child is categorically eligible).
+        categorical = any(self.screen.has_benefit(program) for program in self.presumptive_eligibility) or any(
+            m.relationship == "fosterChild" and self._is_school_meal_proxy_student(m)
+            for m in self.screen.household_members.all()
+        )
         income_ok = self._income_at_or_below_reduced_cap()
 
         # Do not attach the income tuple when categorical applies: `Eligibility.condition`

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -145,9 +145,6 @@ class WaNslp(ProgramCalculator):
         e.condition(self._is_school_meal_proxy_student(e.member))
 
     def household_eligible(self, e: Eligibility):
-        # "Already receives NSLP" is handled centrally by the results layer's
-        # already_has flag (screen.has_benefit(program.name_abbreviated)), so no
-        # in-calculator guard is needed here.
         gross_for_message = int(self.screen.calc_gross_income("yearly", ["all"]))
         income_limit_message = self._reduced_annual_limit()
 

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -145,11 +145,9 @@ class WaNslp(ProgramCalculator):
         e.condition(self._is_school_meal_proxy_student(e.member))
 
     def household_eligible(self, e: Eligibility):
-        e.condition(
-            not self.screen.has_benefit("nslp"),
-            messages.must_not_have_benefit("NSLP"),
-        )
-
+        # "Already receives NSLP" is handled centrally by the results layer's
+        # already_has flag (screen.has_benefit(program.name_abbreviated)), so no
+        # in-calculator guard is needed here.
         gross_for_message = int(self.screen.calc_gross_income("yearly", ["all"]))
         income_limit_message = self._reduced_annual_limit()
 

--- a/programs/programs/wa/nslp/calculator.py
+++ b/programs/programs/wa/nslp/calculator.py
@@ -127,9 +127,7 @@ class WaNslp(ProgramCalculator):
         gross = Decimal(str(self.screen.calc_gross_income("yearly", ["all"])))
         return gross <= red_ann
 
-    # The WA programs that confer NSLP categorical eligibility. Read from the
-    # CurrentBenefit join table (has_benefit_from_list), not the legacy has_*
-    # columns — those are no longer written as of the Step 6 cutover (MFB-720).
+    # WA programs whose receipt confers NSLP categorical eligibility.
     _CATEGORICAL_BENEFITS = ("wa_snap", "wa_tanf", "wa_head_start")
 
     def _household_categorical(self) -> bool:

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -29,12 +29,6 @@ class TestWaNslp(TestCase):
             agree_to_tos=True,
             completed=False,
             household_size=3,
-            has_nslp=False,
-            has_snap=False,
-            has_tanf=False,
-            has_head_start=False,
-            has_early_head_start=False,
-            has_medicaid=False,
         )
         defaults.update(kwargs)
         return Screen.objects.create(**defaults)
@@ -108,12 +102,13 @@ class TestWaNslp(TestCase):
         self.assertEqual(result.value, 828)
 
     def test_eligible_snap_categorical_high_income(self):
+        seed_program(self.white_label, "wa_snap")
         screen = self._screen_base(
             zipcode="99201",
             county="Spokane County",
-            has_snap=True,
             has_benefits="true",
         )
+        set_current_benefits(screen, "wa_snap")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=7000, frequency="monthly"
@@ -126,7 +121,9 @@ class TestWaNslp(TestCase):
         self.assertEqual(result.value, 828)
 
     def test_eligible_tanf_categorical(self):
-        screen = self._screen_base(zipcode="98901", county="Yakima County", has_tanf=True, has_benefits="true")
+        seed_program(self.white_label, "wa_tanf")
+        screen = self._screen_base(zipcode="98901", county="Yakima County", has_benefits="true")
+        set_current_benefits(screen, "wa_tanf")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=5500, frequency="monthly"
@@ -139,7 +136,9 @@ class TestWaNslp(TestCase):
         self.assertEqual(result.value, 828)
 
     def test_ineligible_snap_but_no_school_age_child(self):
-        screen = self._screen_base(zipcode="98103", county="King County", household_size=2, has_snap=True)
+        seed_program(self.white_label, "wa_snap")
+        screen = self._screen_base(zipcode="98103", county="King County", household_size=2)
+        set_current_benefits(screen, "wa_snap")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=1800, frequency="monthly"
@@ -163,13 +162,17 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertFalse(result.eligible)
 
-    def test_eligible_early_head_start_flag_high_income(self):
+    def test_eligible_early_head_start_categorical_high_income(self):
+        # WA's config doesn't currently offer an Early Head Start program, but the
+        # calculator screens on it via _EARLY_HEAD_START_NAMES — seed the bare name
+        # to exercise that pathway.
+        seed_program(self.white_label, "early_head_start")
         screen = self._screen_base(
             zipcode="98402",
             county="Pierce County",
-            has_early_head_start=True,
             has_benefits="true",
         )
+        set_current_benefits(screen, "early_head_start")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=33, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=5000, frequency="monthly"
@@ -181,13 +184,14 @@ class TestWaNslp(TestCase):
         self.assertTrue(result.eligible)
         self.assertEqual(result.value, 828)
 
-    def test_eligible_head_start_flag_high_income(self):
+    def test_eligible_head_start_categorical_high_income(self):
+        seed_program(self.white_label, "wa_head_start")
         screen = self._screen_base(
             zipcode="98402",
             county="Pierce County",
-            has_head_start=True,
             has_benefits="true",
         )
+        set_current_benefits(screen, "wa_head_start")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=33, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=5000, frequency="monthly"
@@ -200,12 +204,13 @@ class TestWaNslp(TestCase):
         self.assertEqual(result.value, 828)
 
     def test_snap_categorical_uses_presumed_eligibility_pass_message_not_income(self):
+        seed_program(self.white_label, "wa_snap")
         screen = self._screen_base(
             zipcode="99201",
             county="Spokane County",
-            has_snap=True,
             has_benefits="true",
         )
+        set_current_benefits(screen, "wa_snap")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=7000, frequency="monthly"

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -68,15 +68,20 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertFalse(result.eligible)
 
-    def test_ineligible_income_one_dollar_over_reduced_monthly(self):
-        """$4,110/mo for HH3 — over $4,109 monthly reduced-price cap; Medicaid irrelevant."""
+    def test_medicaid_does_not_confer_categorical_eligibility(self):
+        """Medicaid must NOT be a categorical pathway (spec: Medicaid alone must not
+        create categorical eligibility). A school-age child is present, so the only
+        thing that could make this over-income HH3 eligible is wrongly treating
+        Medicaid as presumptive — it stays ineligible because Medicaid isn't in
+        `presumptive_eligibility`. ($4,110/mo > $4,109 monthly reduced-price cap.)"""
+        seed_program(self.white_label, "wa_medicaid")
         screen = self._screen_base(
             zipcode="98103",
             county="King County",
             household_size=3,
-            has_medicaid=True,
             has_benefits="true",
         )
+        set_current_benefits(screen, "wa_medicaid")
         head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=39, has_income=True)
         IncomeStream.objects.create(
             screen=screen, household_member=head, type="wages", amount=4110, frequency="monthly"

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -162,28 +162,6 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertFalse(result.eligible)
 
-    def test_eligible_early_head_start_categorical_high_income(self):
-        # WA's config doesn't currently offer an Early Head Start program, but the
-        # calculator screens on it via _EARLY_HEAD_START_NAMES — seed the bare name
-        # to exercise that pathway.
-        seed_program(self.white_label, "early_head_start")
-        screen = self._screen_base(
-            zipcode="98402",
-            county="Pierce County",
-            has_benefits="true",
-        )
-        set_current_benefits(screen, "early_head_start")
-        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=33, has_income=True)
-        IncomeStream.objects.create(
-            screen=screen, household_member=head, type="wages", amount=5000, frequency="monthly"
-        )
-        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=32, has_income=False)
-        HouseholdMember.objects.create(screen=screen, relationship="child", age=5, has_income=False)
-
-        result = self._calc(screen).calc()
-        self.assertTrue(result.eligible)
-        self.assertEqual(result.value, 828)
-
     def test_eligible_head_start_categorical_high_income(self):
         seed_program(self.white_label, "wa_head_start")
         screen = self._screen_base(

--- a/programs/programs/wa/nslp/tests.py
+++ b/programs/programs/wa/nslp/tests.py
@@ -148,20 +148,6 @@ class TestWaNslp(TestCase):
         result = self._calc(screen).calc()
         self.assertFalse(result.eligible)
 
-    def test_ineligible_already_has_nslp(self):
-        seed_program(self.white_label, "nslp")
-        screen = self._screen_base()
-        set_current_benefits(screen, "nslp")
-        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=36, has_income=True)
-        IncomeStream.objects.create(
-            screen=screen, household_member=head, type="wages", amount=2000, frequency="monthly"
-        )
-        HouseholdMember.objects.create(screen=screen, relationship="spouse", age=34, has_income=False)
-        HouseholdMember.objects.create(screen=screen, relationship="child", age=7, has_income=False)
-
-        result = self._calc(screen).calc()
-        self.assertFalse(result.eligible)
-
     def test_eligible_head_start_categorical_high_income(self):
         seed_program(self.white_label, "wa_head_start")
         screen = self._screen_base(

--- a/screener/models.py
+++ b/screener/models.py
@@ -402,6 +402,16 @@ class Screen(models.Model):
         # write target, so we are intentionally NOT adding an invalidation hook.
         return {cb.program.name_abbreviated for cb in self.current_benefits.all()}
 
+    @cached_property
+    def _current_benefit_base_programs(self) -> set[str]:
+        # The `base_program` grouping of the household's current benefits — e.g. a
+        # screen receiving wa_tanf / co_tanf / ma_tafdc all contribute "tanf". Backs
+        # has_base_benefit(), letting callers ask "any variant of program X?" without
+        # a hand-maintained name list that goes stale when a new state program is
+        # added. Same prefetch / per-instance cache behavior (and staleness caveat)
+        # as _current_benefit_names above; base_program is nullable, so drop None.
+        return {cb.program.base_program for cb in self.current_benefits.all() if cb.program.base_program is not None}
+
     def has_benefit(self, name_abbreviated: str) -> bool:
         """
         Returns True if the user has declared they already receive the benefit
@@ -420,6 +430,20 @@ class Screen(models.Model):
         read path needs no special-casing.
         """
         return name_abbreviated in self._current_benefit_names
+
+    def has_base_benefit(self, base_program: str) -> bool:
+        """
+        Returns True if the household receives any current benefit whose
+        `Program.base_program` matches — i.e. any white-label variant of that
+        program. `has_base_benefit("tanf")` covers tanf / co_tanf / il_tanf /
+        wa_tanf / ma_tafdc / … without enumerating the names.
+
+        Prefer this over `has_benefit_from_list([...])` when the intent is "any
+        variant of program X across white labels": it reads the structural
+        `base_program` grouping, so a newly added state variant is included
+        automatically as long as its `base_program` is set.
+        """
+        return base_program in self._current_benefit_base_programs
 
     def set_screen_is_test(self):
         referral_source_tests = ["testorprospect", "test"]


### PR DESCRIPTION
## Context & Motivation

Several calculator code paths read raw `screen.has_*` benefit columns directly. The CB Step 6 cutover (MFB-720, #1573) stops writing those columns, so after it deploys those reads silently return the DB default (`False`) forever — quietly changing eligibility output. This PR migrates **all** such reads to the `CurrentBenefit` join table (`has_benefit` / `has_benefit_from_list`), the authoritative read source since MFB-869.

Affected reads:
- **WaNslp** categorical eligibility — read `has_snap` / `has_tanf` / `has_head_start` / `has_early_head_start` (`programs/programs/wa/nslp/calculator.py`).
- **`snap_ineligible_student()`** (`programs/programs/helpers.py`) — the "household receives TANF" SNAP-student exemption (E6); consumed by the PE dependency `is_snap_ineligible_student` and the CO SNAP-student warning.
- **`NcSnapIneligibleStudentDependency`** (`policyengine/.../member.py`) — the NC SNAP-student TANF exemption.
- **Energy EBT** (`co/energy_calculator/energy_ebt/calculator.py`) — the `has_leap` "no LEAP" gate for the `cesn_energy_ebt` calculator.

The CB Step 6 cutover (MFB-720, #1573) **stops writing those columns** — the frontend now sends `current_benefits: [...]` and the serializer no longer mirrors into `has_*`. Left unchanged, WaNslp's categorical pathway silently goes dead once MFB-720 deploys: those columns stay frozen at their `False` default, so a high-income WA household that selects SNAP/TANF/Head Start on the current-benefits step would no longer be screened categorically eligible for NSLP — it would fall through to the income test only.

This was surfaced reviewing what becomes stale after MFB-720. This PR moves WaNslp's categorical reads onto the `CurrentBenefit` join table (the authoritative read source since MFB-869) and drops a redundant self-check.

- Related: MFB-720 (#1573), MFB-1119 (WaNslp → PolicyEngine conversion, which will replace this logic wholesale)

## Changes Made

- **Categorical reads → join table.** The SNAP/TANF/Head Start categorical check now reads the `CurrentBenefit` join table (`screen.has_benefit(...)`) instead of the `has_*` columns. The qualifying programs live in a `presumptive_eligibility` class attribute — `wa_snap`, `wa_tanf`, `wa_head_start` — the only relevant `name_abbreviated` values a WA screen's current benefits can contain (matching the convention other calculators use). The single-use foster-child categorical helper is inlined into `household_eligible()`. (WA offers no Early Head Start program, so that pathway is dropped — it can't fire on a real WA screen.)
- **Migrated the SNAP-student TANF reads via a structural `base_program` query.** `snap_ineligible_student()` (E6) and `NcSnapIneligibleStudentDependency` (E6) now call a new `Screen.has_base_benefit("tanf")` instead of reading `screen.has_tanf`. `has_base_benefit` reads the current-benefits join table grouped by `Program.base_program`, so it matches *any* TANF variant — tanf / co_tanf / wa_tanf / ma_tafdc / … — without a hand-maintained name list. This deliberately avoids enumerating variants: `wa_tanf` was added as a PE program in #1518/MFB-749 and would have been missed by a name list (it carries `base_program: "tanf"`, so the structural query picks it up automatically). Energy EBT's LEAP gate uses `has_benefit("cesn_leap")` — in the CESN calculator only `cesn_leap` can appear in a screen's current benefits (it's the LEAP variant with `show_in_has_benefits_step=True` on the CESN white label); `leap` (CO WL) and `nc_leap` (NC WL) are never rendered on the CESN screener, so they could never be true here.
- **Dropped the redundant "already has NSLP" guard.** `household_eligible()` previously barred households with `not has_benefit("nslp")`. That duplicates the results layer, which sets each program's `already_has` flag centrally (`screen.has_benefit(program.name_abbreviated)` in `screener/views.py`) and filters it on the frontend. The guard was also subtly wrong — it checked the bare name `"nslp"` while WA only offers `"wa_nslp"`, so it never fired on a real WA screen anyway.
- **Tests:** categorical tests seed the program and write the join table (`seed_program` + `set_current_benefits`) instead of setting `has_*` column kwargs; dropped the now-unused benefit-column defaults from `_screen_base`; removed `test_ineligible_already_has_nslp` (it exercised the removed guard and had to seed a bare `nslp` program WA doesn't offer).

## Testing

- Migrations to run: none
- `black` clean
- `pytest programs/programs/wa/nslp` → **15 passed**; full suite (fresh DB) → **1888 passed**
- Verified the calculator no longer references any `has_*` benefit column; categorical reads go through the join table, and self-filtering relies on the central `already_has` flag.

## Deployment

- **Merge ordering — must ship with or after the MFB-720 pair (#1573 BE + #2123 FE), not ahead of it.** This is about the **WaNslp categorical** read specifically. Most migrated reads are independently safe today because the legacy `has_*` mirror (`_benefit_map_from_has_columns()`) populates the join table on the pre-720 path: it writes `wa_snap` / `wa_head_start` (WaNslp categorical), and `tanf` / `nc_tanf` etc. all carry `base_program: "tanf"` (so the SNAP-student `has_base_benefit("tanf")` reads match). **WaNslp's TANF categorical read is the exception** — it calls `has_benefit("wa_tanf")` directly (by exact `name_abbreviated`, not base_program), and the mirror has no `wa_tanf` row (the variant was added in #1518/MFB-749 without one). So on the pre-720 path that single read is always `False`, where the old `screen.has_tanf` column read worked. If #1575 lands on `main` ahead of #1573/#2123, WA NSLP TANF-categorical eligibility breaks in that window.
- **The SNAP-student TANF reads are safe standalone** — `has_base_benefit("tanf")` matches by `Program.base_program`, and the pre-720 mirror writes the non-WA `tanf` variants (all `base_program: "tanf"`), so a WA TANF household trips E6 both pre-720 (mirror) and post-720 (FE sends `wa_tanf`, also `base_program: "tanf"`). No window.
- **No standalone mirror fix is warranted for the WaNslp categorical gap** — #1573 deletes `_benefit_map_from_has_columns()` wholesale, after which the new FE (#2123) sends `wa_tanf` directly in `current_benefits` and `has_benefit("wa_tanf")` resolves correctly. Adding a `wa_tanf` row to a map that's being deleted this week would be churn and would likely conflict with #1573. The durable fix is the merge ordering above.
- No coordinated FE deploy needed *beyond* the MFB-720 FE PR (#2123) already in flight.

## Notes for Reviewers

- WA offers no Early Head Start program, so that categorical pathway (and the column the old code read) is dropped — it can't fire on a real WA screen.
- This is a stopgap that makes WaNslp correct on the join table; MFB-1119 will replace WaNslp with a PolicyEngine-backed calculator entirely.
- Related cleanup opportunity (not in this PR): other calculators that self-guard against *their own* program name could likewise rely on the central `already_has` flag. (Guards against *other* programs — e.g. SunBucks barred by SNAP/TANF — are real eligibility rules and should stay.)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved eligibility determination for Energy Assistance programs by refining how household benefits are assessed.
  * Enhanced SNAP student exemption logic for more accurate eligibility evaluation.

* **Refactor**
  * Updated Washington NSLP categorical eligibility assessment to align with current benefit records for more consistent program evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


