### PR TITLE
MFB-1159: Connect benefits-api to ai-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,46 @@ pytest -m integration
 ```
 
 For detailed information about writing and maintaining integration tests, see [docs/INTEGRATION_TESTING.md](docs/INTEGRATION_TESTING.md).
+
+## Benbot AI assistant
+
+Benbot is an AI assistant on the results page. The browser calls **this API**,
+which enforces the feature flag, assembles the screen context, and proxies to
+the standalone **mfb-ai-service**. The browser never calls mfb-ai-service directly.
+
+```
+benefits-calculator  ──▶  benefits-api (proxy)  ──▶  mfb-ai-service
+   chat widget              screener/assistant.py        FastAPI + Fireworks
+```
+
+### Feature flag
+
+Benbot is gated by the `benbot` feature flag (defined in
+`screener/feature_flags.py`, `scope="both"`), **off by default**.
+
+1. The flag is registered in code; sync it to all white labels:
+   ```bash
+   python manage.py sync_feature_flags --dry-run   # preview
+   python manage.py sync_feature_flags             # apply
+   ```
+2. Turn it on per white label in **Admin → General Settings → Feature Flags**.
+
+The proxy views (`screener/assistant.py`) reject requests with
+`403 assistant_disabled` when the flag is off, so the flag is real access
+control, not just hidden UI.
+
+### Endpoints
+
+- `POST /screens/<screen_uuid>/assistant/conversations/` — open/resume a conversation
+- `POST /screens/<screen_uuid>/assistant/conversations/<conversation_id>/messages/` — send a message
+
+### Environment variables
+
+- `AI_SERVICE_URL` — base URL of mfb-ai-service (default `http://localhost:8080`)
+- `AI_SERVICE_TOKEN` — shared bearer token; must match the service's `SERVICE_AUTH_TOKEN`. Leave blank for local dev.
+
+### Local dev
+
+Run mfb-ai-service on `:8080` in stub mode (no AI key needed), leave the tokens
+blank on both sides, point `AI_SERVICE_URL` at it, and enable the `benbot` flag
+for your local white label to exercise the full chain.

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -1,0 +1,101 @@
+"""Benbot assistant proxy views.
+
+These are the Layer 1 (browser-facing) endpoints. They authenticate/resolve the
+screen, enforce the `benbot` feature flag, assemble the screen context, and proxy
+to mfb-ai-service (Layer 2). The browser never calls mfb-ai-service directly.
+
+See the ai-service repo's docs/ for the full API contract.
+"""
+
+import os
+
+import requests
+from django.shortcuts import get_object_or_404
+from rest_framework import permissions, status, views
+from rest_framework.response import Response
+
+from .models import Screen
+
+# Where mfb-ai-service lives, and the shared service token (must match the
+# service's SERVICE_AUTH_TOKEN). Both come from the environment.
+AI_SERVICE_URL = os.getenv("AI_SERVICE_URL", "http://localhost:8080")
+AI_SERVICE_TOKEN = os.getenv("AI_SERVICE_TOKEN", "")
+AI_SERVICE_TIMEOUT = 60
+
+
+def _ai_headers() -> dict:
+    headers = {"Content-Type": "application/json"}
+    if AI_SERVICE_TOKEN:
+        headers["Authorization"] = f"Bearer {AI_SERVICE_TOKEN}"
+    return headers
+
+
+def _build_context(screen: Screen) -> dict:
+    """Assemble the screen context passed to mfb-ai-service.
+
+    NOTE (v0): eligible_programs is left empty for now. Populating it from the
+    eligibility calculation is a follow-up; the API contract allows an empty list.
+    """
+    return {
+        "household": {"size": screen.household_size},
+        "eligible_programs": [],  # TODO: populate from eligibility results
+    }
+
+
+def _proxy(method: str, path: str, json_body: dict) -> Response:
+    """Forward a request to mfb-ai-service and pass its response through."""
+    try:
+        resp = requests.request(
+            method,
+            f"{AI_SERVICE_URL}{path}",
+            json=json_body,
+            headers=_ai_headers(),
+            timeout=AI_SERVICE_TIMEOUT,
+        )
+    except requests.RequestException as e:
+        return Response(
+            {"error": {"code": "ai_upstream_error", "message": str(e)}},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {"error": {"code": "ai_upstream_error", "message": "Non-JSON response from AI service."}}
+        return Response(body, status=status.HTTP_502_BAD_GATEWAY)
+    return Response(body, status=resp.status_code)
+
+
+class AssistantStartView(views.APIView):
+    """POST: open (or resume) a Benbot conversation for a screen."""
+
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, screen_uuid):
+        screen = get_object_or_404(Screen, uuid=screen_uuid)
+        if not screen.white_label.has_feature("benbot"):
+            return Response({"error": {"code": "assistant_disabled"}}, status=status.HTTP_403_FORBIDDEN)
+
+        payload = {
+            "screen_uuid": str(screen.uuid),
+            "white_label": screen.white_label.code,
+            "locale": request.data.get("locale", "en-US"),
+            "context": _build_context(screen),
+        }
+        return _proxy("POST", "/v1/conversations", payload)
+
+
+class AssistantMessageView(views.APIView):
+    """POST: send a user message to an existing Benbot conversation."""
+
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, screen_uuid, conversation_id):
+        screen = get_object_or_404(Screen, uuid=screen_uuid)
+        if not screen.white_label.has_feature("benbot"):
+            return Response({"error": {"code": "assistant_disabled"}}, status=status.HTTP_403_FORBIDDEN)
+
+        payload = {
+            "text": request.data.get("text", ""),
+            "client_message_id": request.data.get("client_message_id"),
+        }
+        return _proxy("POST", f"/v1/conversations/{conversation_id}/messages", payload)

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -14,6 +14,9 @@ from django.shortcuts import get_object_or_404
 from rest_framework import permissions, status, views
 from rest_framework.response import Response
 
