### PR TITLE
MFB:1088: Fixing bug from migration to JOIN tables

### DIFF
--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -61,11 +61,20 @@ class TxFpp(ProgramCalculator):
         # §4140 adjunctive income eligibility: enrollment in SNAP, WIC, or CHIP
         # (applicant or their child) bypasses the 250% FPL income test.
         #
-        # Read the has_* columns directly rather than has_benefit(): has_benefit()
-        # resolves against the CurrentBenefit join table keyed by the white-label
-        # program name (e.g. "tx_snap"), so the generic "snap"/"wic" keys do not
-        # reliably match. The columns are the authoritative screen-level flags.
-        adjunctive_eligible = bool(self.screen.has_snap or self.screen.has_wic or self.screen.has_chp)
+        # SNAP/WIC enrollment lives in the CurrentBenefit join table, read via
+        # has_base_benefit() against the cross-white-label `base_program` grouping
+        # (tx_snap → "snap", tx_wic → "wic"). CHIP is collected as a per-member
+        # insurance question, not a current benefit, so it is read from member
+        # insurance (matches any household member — "applicant or their child").
+        #
+        # Do NOT read the legacy Screen.has_snap/has_wic/has_chp boolean columns:
+        # the join-table migration (MFB-720) dropped them from the serializer write
+        # contract, so they are never populated and are permanently False.
+        adjunctive_eligible = (
+            self.screen.has_base_benefit("snap")
+            or self.screen.has_base_benefit("wic")
+            or self.screen.has_insurance_types(("chp",))
+        )
 
         if adjunctive_eligible:
             e.condition(True, messages.presumed_eligibility())

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -61,18 +61,21 @@ class TxFpp(ProgramCalculator):
         # §4140 adjunctive income eligibility: enrollment in SNAP, WIC, or CHIP
         # (applicant or their child) bypasses the 250% FPL income test.
         #
-        # SNAP/WIC enrollment lives in the CurrentBenefit join table, read via
-        # has_base_benefit() against the cross-white-label `base_program` grouping
-        # (tx_snap → "snap", tx_wic → "wic"). CHIP is collected as a per-member
-        # insurance question, not a current benefit, so it is read from member
-        # insurance (matches any household member — "applicant or their child").
+        # SNAP/WIC enrollment lives in the CurrentBenefit join table under their
+        # TX-scoped names (tx_snap, tx_wic — the "already have this" tiles flagged
+        # in migration 0142), read via has_benefit(). CHIP is NOT a current-benefits
+        # tile: tx_chip is a PolicyEngine eligibility program, never written to the
+        # join table, so has_benefit("tx_chip") is always False. CHIP enrollment is
+        # captured as a per-member insurance question, so it is read from member
+        # insurance (matches any household member — "applicant or their child"),
+        # mirroring the sibling Healthy Texas Women calculator.
         #
         # Do NOT read the legacy Screen.has_snap/has_wic/has_chp boolean columns:
         # the join-table migration (MFB-720) dropped them from the serializer write
         # contract, so they are never populated and are permanently False.
         adjunctive_eligible = (
-            self.screen.has_base_benefit("snap")
-            or self.screen.has_base_benefit("wic")
+            self.screen.has_benefit("tx_snap")
+            or self.screen.has_benefit("tx_wic")
             or self.screen.has_insurance_types(("chp",))
         )
 

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -73,13 +73,13 @@ class TxFpp(ProgramCalculator):
         # Do NOT read the legacy Screen.has_snap/has_wic/has_chp boolean columns:
         # the join-table migration (MFB-720) dropped them from the serializer write
         # contract, so they are never populated and are permanently False.
