### PR TITLE
Add Tasty Food (Denver youth meals) CO urgent need

### DIFF
--- a/programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
@@ -18,7 +18,7 @@
     },
     "functions": [],
     "phone_number": "+17204839177",
-    "counties": ["Denver"],
+    "counties": ["Denver County"],
     "required_expense_types": [],
     "active": false,
     "low_confidence": false,

--- a/programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
@@ -17,7 +17,7 @@
       "notification_message": ""
     },
     "functions": [],
-    "phone_number": "+18558554626",
+    "phone_number": "+17204839177",
     "counties": ["Denver"],
     "required_expense_types": [],
     "active": false,

--- a/programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
+++ b/programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
@@ -1,0 +1,27 @@
+{
+  "white_label": { "code": "co" },
+  "need": {
+    "external_name": "co_tasty_food",
+    "category_type": {
+      "external_name": "co_food_or_groceries",
+      "name": "Food or groceries",
+      "icon": "food_groceries"
+    },
+    "type_short": ["food"],
+    "translations": {
+      "name": "Tasty Food (Denver Youth Meals)",
+      "description": "Free meals and snacks for Denver youth ages 3-18, served fresh daily at recreation centers and outdoor pools across the city. No ID or registration required.",
+      "link": "https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Public-Health-Environment/Community-Behavioral-Health/Food-System-Policies/Tasty-Food",
+      "warning": "",
+      "website_description": "Free, fresh meals and snacks for Denver youth ages 3-18 at local rec centers and pools.",
+      "notification_message": ""
+    },
+    "functions": [],
+    "phone_number": "+18558554626",
+    "counties": ["Denver"],
+    "required_expense_types": [],
+    "active": false,
+    "low_confidence": false,
+    "show_on_current_benefits": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new urgent-need / additional-resource config for **Tasty Food**, a Denver Department of Public Health & Environment program that provides free, fresh meals and snacks to youth ages 3–18 at recreation centers and outdoor pools across the city all year long. No ID or registration is required.

Source: [Tasty Food — denvergov.org](https://www.denvergov.org/Government/Agencies-Departments-Offices/Agencies-Departments-Offices-Directory/Public-Health-Environment/Community-Behavioral-Health/Food-System-Policies/Tasty-Food)

## Config details

New file: 'programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json'

| Field | Value |
|-------|-------|
| white_label | 'co' |
| external_name | 'co_tasty_food' |
| category_type | 'co_food_or_groceries' (Food or groceries, 'food_groceries' icon) |
| type_short | '["food"]' |
| counties | Denver |
| phone | Food Resource Hotline (855-855-4626, bilingual) |
| active | 'false' — to be activated in admin after review |

Follows the existing per-state '{state}_food_or_groceries' category-type convention (mirrors 'wa_food_lifeline', 'il_find_food', 'tx_north_texas_food_bank').

## How to import

\`\`\`bash
python manage.py import_urgent_need_config programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json --dry-run
python manage.py import_urgent_need_config programs/management/commands/import_urgent_need_config_data/data/co_tasty_food.json
\`\`\`

## Testing

- JSON validated
- '--dry-run' import passes locally (creates the urgent need + 'co_food_or_groceries' category type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new food assistance resource for Denver, Colorado residents, including contact information and service details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->