+from programs.models import Program
+from translations.models import BLANK_TRANSLATION_PLACEHOLDER
+
 from .models import EligibilitySnapshot, Screen
 
 # Where mfb-ai-service lives, and the shared service token (must match the
@@ -47,6 +50,32 @@ def _latest_snapshot(screen: Screen):
         return None
 
 
+def _apply_urls_by_name(screen: Screen, name_abbreviations: list[str]) -> dict[str, str]:
+    """Map name_abbreviated -> apply link for the given programs (one query).
+
+    apply_button_link is a translated field; `.text` resolves it the same way
+    eligibility_results resolves program.name.text. Blank/placeholder links are
+    skipped so the assistant never receives an empty or placeholder URL.
+    """
+    if not name_abbreviations:
+        return {}
+
+    programs = Program.objects.filter(
+        white_label=screen.white_label,
+        name_abbreviated__in=name_abbreviations,
+    ).select_related("apply_button_link")
+
+    urls: dict[str, str] = {}
+    for program in programs:
+        try:
+            link = (program.apply_button_link.text or "").strip()
+        except Exception:
+            link = ""
+        if link and link != BLANK_TRANSLATION_PLACEHOLDER:
+            urls[program.name_abbreviated] = link
+    return urls
+
+
 def _build_context(screen: Screen) -> dict:
     """Assemble the screen context passed to mfb-ai-service.
 
@@ -59,17 +88,20 @@ def _build_context(screen: Screen) -> dict:
     if snapshot is not None:
         rows = [p for p in snapshot.program_snapshots.all() if p.eligible]
         rows.sort(key=lambda p: p.estimated_value or 0, reverse=True)
+        apply_urls = _apply_urls_by_name(screen, [p.name_abbreviated for p in rows])
         for p in rows:
-            eligible_programs.append(
-                {
-                    "external_name": p.name_abbreviated,
-                    "name": p.name,
-                    # Whole dollars. Frequency is governed by value_type; see the
-                    # API contract's open question on units.
-                    "estimated_value": int(p.estimated_value) if p.estimated_value is not None else None,
-                    "estimated_application_time": p.estimated_application_time,
-                }
-            )
+            program = {
+                "external_name": p.name_abbreviated,
+                "name": p.name,
+                # Whole dollars. Frequency is governed by value_type; see the
+                # API contract's open question on units.
+                "estimated_value": int(p.estimated_value) if p.estimated_value is not None else None,
+                "estimated_application_time": p.estimated_application_time,
+            }
+            apply_url = apply_urls.get(p.name_abbreviated)
+            if apply_url:
+                program["apply_url"] = apply_url
+            eligible_programs.append(program)
 
     return {
         "household": {"size": screen.household_size},

--- a/screener/assistant.py
+++ b/screener/assistant.py
@@ -14,7 +14,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import permissions, status, views
 from rest_framework.response import Response
 
-from .models import Screen
+from .models import EligibilitySnapshot, Screen
 
 # Where mfb-ai-service lives, and the shared service token (must match the
 # service's SERVICE_AUTH_TOKEN). Both come from the environment.
@@ -30,15 +30,50 @@ def _ai_headers() -> dict:
     return headers
 
 
+def _latest_snapshot(screen: Screen):
+    """Most recent successful, non-batch eligibility snapshot for this screen.
+
+    The results page computes one of these on load, so by the time the user
+    opens the assistant there is normally a fresh snapshot to read — far cheaper
+    than recomputing eligibility (which calls PolicyEngine).
+    """
+    try:
+        return (
+            EligibilitySnapshot.objects.filter(screen=screen, is_batch=False, had_error=False)
+            .prefetch_related("program_snapshots")
+            .latest("submission_date")
+        )
+    except EligibilitySnapshot.DoesNotExist:
+        return None
+
+
 def _build_context(screen: Screen) -> dict:
     """Assemble the screen context passed to mfb-ai-service.
 