-        adjunctive_eligible = (
+        presumptive_eligibility = (
             self.screen.has_benefit("tx_snap")
             or self.screen.has_benefit("tx_wic")
             or self.screen.has_insurance_types(("chp",))
         )
 
-        if adjunctive_eligible:
+        if presumptive_eligibility:
             e.condition(True, messages.presumed_eligibility())
             return
 

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -35,8 +35,7 @@ def make_member(age=30, medicaid=False, emergency_medicaid=False, employer=False
 
 
 def make_calculator(
-    has_snap=False,
-    has_wic=False,
+    current_benefits=None,
     has_chp=False,
     household_income=0,
     household_size=1,
@@ -46,25 +45,29 @@ def make_calculator(
     """Create a TxFpp calculator with a mocked screen and program.
 
     The §4140 adjunctive bypass reads enrollment the way a real screen exposes it:
-    SNAP/WIC from the CurrentBenefit join table via has_benefit("tx_snap"/"tx_wic"),
-    and CHIP from per-member insurance via has_insurance_types(("chp",)) — tx_chip is
-    a PolicyEngine eligibility program, never a current benefit. The mocks below
-    mirror those methods rather than the legacy has_snap/has_wic/has_chp columns,
-    which the serializer no longer populates (MFB-720) — so a regression back to
-    reading those dead columns (or to has_benefit("tx_chip"), which is always
-    False) would fail these tests.
+    SNAP/WIC from the CurrentBenefit join table via has_benefit(), and CHIP from
+    per-member insurance via has_insurance_types(("chp",)). The mocks below mirror
+    those methods rather than the legacy has_snap/has_wic/has_chp columns, which the
+    serializer no longer populates (MFB-720) — so a regression back to those dead
+    columns would fail these tests.
+
+    Args:
+        current_benefits: name_abbreviated strings the household already receives,
+            as written to the CurrentBenefit join table — e.g. ["tx_snap", "tx_wic"].
+            Drives has_benefit(). Note tx_chip is never a current benefit (it's a
+            PolicyEngine eligibility program), so passing it here is a no-op; use
+            has_chp for CHIP.
+        has_chp: whether a household member has CHIP coverage — a per-member
+            insurance flag, read via has_insurance_types(("chp",)), not a current
+            benefit.
     """
     mock_program = Mock()
     mock_program.year.get_limit.return_value = fpl_limit
 
-    current_benefits = set()
-    if has_snap:
-        current_benefits.add("tx_snap")
-    if has_wic:
-        current_benefits.add("tx_wic")
+    benefits = set(current_benefits or [])
 
     mock_screen = Mock()
-    mock_screen.has_benefit = Mock(side_effect=lambda name_abbreviated: name_abbreviated in current_benefits)
+    mock_screen.has_benefit = Mock(side_effect=lambda name_abbreviated: name_abbreviated in benefits)
     mock_screen.has_insurance_types = Mock(side_effect=lambda types, strict=True: has_chp and "chp" in types)
     mock_screen.household_size = household_size
     mock_screen.calc_gross_income = Mock(return_value=household_income)
@@ -162,10 +165,9 @@ class TestTxFppHouseholdIncome(TestCase):
 class TestTxFppAdjunctiveBypass(TestCase):
     """§4140 — SNAP / WIC / CHIP enrollment bypasses the income test."""
 
-    def _run(self, has_snap=False, has_wic=False, has_chp=False, household_income=99_999, fpl_limit=15_000):
+    def _run(self, current_benefits=None, has_chp=False, household_income=99_999, fpl_limit=15_000):
         calc = make_calculator(
-            has_snap=has_snap,
-            has_wic=has_wic,
+            current_benefits=current_benefits,
             has_chp=has_chp,
             household_income=household_income,
             fpl_limit=fpl_limit,
@@ -176,10 +178,10 @@ class TestTxFppAdjunctiveBypass(TestCase):
         return e.eligible
 
     def test_snap_bypasses_income_test(self):
-        self.assertTrue(self._run(has_snap=True))
+        self.assertTrue(self._run(current_benefits=["tx_snap"]))
 
     def test_wic_bypasses_income_test(self):
-        self.assertTrue(self._run(has_wic=True))
+        self.assertTrue(self._run(current_benefits=["tx_wic"]))
 
     def test_chip_bypasses_income_test(self):
         self.assertTrue(self._run(has_chp=True))

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -46,23 +46,25 @@ def make_calculator(
     """Create a TxFpp calculator with a mocked screen and program.
 
     The §4140 adjunctive bypass reads enrollment the way a real screen exposes it:
-    SNAP/WIC from the CurrentBenefit join table via has_base_benefit("snap"/"wic"),
-    and CHIP from per-member insurance via has_insurance_types(("chp",)). The mocks
-    below mirror those methods rather than the legacy has_snap/has_wic/has_chp
-    columns, which the serializer no longer populates (MFB-720) — so a regression
-    back to reading those dead columns would fail these tests.
+    SNAP/WIC from the CurrentBenefit join table via has_benefit("tx_snap"/"tx_wic"),
+    and CHIP from per-member insurance via has_insurance_types(("chp",)) — tx_chip is
+    a PolicyEngine eligibility program, never a current benefit. The mocks below
+    mirror those methods rather than the legacy has_snap/has_wic/has_chp columns,
+    which the serializer no longer populates (MFB-720) — so a regression back to
+    reading those dead columns (or to has_benefit("tx_chip"), which is always
+    False) would fail these tests.
     """
     mock_program = Mock()
     mock_program.year.get_limit.return_value = fpl_limit
 
-    base_benefits = set()
+    current_benefits = set()
     if has_snap:
-        base_benefits.add("snap")
+        current_benefits.add("tx_snap")
     if has_wic:
-        base_benefits.add("wic")
+        current_benefits.add("tx_wic")
 
     mock_screen = Mock()
-    mock_screen.has_base_benefit = Mock(side_effect=lambda base_program: base_program in base_benefits)
+    mock_screen.has_benefit = Mock(side_effect=lambda name_abbreviated: name_abbreviated in current_benefits)
     mock_screen.has_insurance_types = Mock(side_effect=lambda types, strict=True: has_chp and "chp" in types)
     mock_screen.household_size = household_size
     mock_screen.calc_gross_income = Mock(return_value=household_income)

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -43,14 +43,27 @@ def make_calculator(
     fpl_limit=15_000,
     members=None,
 ):
-    """Create a TxFpp calculator with a mocked screen and program."""
+    """Create a TxFpp calculator with a mocked screen and program.
+
+    The §4140 adjunctive bypass reads enrollment the way a real screen exposes it:
+    SNAP/WIC from the CurrentBenefit join table via has_base_benefit("snap"/"wic"),
+    and CHIP from per-member insurance via has_insurance_types(("chp",)). The mocks
+    below mirror those methods rather than the legacy has_snap/has_wic/has_chp
+    columns, which the serializer no longer populates (MFB-720) — so a regression
+    back to reading those dead columns would fail these tests.
+    """
     mock_program = Mock()
     mock_program.year.get_limit.return_value = fpl_limit
 
+    base_benefits = set()
+    if has_snap:
+        base_benefits.add("snap")
+    if has_wic:
+        base_benefits.add("wic")
+
     mock_screen = Mock()
-    mock_screen.has_snap = has_snap
-    mock_screen.has_wic = has_wic
-    mock_screen.has_chp = has_chp
+    mock_screen.has_base_benefit = Mock(side_effect=lambda base_program: base_program in base_benefits)
+    mock_screen.has_insurance_types = Mock(side_effect=lambda types, strict=True: has_chp and "chp" in types)
     mock_screen.household_size = household_size
     mock_screen.calc_gross_income = Mock(return_value=household_income)
     mock_screen.household_members.all = Mock(return_value=members if members is not None else [])

--- a/validations/management/commands/import_validations/data/tx_fpp.json
+++ b/validations/management/commands/import_validations/data/tx_fpp.json
@@ -319,7 +319,7 @@
       "county": "Collin",
       "household_size": 1,
       "household_assets": 5000.00,
-      "has_snap": true,
+      "current_benefits": ["tx_snap"],
       "household_members": [
         {
           "relationship": "headOfHousehold",

--- a/validations/management/commands/import_validations/test_case_schema.json
+++ b/validations/management/commands/import_validations/test_case_schema.json
@@ -98,6 +98,11 @@
         "energy_calculator": {
           "$ref": "#/definitions/energyCalculatorScreen"
         },
+        "current_benefits": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "name_abbreviated strings written to the CurrentBenefit join table (e.g. ['tx_snap']). This is the supported way to record current-benefit enrollment; the legacy has_* booleans below are no longer persisted by ScreenSerializer (MFB-720)."
+        },
         "has_tanf": { "type": "boolean" },
         "has_wic": { "type": "boolean" },
         "has_snap": { "type": "boolean" },


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes MFB-1088 (TX Family Planning Program custom calculator follow-up)
- Related PR: _N/A_

The TX FPP `§4140` adjunctive income bypass — which should make an applicant with
income above 250% FPL eligible when they (or their child) are enrolled in SNAP,
WIC, or CHIP — never fired in production. A validation case (income above 250%
FPL but enrolled in SNAP, expected `$266`) returned `$0`.

Root cause: the calculator read the legacy `Screen.has_snap` / `has_wic` /
`has_chp` boolean columns. The join-table migration (MFB-720) dropped those
columns from the `ScreenSerializer` write contract, so nothing populates them
anymore — they are permanently `False` on every real screen. Current-benefit
enrollment now lives in the `CurrentBenefit` join table (`current_benefits`,
e.g. `tx_snap`), and CHIP is captured as a per-member insurance question
(`member.insurance.chp`), never as a current benefit.

This affected all three adjunctive programs (SNAP, WIC, CHIP) identically — SNAP
was simply the only one with a validation scenario, so it was the one observed.
The unit tests passed only because they mocked the dead boolean columns directly,
bypassing the real read path.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- **`programs/programs/tx/fpp/calculator.py`** — `household_eligible()` now reads
  the live data surface for the §4140 bypass:
  - SNAP: `self.screen.has_benefit("tx_snap")` — `tx_snap` is a TX current-benefits
    tile (flagged in migration `0142`), so it lands in the `CurrentBenefit` join
    table under that exact name.
  - WIC: `self.screen.has_benefit("tx_wic")` (same — flagged in `0142`).
  - CHIP: `self.screen.has_insurance_types(("chp",))` — CHIP is a per-member
    insurance question ("applicant or their child"), **not** a current-benefits
    tile. `tx_chip` is a PolicyEngine *eligibility* program and is never written to
    the join table, so `has_benefit("tx_chip")` would always be `False`. This
    mirrors the sibling Healthy Texas Women calculator (`tx/htw/calculator.py`).
  - Replaced the old comment that argued the `has_*` columns were authoritative
    with one explaining they are dead post-MFB-720 and must not be used, plus why
    SNAP/WIC use the join table while CHIP uses member insurance.
  - **Fixed a critical correctness bug** introduced mid-iteration: a trailing comma
    made `adjunctive_eligible` a 1-tuple `(bool,)`, which is always truthy — so the
    250% FPL income test was bypassed for *every* household. Removed.
- **`validations/.../import_validations/data/tx_fpp.json`** — the §4140 SNAP
  scenario set `"has_snap": true`, which `ScreenSerializer` silently drops.
  Changed to `"current_benefits": ["tx_snap"]` so the imported screen actually
  records SNAP enrollment in the join table.
- **`validations/.../import_validations/test_case_schema.json`** — added a
  `current_benefits` array property (with a note that the legacy `has_*` booleans
  are no longer persisted), so the supported field is documented in the schema.
- **`programs/programs/tx/fpp/tests/test_fpp.py`** — `make_calculator()` now mocks
  the real methods (`has_benefit` for `tx_snap`/`tx_wic`, `has_insurance_types` for
  CHIP) instead of the dead `has_snap`/`has_wic`/`has_chp` attributes, so a
  regression back to reading the legacy columns — or to `has_benefit("tx_chip")`,
  which is always `False` — would fail the tests. The public test signature
  (`has_snap=`/`has_wic=`/`has_chp=`) is unchanged.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none (no schema changes).
- Configuration updates needed: none.
- Environment variables/settings to add: none.
- Manual testing steps:
  - Unit tests: `python -m pytest programs/programs/tx/fpp/tests/test_fpp.py`
    (26 passed locally).
  - Lint/format: `black` reports both changed files unchanged; run project
    `flake8` to confirm clean.
  - Re-import the corrected validation fixture and confirm the §4140 SNAP
    scenario now computes `$266` (eligible) instead of `$0`:
    `python manage.py import_validations validations/management/commands/import_validations/data/tx_fpp.json`
    Then view the new screen's results with `?admin=true` and confirm the
    `tx_fpp` validation passes.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: **Yes.** The existing prod validation screen
  (`116305ae-9f29-4865-aa0d-f19f554604f2`) was created from the old fixture, so
  its `current_benefits` join table is empty — it will **not** self-heal after the
  code deploys and will keep showing `$0`. Re-run `import_validations` with the
  corrected `tx_fpp.json` to create a fresh screen that records `tx_snap`.
  - Note: `import_validations` is **additive** — it creates a new screen per run
    and will error if a validation already exists for the same screen+program.
    Purge the stale `Validation` row(s) / screen for `tx_fpp` first to avoid
    accumulating duplicates.
- Production config updates: none.
- Admin updates needed: none beyond the validation re-import above.
- Notify team/users of: QA that previously saw the TX FPP §4140 SNAP case fail
  can re-verify; WIC/CHIP adjunctive paths were silently broken too and are now
  fixed.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
  - CHIP Perinatal (the 4th §4140 program) is still not collected by the screener
    and remains a data gap, as documented in the calculator docstring.
  - The unit tests remain mock-based (matching the existing file style). They now
    mirror the real method surface, but a true integration test that builds a
    `Screen` through `ScreenSerializer` with `current_benefits` and runs the
    calculator end-to-end would be the strongest guard against this class of bug.
- Future considerations:
  - The frontend still defines legacy `has_snap`/`has_wic`/`has_chp` in
    `ApiFormData`/`updateScreen` plumbing slated for removal once MFB-720 fully
    lands; confirm no other custom calculator still reads the dead `Screen.has_*`
    columns (grep found the TX FPP usage was the live offender).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Corrected adjunctive-income bypass eligibility calculation in Texas FPP to use current benefit enrollment and insurance type records for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->