### PR TITLE
[WA] Fix broken "Visit Website" link on Washington 211 result

### DIFF
--- a/configuration/white_labels/wa.py
+++ b/configuration/white_labels/wa.py
@@ -28,7 +28,7 @@ class WaConfigurationData(ConfigurationData):
                     "_default_message": "211 Washington",
                     "_label": "moreHelp.211.name.wa",
                 },
-                "link": "https://www.211wa.org/",
+                "link": "https://wa211.org/",
                 "phone": {
                     "_default_message": "Dial 2-1-1",
                     "_label": "moreHelp.211.phone.wa",


### PR DESCRIPTION
## Summary

Fixes the broken **Visit Website** link on the Washington 211 result. The WA 211 listing in the `more_help_options` config pointed at `https://www.211wa.org/`, which returns an error and left users unable to reach the resource.

Updated the URL to `https://wa211.org/`, the working URL confirmed by the Washington partner.

## Change

`configuration/white_labels/wa.py` — `more_help_options` → 211 Washington listing:

- `https://www.211wa.org/` → `https://wa211.org/`

## Testing

- Partner verified `https://wa211.org/` works correctly (per ticket).

Fixes [MFB-1127](https://linear.app/myfriendben/issue/MFB-1127/wa-fix-broken-visit-website-link-on-washington-211-result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)