-    NOTE (v0): eligible_programs is left empty for now. Populating it from the
-    eligibility calculation is a follow-up; the API contract allows an empty list.
+    Pulls the eligible programs from the latest snapshot, highest-value first,
+    so the assistant can prioritize and explain them. Returns an empty list if
+    no snapshot exists yet (the contract allows this).
     """
+    eligible_programs = []
+    snapshot = _latest_snapshot(screen)
+    if snapshot is not None:
+        rows = [p for p in snapshot.program_snapshots.all() if p.eligible]
+        rows.sort(key=lambda p: p.estimated_value or 0, reverse=True)
+        for p in rows:
+            eligible_programs.append(
+                {
+                    "external_name": p.name_abbreviated,
+                    "name": p.name,
+                    # Whole dollars. Frequency is governed by value_type; see the
+                    # API contract's open question on units.
+                    "estimated_value": int(p.estimated_value) if p.estimated_value is not None else None,
+                    "estimated_application_time": p.estimated_application_time,
+                }
+            )
+
     return {
         "household": {"size": screen.household_size},
-        "eligible_programs": [],  # TODO: populate from eligibility results
+        "eligible_programs": eligible_programs,
     }
 
 

--- a/screener/feature_flags.py
+++ b/screener/feature_flags.py
@@ -45,6 +45,14 @@ WHITELABEL_FEATURE_FLAGS: dict[str, FeatureFlagConfig] = {
         description="Display member-level eligibility status tags on program cards in results.",
         scope="frontend",
     ),
+    "benbot": FeatureFlagConfig(
+        label="Benbot AI Assistant",
+        description=(
+            "Show the Benbot AI assistant on the results page and enable the "
+            "mfb-ai-service proxy endpoints for guided benefit applications."
+        ),
+        scope="both",  # frontend renders the widget; backend gates the proxy endpoints
+    ),
     "share_popup": FeatureFlagConfig(
         label="Share Popup",
         description="Show a popup in results that lets users share MyFriendBen with friends via email, SMS, or link.",

--- a/screener/urls.py
+++ b/screener/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from rest_framework import routers
 from . import views
+from . import assistant
 
 router = routers.DefaultRouter()
 router.register(r"screens", views.ScreenViewSet)
@@ -12,6 +13,17 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("eligibility/<id>", views.EligibilityTranslationView.as_view(), name="translated screen eligibility endpoint"),
     path("screens/<uuid:screen_uuid>/nps/", views.NPSScoreView.as_view(), name="nps-score"),
+    # Benbot assistant — proxies to mfb-ai-service; gated by the 'benbot' feature flag.
+    path(
+        "screens/<uuid:screen_uuid>/assistant/conversations/",
+        assistant.AssistantStartView.as_view(),
+        name="assistant-start",
+    ),
+    path(
+        "screens/<uuid:screen_uuid>/assistant/conversations/<str:conversation_id>/messages/",
+        assistant.AssistantMessageView.as_view(),
+        name="assistant-message",
+    ),
     path(
         "screener-options/<str:white_label>/has-benefits-programs/",
         views.HasBenefitsProgramsView.as_view(),


### PR DESCRIPTION
# Add Benbot feature flag and mfb-ai-service proxy

## Summary

Wires `benefits-api` to the new `mfb-ai-service` so the frontend can talk to Benbot through our backend. Adds the `benbot` feature flag (off by default) and two thin proxy endpoints that authenticate the request, assemble the screen context, enforce the flag, and forward to `mfb-ai-service`.

The browser never calls the AI service directly. The chain is **benefits-calculator → benefits-api → mfb-ai-service**; this PR adds the middle hop.

## What's included

- **Feature flag** (`screener/feature_flags.py`) — registers `benbot` with `scope="both"`, default **off**. Run `python manage.py sync_feature_flags` to populate it on all white labels, then toggle per white label in the admin.
- **Proxy endpoints** (`screener/assistant.py`) —
  - `POST /screens/<screen_uuid>/assistant/conversations/` — open/resume a conversation
  - `POST /screens/<screen_uuid>/assistant/conversations/<conversation_id>/messages/` — send a message
  - Both reject requests with `403 assistant_disabled` when the flag is off, so the flag is real access control, not just hidden UI.
  - Assembles the screen context (household + eligible programs, highest-value first, with `apply_url` when available) from the latest eligibility snapshot — no recompute on chat open.
- **URL routes** (`screener/urls.py`) — wires the two endpoints.
- **README** — "Benbot AI assistant" section documenting the flag, endpoints, env vars, and local dev.

## Configuration

New env / Heroku config vars (per environment):
- `AI_SERVICE_URL` — base URL of mfb-ai-service (e.g. staging app URL)
- `AI_SERVICE_TOKEN` — shared bearer token; must equal mfb-ai-service's `SERVICE_AUTH_TOKEN`

Leaving these unset is safe — the flag stays off and the endpoints return `403`.

## How to enable (after deploy)

1. `python manage.py sync_feature_flags`
2. Set `AI_SERVICE_URL` + `AI_SERVICE_TOKEN` on the app (matching the mfb-ai-service token).
3. Admin → Feature Flags → set `benbot = true` for the target white label.

## Known limitations / follow-ups

- **`apply_url` only** is enriched from the program's translated apply link; programs without a real link are sent without one (the assistant is instructed never to invent links).
- **`estimated_value` units** — the snapshot's whole-dollar value is passed as-is; confirm annual vs. `value_type` frequency and normalize if needed.
- **Auth is a static shared token** for the service-to-service hop — fine to start; revisit (mTLS / signed requests) later.
- **PII** — household/program context is sent to mfb-ai-service; retention/handling there is tracked in that repo (ADR-001).

## Testing

- Files compile; `benbot` flag registers (`scope=both`, default `False`).
- Proxy views follow the existing `APIView` patterns (mirrors `NPSScoreView`).
- Flag-off path returns `403 assistant_disabled`; flag-on path forwards to the AI service. Run `manage.py check` in-environment to confirm URLConf loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive guide added for Benbot AI assistant backend flow, including feature flag setup, environment variable configuration, and local development instructions to run the AI service.

* **New Features**
  * New AI assistant endpoints for initiating and managing conversations with feature flag-based access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->