### PR TITLE
Skip setTopic on on-call catch-up runs to stop daily channel noise

### DIFF
--- a/.github/oncall/rotate_oncall.py
+++ b/.github/oncall/rotate_oncall.py
@@ -212,9 +212,16 @@ def main() -> int:
         token,
         {"usergroup": usergroup, "users": on_call["slack_id"]},
     )
+    # Has this week's handoff already been announced? If so, this is a catch-up
+    # run on a week that already fired — the announcement and topic are already
+    # correct, so we skip both. (setTopic isn't idempotent from Slack's view: it
+    # emits a "set the channel topic" system line on every call even when the
+    # value is unchanged, so re-applying it would noise the channel daily.)
+    already_announced = already_announced_this_week(token, channel, ref)
+
     # 2. Announce the handoff — but only once per week. The daily catch-up cron
     #    re-runs this script; without this guard it would re-post every weekday.
-    if already_announced_this_week(token, channel, ref):
+    if already_announced:
         print(f"Handoff for week of {ref} already announced; skipping post.")
     else:
         # blocks for layout, text for the notification.
@@ -223,15 +230,20 @@ def main() -> int:
             token,
             {"channel": channel, "text": fallback, "blocks": blocks},
         )
-    # 3. Update the channel topic (best effort; don't fail the run on topic error).
-    try:
-        slack_post(
-            "conversations.setTopic",
-            token,
-            {"channel": channel, "topic": topic},
-        )
-    except SystemExit as exc:
-        print(f"Warning: could not set channel topic: {exc}", file=sys.stderr)
+    # 3. Update the channel topic (best effort; don't fail the run on topic
+    #    error). Skipped on catch-up runs where the handoff already posted — the
+    #    topic was set then and re-applying only emits a noisy system message.
+    if already_announced:
+        print(f"Topic already set for week of {ref}; skipping setTopic.")
+    else:
+        try:
+            slack_post(
+                "conversations.setTopic",
+                token,
+                {"channel": channel, "topic": topic},
+            )
+        except SystemExit as exc:
+            print(f"Warning: could not set channel topic: {exc}", file=sys.stderr)
 
     print(f"On-call updated: {on_call['name']} ({on_call['slack_id']}) for week of {ref}.")
     return 0


### PR DESCRIPTION
## Problem

The weekly on-call rotation has a daily Tue–Fri catch-up cron (a safety net for missed Monday runs). After fixing the `channels:history` scope so the handoff announcement is correctly deduped, the channel was *still* getting a daily message:

> On-Call Eng: set the channel topic: On-call: Elliott

`conversations.setTopic` runs unconditionally on every execution. Slack emits a `set the channel topic` system line on **every** setTopic call, even when the topic value is unchanged — so each catch-up run produced one.

## Fix

Compute `already_announced_this_week()` once and gate **both** the handoff post and the topic update on it. On a week that already fired, the topic was already set during that run, so we skip setTopic. No new Slack scope needed — reuses the existing check.

Catch-up runs that find the week already handled are now fully silent (usergroup re-apply is the only action, and that's invisible). A genuinely missed Monday still self-heals: nothing posted yet ⇒ both the announcement and the topic fire.

## Testing

- `python -c "ast.parse(...)"` — syntax OK
- Dry run (`ONCALL_DRY_RUN=1 ONCALL_TODAY=2026-06-11`) — unchanged output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized on-call handoff announcement logic to reduce redundant operations
  * Added configuration for new community service support (Denver youth meals)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->