### PR TITLE
MFB-1136: Fix TANF mislabeled as Colorado Works in WA government benefits income

### DIFF
--- a/configuration/white_labels/co.py
+++ b/configuration/white_labels/co.py
@@ -174,7 +174,7 @@ class CoConfigurationData(ConfigurationData):
         "government": {
             **ConfigurationData.income_options_by_category["government"],
             "cashAssistance": {
-                "_label": "incomeOptions.cashAssistance",
+                "_label": "incomeOptions.cashAssistance.co",
                 "_default_message": "Government Cash Assistance (including Colorado Works/TANF)",
             },
             "cOSDisability": {


### PR DESCRIPTION
## Summary

Fixes [MFB-1136](https://linear.app/myfriendben/issue/MFB-1136/fix-tanf-mislabeled-as-colorado-works-in-wa-government-benefits-income): the WA government benefits income source dropdown was showing **"Government Cash Assistance (including Colorado Works/TANF)"** — Colorado-specific copy that doesn't belong in Washington.

## Root cause

WA's income source list isn't configured in `wa.py`; it inherits `income_options_by_category` from `base.py`. The `cashAssistance` option there uses the shared label `incomeOptions.cashAssistance`.

The CO white label overrode that option's `_default_message` with Colorado-specific text **but kept the shared base label** `incomeOptions.cashAssistance`. Since the FE renders the translated string for that label, the Colorado-flavored TANF translation leaked into every white label that inherits base — including WA.

This matches the bug pattern MA/IL already avoid by pointing their state-specific overrides at scoped labels (`incomeOptions.cashAssistance.ma` / `.il`).

## Change

Give Colorado its own label, `incomeOptions.cashAssistance.co`, so the generic `incomeOptions.cashAssistance` stays neutral ("Cash Assistance Grant") for WA and all other states.

## Follow-ups required for this to fully take effect (not in this PR)

1. **Add the `incomeOptions.cashAssistance.co` Translation row** per environment (admin portal or `add_translations`), since `_default_message` is only a fallback.
2. **Re-run `add_config`** for the CO white label so the updated config is written to the DB.
3. **Reset the existing `incomeOptions.cashAssistance` Translation row** back to neutral "Cash Assistance Grant" in each env — it currently holds the Colorado copy, so WA will keep showing the Colorado string until that DB value is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated Colorado's configuration to use state-specific translation labels for cash assistance income options, improving localization for users in the state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->