### PR TITLE
Add KS Food Assistance (SNAP) (ks)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json
@@ -12,15 +12,12 @@
     "year": "2026",
     "legal_status_required": [
       "citizen",
-      "non_citizen",
-      "refugee",
       "gc_5plus",
-      "gc_5less",
-      "otherWithWorkPermission"
+      "gc_5less"
     ],
     "name": "Food Assistance (SNAP)",
     "description_short": "Monthly food benefits loaded onto an EBT card for low-income households",
-    "description": "Food Assistance is Kansas's name for the federal Supplemental Nutrition Assistance Program (SNAP). It provides monthly benefits to help low-income households buy food.\n\nEach month, benefits go onto a Kansas Benefits Card—an EBT card that works like a debit card. Use it at grocery stores, farmers markets, and select online stores. If you receive Food Assistance, your children may also qualify for free school meals.\n\nA limit applies to savings and bank accounts. Households with an elderly or disabled member get a higher limit. Adults without dependents may need to work or train to keep their benefits.\n\nApply online or get a paper application from your local DCF office. After applying, you will need to complete a phone or in-person interview. It may take several weeks to hear back. If your income is very low, you may get benefits sooner.",
+    "description": "Food Assistance is Kansas's name for the federal Supplemental Nutrition Assistance Program (SNAP). It helps low-income households buy food each month. The amount you get depends on your household's size and income.\n\nEach month, your benefits go on a Kansas Benefits Card, which works like a debit card. You can use it at grocery stores, farmers markets, and many online stores. If you get Food Assistance, your children may also qualify for free school meals.\n\nAdults without dependents may need to work or train to keep their benefits. Single parents may need to cooperate with child support services to get benefits. Some exceptions apply, such as for safety reasons.\n\nTo apply, start your application online, or get a paper application from a local DCF office. After you apply, you'll have a phone or in-person interview. It may take a few weeks to hear back. If your income is very low, you may hear back sooner.",
     "learn_more_link": "https://www.dcf.ks.gov/services/ees/Pages/Food/FoodAssistanceFAQs.aspx",
     "apply_button_link": "https://cssp.kees.ks.gov/apspssp/sspNonMed.portal/login/doView",
     "apply_button_description": "",
@@ -55,6 +52,12 @@
       "link_text": ""
     },
     {
+      "external_name": "ks_snap_proof_address",
+      "text": "Proof of Kansas address (e.g. lease, utility bill, or mail with your name and address)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
       "external_name": "ks_snap_proof_income",
       "text": "Proof of income for all household members (e.g. pay stubs, award letters)",
       "link_url": "",
@@ -80,25 +83,17 @@
       "email": "info@mirrorinc.org",
       "phone_number": "+13162836743",
       "description": "Helps Kansas residents in the Wichita and KC areas apply for Food Assistance and understand their eligibility.",
-      "assistance_link": "https://www.mirrorinc.org/contact-us",
+      "assistance_link": "https://www.dcf.ks.gov/services/ees/pages/Food-Assistance-Application-Assistance-(SNAP-Outreach).aspx",
       "counties": ["Johnson", "Shawnee", "Harvey", "Sedgwick", "Douglas", "Barber", "Harper"]
     },
     {
       "external_name": "ks_harvesters",
       "name": "Harvesters — The Community Food Network",
       "email": "inforequest@harvesters.org",
-      "phone_number": "+17858617700",
+      "phone_number": "+18776539522",
       "description": "Helps Kansas City-area Kansas residents apply for Food Assistance by phone — no need to visit a government office.",
       "assistance_link": "https://www.harvesters.org/get-food-assistance/snap-assistance",
       "counties": ["Washington", "Marshall", "Nemaha", "Clay", "Riley", "Pottawatomie", "Jackson", "Jefferson", "Shawnee", "Wabaunsee", "Douglas", "Johnson", "Leavenworth", "Wyandotte", "Osage", "Franklin", "Miami"]
-    },
-    {
-      "external_name": "ks_kansas_food_bank",
-      "name": "Kansas Food Bank",
-      "email": "info@kansasfoodbank.org",
-      "phone_number": "+18002893356",
-      "description": "Statewide SNAP outreach organization. Assists Kansas residents with SNAP applications by phone and online.",
-      "assistance_link": "https://kansasfoodbank.org/snapinkansas/"
     }
   ]
 }

--- a/programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json
@@ -1,0 +1,104 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "program_category": {
+    "external_name": "ks_food",
+    "name": "Food and Nutrition",
+    "icon": "food"
+  },
+  "program": {
+    "name_abbreviated": "ks_snap",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "non_citizen",
+      "refugee",
+      "gc_5plus",
+      "gc_5less",
+      "otherWithWorkPermission"
+    ],
+    "name": "Food Assistance (SNAP)",
+    "description_short": "Monthly food benefits loaded onto an EBT card for low-income households",
+    "description": "Food Assistance is Kansas's name for the federal Supplemental Nutrition Assistance Program (SNAP). It provides monthly benefits to help low-income households buy food.\n\nEach month, benefits go onto a Kansas Benefits Card—an EBT card that works like a debit card. Use it at grocery stores, farmers markets, and select online stores. If you receive Food Assistance, your children may also qualify for free school meals.\n\nA limit applies to savings and bank accounts. Households with an elderly or disabled member get a higher limit. Adults without dependents may need to work or train to keep their benefits.\n\nApply online or get a paper application from your local DCF office. After applying, you will need to complete a phone or in-person interview. It may take several weeks to hear back. If your income is very low, you may get benefits sooner.",
+    "learn_more_link": "https://www.dcf.ks.gov/services/ees/Pages/Food/FoodAssistanceFAQs.aspx",
+    "apply_button_link": "https://cssp.kees.ks.gov/apspssp/sspNonMed.portal/login/doView",
+    "apply_button_description": "",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "30 days",
+    "estimated_value": "",
+    "value_format": null,
+    "value_type": "benefit",
+    "website_description": "Monthly food benefits loaded onto an EBT card for low-income households",
+    "base_program": "snap",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": true
+  },
+  "documents": [
+    {
+      "external_name": "ks_snap_photo_id",
+      "text": "Government-issued ID for all household members age 18+ (e.g. driver's license, state ID)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_snap_citizenship_status",
+      "text": "Proof of citizenship or immigration status (e.g. birth certificate, passport, immigration documents)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_snap_ssn",
+      "text": "Social Security Number for all household members applying",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_snap_proof_income",
+      "text": "Proof of income for all household members (e.g. pay stubs, award letters)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_snap_proof_expenses",
+      "text": "Proof of monthly expenses (e.g. rent, utilities, child support, medical costs for elderly or disabled members)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_snap_proof_assets",
+      "text": "Bank statements and proof of any other assets (e.g. stocks, bonds, annuities)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "ks_mirror_inc",
+      "name": "Mirror Inc.",
+      "email": "info@mirrorinc.org",
+      "phone_number": "+13162836743",
+      "description": "Helps Kansas residents in the Wichita and KC areas apply for Food Assistance and understand their eligibility.",
+      "assistance_link": "https://www.mirrorinc.org/contact-us",
+      "counties": ["Johnson", "Shawnee", "Harvey", "Sedgwick", "Douglas", "Barber", "Harper"]
+    },
+    {
+      "external_name": "ks_harvesters",
+      "name": "Harvesters — The Community Food Network",
+      "email": "inforequest@harvesters.org",
+      "phone_number": "+17858617700",
+      "description": "Helps Kansas City-area Kansas residents apply for Food Assistance by phone — no need to visit a government office.",
+      "assistance_link": "https://www.harvesters.org/get-food-assistance/snap-assistance",
+      "counties": ["Washington", "Marshall", "Nemaha", "Clay", "Riley", "Pottawatomie", "Jackson", "Jefferson", "Shawnee", "Wabaunsee", "Douglas", "Johnson", "Leavenworth", "Wyandotte", "Osage", "Franklin", "Miami"]
+    },
+    {
+      "external_name": "ks_kansas_food_bank",
+      "name": "Kansas Food Bank",
+      "email": "info@kansasfoodbank.org",
+      "phone_number": "+18002893356",
+      "description": "Statewide SNAP outreach organization. Assists Kansas residents with SNAP applications by phone and online.",
+      "assistance_link": "https://kansasfoodbank.org/snapinkansas/"
+    }
+  ]
+}

--- a/programs/programs/ks/pe/__init__.py
+++ b/programs/programs/ks/pe/__init__.py
@@ -1,4 +1,3 @@
-import programs.programs.ks.pe.member as member
 import programs.programs.ks.pe.spm as spm
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
 

--- a/programs/programs/ks/pe/__init__.py
+++ b/programs/programs/ks/pe/__init__.py
@@ -1,0 +1,17 @@
+import programs.programs.ks.pe.member as member
+import programs.programs.ks.pe.spm as spm
+from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
+
+ks_member_calculators = {}
+
+ks_tax_unit_calculators = {}
+
+ks_spm_calculators = {
+    "ks_snap": spm.KsSnap,
+}
+
+ks_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {
+    **ks_member_calculators,
+    **ks_tax_unit_calculators,
+    **ks_spm_calculators,
+}

--- a/programs/programs/ks/pe/member.py
+++ b/programs/programs/ks/pe/member.py
@@ -1,5 +1,0 @@
-# Kansas member-level PolicyEngine calculators.
-#
-# No member-level KS PE programs yet. Sibling KS program PRs (part of the KS
-# Launch) may add classes here following the Texas pattern
-# (see programs/programs/tx/pe/member.py).

--- a/programs/programs/ks/pe/member.py
+++ b/programs/programs/ks/pe/member.py
@@ -1,0 +1,5 @@
+# Kansas member-level PolicyEngine calculators.
+#
+# No member-level KS PE programs yet. Sibling KS program PRs (part of the KS
+# Launch) may add classes here following the Texas pattern
+# (see programs/programs/tx/pe/member.py).

--- a/programs/programs/ks/pe/spm.py
+++ b/programs/programs/ks/pe/spm.py
@@ -1,0 +1,18 @@
+import programs.programs.policyengine.calculators.dependencies as dependency
+from programs.programs.federal.pe.spm import Snap
+
+
+class KsSnap(Snap):
+    """
+    Kansas Food Assistance (SNAP) calculator.
+
+    Uses PolicyEngine's federal SNAP calculator. SNAP is a federal program with
+    no Kansas-specific calculator variance; state elections (BBCE, vehicle
+    exemptions, utility regions) are keyed off the state code in PolicyEngine's
+    SNAP parameters, so passing the KS state code is all that is required.
+    """
+
+    pe_inputs = [
+        *Snap.pe_inputs,
+        dependency.household.KsStateCodeDependency,
+    ]

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -148,7 +148,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 - [ ] Scenario 10 (Half-Time Student with 20+ hrs/week Work Exemption): **eligible**
 - [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible**
 - [ ] Scenario 12 (SUA value — Single Adult): **eligible**, **$2,461/yr ($205/mo)**
-- [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$2,533/yr ($211/mo)**
+- [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$3,596/yr ($300/mo)**
 - [ ] Scenario 14 (SUA value — Family of Three): **eligible**, **$4,738/yr ($395/mo)**
 
 
@@ -372,7 +372,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ### Scenario 13: Standard Utility Allowance — Elderly Individual
 
-**What we're checking**: An elderly household (uncapped shelter deduction) where the SUA is binding. Committed expected benefit: **$2,533/yr ($211/mo)**.
+**What we're checking**: An elderly household (uncapped shelter deduction) where the SUA is binding. Committed expected benefit: **$3,596/yr ($300/mo)**. The uncapped elderly shelter deduction (rent + HCSUA) drives net income to $0, so the household qualifies for the full max allotment for a household of 1 (~$300/mo).
 
 **Expected**: Eligible
 
@@ -385,7 +385,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 - **Assets**: Below the $4,500 elderly/disabled limit
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
-**Why this matters**: SUA validation on the elderly/disabled path; SUA-sensitive (−$248/yr if HCSUA $469→$400). PolicyEngine-verified on `policyengine-us` 1.739.4.
+**Why this matters**: SUA validation on the elderly/disabled path; the HCSUA feeds the uncapped elderly shelter deduction that zeroes net income. Verified against the live PolicyEngine API (the path benefits-api uses), version 1.715.2.
 
 ---
 
@@ -435,7 +435,7 @@ Scenarios 1–14. Expected `eligible`:
 - `true`: 1, 2, 3, 7, 8, 10, 12, 13, 14
 - `false`: 4, 5, 6, 9, 11
 
-Value scenarios 12–14 carry committed amounts ($2,461 / $2,533 / $4,738 per year), computed on `policyengine-us` 1.739.4.
+Value scenarios 12–14 carry committed amounts ($2,461 / $3,596 / $4,738 per year), verified against the live PolicyEngine API (the path benefits-api uses), version 1.715.2.
 
 
 ## Generated Program Configuration

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -136,17 +136,17 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ## Acceptance Criteria
 
-- [ ] Scenario 1 (Single Adult Worker — Clearly Eligible): **eligible**
-- [ ] Scenario 2 (Family of Four — Just Under 130% Gross & 100% Net): **eligible**
-- [ ] Scenario 3 (Single Parent HH2 — Gross $1 Below 130% FPL): **eligible**
-- [ ] Scenario 4 (Single Adult — Gross Above 130% FPL): **ineligible**
-- [ ] Scenario 5 (Net Income Test Failure — Gross Passes, Net Fails): **ineligible**
-- [ ] Scenario 6 (Non-Elderly Household — Assets Above $3,000): **ineligible**
-- [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**
-- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**
-- [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible**
-- [ ] Scenario 10 (Half-Time Student with 20+ hrs/week Work Exemption): **eligible**
-- [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible**
+- [ ] Scenario 1 (Single Adult Worker — Clearly Eligible): **eligible**, **$897/yr ($75/mo)**
+- [ ] Scenario 2 (Family of Four — Just Under 130% Gross & 100% Net): **eligible**, **$6,508/yr ($542/mo)**
+- [ ] Scenario 3 (Single Parent HH2 — Gross $1 Below 130% FPL): **eligible**, **$3,589/yr ($299/mo)**
+- [ ] Scenario 4 (Single Adult — Gross Above 130% FPL): **ineligible** ($0)
+- [ ] Scenario 5 (Net Income Test Failure — Gross Passes, Net Fails): **ineligible** ($0)
+- [ ] Scenario 6 (Non-Elderly Household — Assets Above $3,000): **ineligible** ($0)
+- [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**, **$310/yr ($26/mo)**
+- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible** (gated by MFB SSI categorical logic, not raw PE)
+- [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible** ($0)
+- [ ] Scenario 10 (Half-Time Student with 20+ hrs/week Work Exemption): **eligible**, **$897/yr ($75/mo)**
+- [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible** (gated by MFB `already_has` results-layer filter, not raw PE)
 - [ ] Scenario 12 (SUA value — Single Adult): **eligible**, **$2,461/yr ($205/mo)**
 - [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$3,596/yr ($300/mo)**
 - [ ] Scenario 14 (SUA value — Family of Three): **eligible**, **$4,738/yr ($395/mo)**
@@ -154,13 +154,13 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ## Test Scenarios
 
-> All scenarios verified through PolicyEngine (`policyengine-us` 1.739.4, period 2026, `state_code=KS`). Scenarios 1–10 confirm the eligible/ineligible outcome; 12–14 also carry committed SUA-isolating dollar amounts (each changes −$248/yr if the KS HCSUA drifts $469→$400). Two modeling notes: **Scenario 11** (already receiving SNAP) is not a calculator check — the generic `already_has` results-layer workflow filters the program out when the household reports it (read via `screen.has_benefit("ks_snap")`), so it's verified by design. **Scenarios 9–10** (students) are handled by the federal SNAP calculator's `is_snap_ineligible_student` **dependency** (`SnapIneligibleStudentDependency`), which computes student ineligibility from screener fields and passes it to PolicyEngine as an input (not a post-hoc override) — PolicyEngine then applies it. All inputs use screener-measurable fields.
+> All value-bearing scenarios verified against the **live PolicyEngine API** (the path benefits-api uses; version 1.715.2), period 2026, `state_code=KS`. Every scenario carries an expected dollar outcome: the eligible cases (1–3, 7, 10, 12–14) assert the computed annual benefit, and the ineligible cases (4–6, 9) assert **$0**. Two scenarios are gated by MFB *outside* PE and verified by design rather than via a raw PE value: **Scenario 8** (all-SSI categorical eligibility) is decided by MFB's SSI categorical logic, and **Scenario 11** (already receiving SNAP) is filtered out by the generic `already_has` results-layer workflow when the household reports it (read via `screen.has_benefit("ks_snap")`). **Scenarios 9–10** (students) are handled by the federal SNAP calculator's `is_snap_ineligible_student` **dependency** (`SnapIneligibleStudentDependency`), which computes student ineligibility from screener fields and passes it to PolicyEngine as an input (not a post-hoc override) — PolicyEngine then applies it. All inputs use screener-measurable fields.
 
 ### Scenario 1: Single Adult Worker — Clearly Eligible for Food Assistance
 
 **What we're checking**: Typical single adult with low wage income who clearly meets both the federal gross (130% FPL) and net (100% FPL) income tests (criteria 1–2).
 
-**Expected**: Eligible
+**Expected**: Eligible — $897/yr ($75/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
@@ -178,7 +178,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: A household that barely meets both the gross (130% FPL) and net (100% FPL) income tests, validating edge-case eligibility at the income ceiling with shelter and dependent-care deductions (criteria 1, 2, 4, 16).
 
-**Expected**: Eligible
+**Expected**: Eligible — $6,508/yr ($542/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66603`, Select county `Shawnee`
@@ -199,7 +199,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: A 2-person household with gross monthly income $1 below the 130% FPL threshold ($2,292/mo for HH2) is correctly found eligible (criterion 1, boundary).
 
-**Expected**: Eligible
+**Expected**: Eligible — $3,589/yr ($299/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
@@ -268,7 +268,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: The federal elderly/disabled treatment — a 60+ household is exempt from the gross income test and qualifies on net income alone, using the higher $4,500 asset limit and an uncapped shelter deduction (criterion 6).
 
-**Expected**: Eligible
+**Expected**: Eligible — $310/yr ($26/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
@@ -322,7 +322,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: A half-time college student who works 20+ hours/week meets a student exemption and is eligible (criterion 7, exemption regression guard).
 
-**Expected**: Eligible
+**Expected**: Eligible — $897/yr ($75/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66045`, Select county `Douglas`

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -1,0 +1,463 @@
+# Implement Food Assistance - Supplemental Nutrition Assistance Program (SNAP) (KS) Program
+
+## Program Details
+
+- **Program**: Food Assistance - Supplemental Nutrition Assistance Program (SNAP)
+- **State**: KS
+- **White Label**: ks
+- **Calculator Type**: PE Federal (state values)
+- **PE Variable**: `snap` (implemented as `KsSnap(Snap)` — PolicyEngine federal SNAP calculator + KS state code)
+- **Research Date**: 2026-06-21
+- **Spec basis**: Adapted from `wa/snap/spec.md` (federal SNAP precedent). **Key state difference: Kansas has NOT adopted BBCE**, so WA's 200% FPL gross / waived-net / no-asset-test rules are replaced with the standard federal tests (130% gross, 100% net, $3,000/$4,500 asset limit). The only KS-specific *value* is the Standard Utility Allowance (SUA); value scenarios isolate it.
+
+## Eligibility Criteria
+
+> Listed core/priority criteria first (all screener-evaluable), then federal rules that the screener cannot measure (⚠️ data gaps), each with a handling suggestion. Pure administrative / application-stage requirements are **excluded** — see "Administrative requirements (excluded)" below.
+
+### Core / priority criteria (screener-evaluable)
+
+1. **Gross monthly income at or below 130% of the Federal Poverty Level** *(priority)*
+   - Screener fields: `household_size`, `calc_gross_income`
+   - Note: Kansas has **not** adopted Broad-Based Categorical Eligibility (the legislature prohibited it), so the standard federal 130% FPL gross test applies — not the 200% BBCE limit WA uses. FY2026 monthly limits (KEESM Appendix F-2): HH1 $1,696; HH2 $2,292; HH3 $2,888; HH4 $3,483; HH5 $4,079 (+$596 per additional person).
+   - Source: 7 CFR 273.9(a)(1); KEESM Appendix F-2; FNS BBCE State Chart (KS not listed).
+
+2. **Net monthly income at or below 100% of the Federal Poverty Level — test APPLIES** *(priority)*
+   - Screener fields: `household_size`, `calc_net_income`
+   - Note: Because KS has no BBCE, the 100% FPL net income test applies to all households (in WA it is waived). FY2026 monthly net limits: HH1 $1,305; HH2 $1,763; HH3 $2,221; HH4 $2,680; HH5 $3,138 (+$459 per additional person).
+   - Source: 7 CFR 273.9(a)(2); KEESM Appendix F-2.
+
+3. **Asset/resource test APPLIES: $3,000 standard; $4,500 for households with an elderly (60+) or disabled member** *(priority — KS-distinctive)*
+   - Screener fields: `household_assets`
+   - Note: KS has no BBCE asset-test waiver, so the standard federal resource limits apply (verified current for FY2026). PE's `snap_assets` counts liquid resources (bank accounts, stocks, bonds) and excludes vehicles — an acceptable approximation.
+   - Source: 7 CFR 273.8; FNS FY2026 COLA; KEESM Appendix F-2.
+
+4. **Household size determination** *(priority — foundational)*
+   - Screener fields: `household_size`
+   - Note: People who live together and customarily purchase and prepare meals together are one SNAP household. **A pregnant woman counts as one member** (unborn children are not counted); the `pregnant` field matters only for the work-requirement exemption, not household size.
+   - Source: 7 CFR 273.1(a)-(b); KEESM.
+
+5. **TANF/SSI categorical eligibility — households where all members receive TANF or SSI are categorically eligible** *(priority)*
+   - Screener fields: `has_tanf`, `has_ssi`
+   - Note: Categorical eligibility bypasses the financial (income and asset) tests; non-financial rules (student, citizenship, residency) still apply. *All* members must receive TANF or SSI. (KS's SSPP does not independently confer categorical eligibility — SSPP recipients qualify via their SSI status.)
+   - Source: 7 CFR 273.2(j); 7 U.S.C. § 2014(a); KEESM Section 2510.
+
+6. **Elderly or disabled household member — federal alternative treatment**
+   - Screener fields: `birth_year`, `birth_month`, `disabled`, `calc_net_income`, `household_assets`
+   - Note: A household with a member aged 60+ or disabled is **exempt from the gross income test** and qualifies on the net income test (≤100% FPL) alone, uses the higher **$4,500** asset limit, and receives an **uncapped** excess-shelter deduction. (There is no BBCE Option A/B; this is the standard federal treatment.)
+   - Source: 7 CFR 273.9(a); 7 CFR 273.8; 7 CFR 273.9(d)(6); KEESM Appendix F-2.
+
+7. **Student eligibility — half-time+ college students aged 18–49 must meet an exemption**
+   - Screener fields: `student`, `student_full_time`, `student_works_20_plus_hrs`, `student_has_work_study`, `student_job_training_program`, `birth_year`, `birth_month`
+   - Note: Students enrolled at least half-time in higher education are ineligible unless they meet an exemption (working 20+ hrs/week, work-study, job-training program, caring for a dependent child under 6 — or under 12 if a single parent enrolled full-time — or age 17 or younger). MFB supplies `is_snap_ineligible_student` via its own helper, which implements these exemptions correctly.
+   - Source: 7 CFR 273.5; 7 U.S.C. § 2015(e); KEESM Student Eligibility Criteria.
+
+8. **Must not already be receiving SNAP/Food Assistance benefits**
+   - Screener fields: current benefits (read via `screen.has_benefit("ks_snap")` / `has_base_benefit("snap")`). Not a calculator check — the generic `already_has` results-layer workflow filters the program out of results when the household reports it.
+   - Source: General SNAP policy — households cannot receive duplicate benefits.
+
+9. **State residency — must reside in Kansas**
+   - Screener fields: `zipcode`, `county`
+   - Source: 7 CFR 273.3; KEESM.
+
+### Federal & KS-specific rules the screener cannot fully measure (⚠️ data gaps)
+
+10. **At least one household member must be a U.S. citizen or qualified non-citizen** ⚠️ *not screened — by design*
+    - Note: This is a federal eligibility rule, but **MFB intentionally does not screen or gate on citizenship.** The calculation always runs as `CITIZEN`, so SNAP is computed and shown to everyone; status only affects which program cards are *displayed*, via the results-page `legal_status_required` filter (post-OBBBA: `citizen`, `gc_5plus`, `gc_5less`). KS has no state-funded food program for immigrants (unlike WA's FAP).
+    - **Suggestion — no screener improvement:** Because citizenship isn't a screener input at all (it's handled only as a results-page display filter), there's no screener field to add. The single action is keeping that filter accurate — the dev's current cleanup dropping the now-ineligible statuses (`refugee`, `non_citizen`, `otherWithWorkPermission`). The Cuban/Haitian/COFA edge stays an accepted inclusivity assumption (small group; PE's COFA gap #8296 mishandles it anyway).
+    - Source: 7 U.S.C. § 2015(f); 7 CFR 273.4. Impact: Medium
+
+11. **General work requirement — "work registrants" aged 18–59 must register for work, accept suitable employment, and not voluntarily quit** ⚠️ *data gap (PE applies the hours test)*
+    - Note: Kansas's HOPE Act sets the general SNAP work requirement at **30 hours/week** (the federal general-requirement threshold) and refers anyone working under it to **mandatory Employment & Training**; KS extended this stricter treatment to ages 50–59. PE applies the hours-based general work test via `weekly_hours_worked_before_lsr`, so a working applicant passes and an unexempted non-worker fails. Not captured: E&T-participation compliance, and the reason for a job separation (voluntary quit / hour reduction below 30/week without good cause).
+    - **Suggestion (inclusivity assumption):** Don't add E&T-compliance or job-separation-reason questions (administrative, rarely dispositive at screening). PE's point-in-time hours test is sufficient; assume compliant / good cause. The config description's work line covers expectations.
+    - Source: 7 CFR 273.7; K.S.A. 39-709 (HOPE Act); KEESM. Impact: Medium
+
+12. **ABAWD time limit — able-bodied adults without dependents aged 18–64 limited to 3 months of benefits in 36 unless working ≥80 hrs/month** ⚠️ *data gap (PE applies the hours test)*
+    - Note: KS applies full ABAWD rules statewide with **no waivers** (FY2025–2026); age range **18–64** (federal OBBBA expansion; KS independently added 50–59 in 2023). PE applies the work test monthly via `weekly_hours_worked_before_lsr` but does not model the **3-month-in-36 time-limit clock** (months of prior SNAP receipt).
+    - **Suggestion (inclusivity assumption + program description):** Don't ask prior-SNAP-receipt history (invasive, low-value). Assume not time-limited. The program description already surfaces this ("Adults without dependents may need to work or train to keep their benefits") — keep that line.
+    - Source: 7 U.S.C. § 2015(o); 7 CFR 273.24; FNS ABAWD Waivers FY2025–2029 (KS not waived). Impact: Medium
+
+13. **Child support cooperation — Kansas requires custodial parents to cooperate with child support enforcement as a condition of eligibility** ⚠️ *data gap — KS-specific state option*
+    - Note: **KS-specific.** Federal SNAP makes child-support cooperation a *state option*; Kansas adopted it (HOPE Act, 2015) and has repeatedly declined to repeal it. A custodial parent living with a child whose other parent is absent must cooperate in establishing paternity and pursuing support; without cooperation — and absent a good-cause exception such as domestic violence — that adult is ineligible. The child(ren) may remain eligible, and the non-cooperating adult's income/resources are counted pro-rata. The screener does not collect cooperation status, and PolicyEngine does not model it.
+    - **Suggestion (inclusivity assumption + surface in program description):** Don't add a screener question — it's invasive, hinges on an absent parent and good-cause/abuse exceptions, and conflicts with MFB's simple design; assume the applicant cooperates or has good cause (inclusive default for the calculation). But because this hits a meaningful population (single parents) and is a real KS condition, **add a brief, neutral line to the program description** — e.g. "Single parents may need to cooperate with child support services to get benefits. Some exceptions apply, such as for safety reasons." Keep it short and non-alarming.
+    - Source: 7 CFR 273.11(o)-(p) (state option); K.S.A. 39-709; KEESM. Impact: Medium
+
+14. **Drug felony disqualification — Kansas modified ban** ⚠️ *data gap*
+    - Note: KS has a **modified** ban (Kan. Stat. Ann. § 39-709(f)(4)): convictions on/after July 1, 2015 disqualify; a first conviction allows reinstatement via treatment/testing, a second+ is permanent. PE does not model this; the screener does not collect criminal history.
+    - **Suggestion (inclusivity assumption):** Do not add a criminal-history question (invasive, sensitive, small affected population). Assume not disqualified. Not recommended for the program description either — too niche and potentially alarming.
+    - Source: Kan. Stat. Ann. § 39-709(f)(4); 21 U.S.C. § 862a (federal drug-felony ban states may modify). Impact: Low
+
+15. **Must not be a fleeing felon or in violation of parole/probation** ⚠️ *data gap*
+    - Note: Federal disqualification; not screenable.
+    - **Suggestion (inclusivity assumption):** Do not collect criminal-justice status (invasive, small population). Assume not disqualified.
+    - Source: 7 CFR 273.11(n). Impact: Low
+
+16. **Must not reside in an ineligible institutional setting** ⚠️ *data gap*
+    - Note: Homeless individuals ARE eligible; this excludes those in institutions (prisons, long-term hospitals, nursing homes). The screener's `housing_situation` captures homelessness but not institutional residence.
+    - **Suggestion (inclusivity assumption):** No dedicated field needed — the vast majority of screener users are community-residing. Assume not institutionalized. (`housing_situation` already correctly keeps homeless users eligible.)
+    - Source: 7 CFR 273.1(b). Impact: Low
+
+17. **Precise net-income deduction calculations** (value-precision note, not an eligibility gate)
+    - Note: The screener approximates net income; PolicyEngine computes the exact deductions. KS FY2026 values (KEESM Appendix F-2): standard deduction $209 (HH 1–3) / $223 (4) / $261 (5) / $299 (6+); **SUA/HCSUA $469**, LUA $345, Telephone $44; excess shelter cap **$744** (uncapped for elderly/disabled); homeless shelter deduction $198.99; standard medical deduction $175 (elderly/disabled only).
+    - **Suggestion:** No screener change needed — `estimated_value` uses PolicyEngine's exact calculation. The screener's approximate net income is used only for the eligibility gate, which is acceptable.
+    - Source: 7 CFR 273.9(d); KEESM Appendix F-2.
+
+### Administrative requirements (excluded from eligibility criteria)
+
+These are application/process requirements, not eligibility rules the screener should evaluate, so they are intentionally **not** listed above: **SSN provision** (7 CFR 273.6 — application-stage), **identity verification & interview** (7 CFR 273.2(e) — process), and **Intentional Program Violation (IPV) disqualification** (7 CFR 273.16 — verified administratively via state databases). None are screenable and none belong in the eligibility logic.
+
+
+## Benefit Value
+
+- Calculated as **maximum allotment for household size MINUS 30% of net monthly income** (net income = gross minus the standard deduction, 20% earned-income deduction, excess shelter + Standard Utility Allowance, dependent care, and elderly/disabled medical deductions).
+- Maximum monthly allotments (48 contiguous states + DC, eff. October 2025; KEESM Appendix F-2, verified):
+
+| Household Size | Max Monthly Benefit | Annual Value |
+|---|---|---|
+| 1 | $298 | $3,576 |
+| 2 | $546 | $6,552 |
+| 3 | $785 | $9,420 |
+| 4 | $994 | $11,928 |
+| 5 | $1,183 | $14,196 |
+| Each add'l | +$218 | +$2,616 |
+
+- **KS state-specific value:** the Standard Utility Allowance feeds the excess-shelter deduction. KS FY2026 HCSUA = **$469/mo** (LUA $345, phone $44), verified against KEESM Appendix F-2 and confirmed in PolicyEngine effective 2025-10-01.
+- `estimated_value` uses PolicyEngine's exact calculation (the screener's net-income approximation is not used for the dollar amount).
+- Source: [KEESM Appendix F-2](https://content.dcf.ks.gov/EES/KEESM/Appendix/F-2%20FA%20Program%20Standards.pdf); [FNS FY2026 COLA](https://www.fns.usda.gov/snap/allotment/cola/fy26); [CBPP SNAP guide](https://www.cbpp.org/research/food-assistance/a-quick-guide-to-snap-eligibility-and-benefits).
+
+
+## Implementation Coverage
+
+- ✅ Evaluable criteria: 9 (criteria 1–9)
+- ⚠️ Data gaps: 7 (criteria 10–16) — work requirements (11–12) are partially applied by PolicyEngine via the hours test; all are otherwise addressed via inclusivity assumptions or program-description surfacing; none is viable/appropriate as a new screener field
+- ℹ️ Value-precision note: 1 (criterion 17) — handled by PolicyEngine
+
+The screener evaluates the criteria that drive nearly all SNAP outcomes: gross income (130% FPL), net income (100% FPL), the $3,000/$4,500 asset test, household size, TANF/SSI categorical eligibility, the elderly/disabled path, student rules, duplicate-benefit exclusion, and residency. Because KS has no BBCE, the net income test and asset test are *live* screening criteria here (they are not for WA). The data gaps are federal rules — plus one **KS-specific** rule, the child-support-cooperation requirement (criterion 13) — that are invasive or low-value to screen for; each is handled by the `CITIZEN` inclusivity default, the point-in-time work-hours test PolicyEngine already applies, an "assume not disqualified / cooperating" inclusivity assumption, or existing program-description language — consistent with MFB's inclusive design.
+
+
+## Acceptance Criteria
+
+- [ ] Scenario 1 (Single Adult Worker — Clearly Eligible): **eligible**
+- [ ] Scenario 2 (Family of Four — Just Under 130% Gross & 100% Net): **eligible**
+- [ ] Scenario 3 (Single Parent HH2 — Gross $1 Below 130% FPL): **eligible**
+- [ ] Scenario 4 (Single Adult — Gross Above 130% FPL): **ineligible**
+- [ ] Scenario 5 (Net Income Test Failure — Gross Passes, Net Fails): **ineligible**
+- [ ] Scenario 6 (Non-Elderly Household — Assets Above $3,000): **ineligible**
+- [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**
+- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**
+- [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible**
+- [ ] Scenario 10 (Half-Time Student with 20+ hrs/week Work Exemption): **eligible**
+- [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible**
+- [ ] Scenario 12 (SUA value — Single Adult): **eligible**, **$2,461/yr ($205/mo)**
+- [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$2,533/yr ($211/mo)**
+- [ ] Scenario 14 (SUA value — Family of Three): **eligible**, **$4,738/yr ($395/mo)**
+
+
+## Test Scenarios
+
+> All scenarios verified through PolicyEngine (`policyengine-us` 1.739.4, period 2026, `state_code=KS`). Scenarios 1–10 confirm the eligible/ineligible outcome; 12–14 also carry committed SUA-isolating dollar amounts (each changes −$248/yr if the KS HCSUA drifts $469→$400). Two modeling notes: **Scenario 11** (already receiving SNAP) is not a calculator check — the generic `already_has` results-layer workflow filters the program out when the household reports it (read via `screen.has_benefit("ks_snap")`), so it's verified by design. **Scenarios 9–10** (students) are handled by the federal SNAP calculator's `is_snap_ineligible_student` **dependency** (`SnapIneligibleStudentDependency`), which computes student ineligibility from screener fields and passes it to PolicyEngine as an input (not a post-hoc override) — PolicyEngine then applies it. All inputs use screener-measurable fields.
+
+### Scenario 1: Single Adult Worker — Clearly Eligible for Food Assistance
+
+**What we're checking**: Typical single adult with low wage income who clearly meets both the federal gross (130% FPL) and net (100% FPL) income tests (criteria 1–2).
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1992` (age 34), Relationship: Head of Household, Sex: Male, Not a student enrolled in higher education, Not pregnant, No disability, U.S. citizen
+- **Income**: Employment income: `$1,200` per month, No other income sources
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+- **Assets**: No significant countable assets
+
+**Why this matters**: The most common Food Assistance applicant profile — a single working adult with modest earnings. Validates that the screener correctly identifies a clearly eligible household passing both the 130% FPL gross test and the 100% FPL net test, with no complicating factors.
+
+---
+
+### Scenario 2: Family of Four — Income Just Under 130% FPL Gross and 100% FPL Net
+
+**What we're checking**: A household that barely meets both the gross (130% FPL) and net (100% FPL) income tests, validating edge-case eligibility at the income ceiling with shelter and dependent-care deductions (criteria 1, 2, 4, 16).
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66603`, Select county `Shawnee`
+- **Household**: Number of people: `4`
+- **Person 1**: Birth month/year: `January 1987` (age 39), Relationship: Head of Household, Sex: Male, Not a student, Not pregnant, No disability, U.S. citizen, Employment income: `$3,400` per month
+- **Person 2**: Birth month/year: `January 1989` (age 37), Relationship: Spouse, Sex: Female, Not a student, Not pregnant, No disability, U.S. citizen, No income
+- **Person 3**: Birth month/year: `January 2016` (age 10), Relationship: Child, Sex: Female, No income
+- **Person 4**: Birth month/year: `January 2020` (age 6), Relationship: Child, Sex: Male, No income
+- **Income**: Employment income (Person 1): `$3,400` per month (below the HH4 gross limit of $3,483)
+- **Expenses**: Monthly rent: `$1,300`, Monthly dependent care: `$300`, Heating/cooling utilities
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Tests the boundary where a family's gross income is just under the 130% FPL limit and net income, after the standard deduction, earned-income deduction, and excess-shelter/SUA deductions, falls just under 100% FPL.
+
+---
+
+### Scenario 3: Single Parent (Household of 2) — Gross Income $1 Below 130% FPL
+
+**What we're checking**: A 2-person household with gross monthly income $1 below the 130% FPL threshold ($2,292/mo for HH2) is correctly found eligible (criterion 1, boundary).
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `January 1992` (age 34), Relationship: Head of Household, Sex: Female, Not a student, Not pregnant, No disability, U.S. citizen, Employment income: `$2,291` per month ($1 below the HH2 limit of $2,292)
+- **Person 2**: Birth month/year: `January 2021` (age 5), Relationship: Child, Sex: Male, No income
+- **Expenses**: Monthly rent: `$1,000`, Monthly child care: `$400`
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Validates the exact gross-income boundary at $1 below the federal 130% FPL limit for a household of 2 in Kansas.
+
+---
+
+### Scenario 4: Single Adult — Gross Income Above 130% FPL
+
+**What we're checking**: A single-person household with gross income above the 130% FPL limit is correctly denied (criterion 1, gross cap).
+
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1992` (age 34), Relationship: Head of Household, Sex: Male, Not a student, Not pregnant, No disability, U.S. citizen, Employment income: `$1,800` per month (above the HH1 limit of $1,696)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Confirms the screener enforces the federal 130% FPL gross cap for Kansas — there is no BBCE 200% allowance as in Washington.
+
+---
+
+### Scenario 5: Net Income Test Failure — Gross Passes, Net Fails
+
+**What we're checking**: A household whose gross income is below the 130% FPL limit but whose net income exceeds the 100% FPL limit is denied — the KS-distinctive net income test that Washington (BBCE) waives (criterion 2).
+
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66603`, Select county `Shawnee`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: Head of Household, Sex: Male, Not a student, Not pregnant, No disability, U.S. citizen
+- **Income**: Unemployment income: `$1,650` per month (unearned; below the gross limit of $1,696, but with only the $209 standard deduction and no earned-income or shelter deductions, net ≈ $1,441, above the net limit of $1,305)
+- **Expenses**: No shelter or dependent-care expenses
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: The only scenario that flips to eligible if the net income test were accidentally waived (e.g., BBCE wrongly applied to Kansas). Directly validates that the 100% FPL net test is enforced.
+
+---
+
+### Scenario 6: Non-Elderly Household — Countable Assets Above $3,000
+
+**What we're checking**: A non-elderly/non-disabled household that passes the income tests but holds countable assets above $3,000 is denied — the KS-distinctive asset test that Washington (BBCE) eliminates (criterion 3).
+
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66603`, Select county `Shawnee`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: Head of Household, Sex: Female, Not a student, Not pregnant, No disability, U.S. citizen, Employment income: `$1,000` per month (well under the income limits)
+- **Assets**: `$5,000` in countable resources (above the $3,000 limit)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Validates that the federal asset test is enforced for Kansas. This scenario flips to eligible if the asset test were wrongly waived.
+
+---
+
+### Scenario 7: Elderly Individual — Gross Above 130% FPL, Net Below 100% FPL, Assets ≤ $4,500
+
+**What we're checking**: The federal elderly/disabled treatment — a 60+ household is exempt from the gross income test and qualifies on net income alone, using the higher $4,500 asset limit and an uncapped shelter deduction (criterion 6).
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1959` (age 67), Relationship: Head of Household, Not a student, Not pregnant, Not disabled (using the age 60+ exemption)
+- **Income**: Social Security retirement income: `$1,800` per month (above the HH1 gross limit of $1,696)
+- **Expenses**: Monthly rent: `$1,000`, Heating/cooling utilities (uncapped shelter deduction for elderly)
+- **Assets**: `$1,000` (below the $4,500 elderly/disabled limit)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Tests the path unique to elderly/disabled households — gross income exceeds 130% FPL, but the household still qualifies via the net income test, using the higher asset limit and uncapped shelter deduction.
+
+---
+
+### Scenario 8: Categorical Eligibility — All Members Receive SSI, Income and Assets Above Limits
+
+**What we're checking**: A household in which all members receive SSI is categorically eligible — the income and asset tests are bypassed (criterion 5).
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1981` (age 45), Relationship: Head of Household, Not a student, Not pregnant, No disability, U.S. citizen
+- **Income**: Other income above the standard limit (with SSI received)
+- **Assets**: `$6,000` (above the $3,000 standard limit)
+- **Current Benefits**: Currently receiving SSI (`has_ssi` = Yes), Not currently receiving SNAP/Food Assistance, Not receiving TANF
+
+**Why this matters**: Validates that an all-SSI household is categorically eligible regardless of income or assets — confirms categorical eligibility correctly overrides the financial tests.
+
+---
+
+### Scenario 9: Half-Time College Student Aged 18–49 — No Exemption
+
+**What we're checking**: A college student enrolled at least half-time, aged 18–49, with no qualifying exemption is an ineligible student (criterion 7).
+
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66045`, Select county `Douglas`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 2006` (age 20), Relationship: Head of Household, Student status: enrolled in higher education at least half-time, Working: No, No work-study, No job-training program, No dependent child, No disability
+- **Income**: No earned or unearned income, Total gross monthly income: `$0`
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Confirms the federal student restriction is applied — an unexempted half-time student aged 18–49 is ineligible even with $0 income.
+
+---
+
+### Scenario 10: Half-Time College Student with 20+ Hours/Week Work Exemption
+
+**What we're checking**: A half-time college student who works 20+ hours/week meets a student exemption and is eligible (criterion 7, exemption regression guard).
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66045`, Select county `Douglas`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 2004` (age 22), Relationship: Head of Household, Student status: enrolled in higher education at least half-time, Works 20+ hours per week (qualifies for the student exemption), No disability
+- **Income**: Employment income consistent with 20+ hours/week
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Confirms a qualifying student exemption restores eligibility, guarding against the screener over-applying the student restriction.
+
+---
+
+### Scenario 11: Already Receiving SNAP/Food Assistance — Duplicate Benefit Exclusion
+
+**What we're checking**: A household already receiving Food Assistance is flagged ineligible, preventing duplicate enrollment (criterion 8).
+
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: Head of Household, Sex: Female, Not a student, Not pregnant, No disability, U.S. citizen, Employment income: `$1,500` per month
+- **Person 2**: Birth month/year: `January 2019` (age 7), Relationship: Child, Sex: Male, No income
+- **Current Benefits**: Already receiving SNAP/Food Assistance (reported on the "already have" step → `screen.has_benefit("ks_snap")`)
+
+**Why this matters**: Preventing duplicate enrollment is critical for program integrity.
+
+---
+
+### Scenario 12: Standard Utility Allowance — Single Adult, Moderate Income
+
+**What we're checking**: A single adult below the maximum allotment with a binding excess-shelter deduction, so the KS Standard Utility Allowance ($469/mo HCSUA) flows through to the benefit. Committed expected benefit: **$2,461/yr ($205/mo)**.
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1991` (age 35), Relationship: Head of Household, Not a student, Not pregnant, No disability, U.S. citizen
+- **Income**: Employment income: `$1,500` per month ($18,000/year)
+- **Expenses**: Monthly rent: `$700`, Heating/cooling utilities (qualifies for HCSUA $469/mo)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Primary SUA validation. Reducing the KS HCSUA $469→$400 lowers this benefit by exactly $248/yr (0.30 × $69 × 12), proving the expected value isolates the SUA. PolicyEngine-verified on `policyengine-us` 1.739.4.
+
+---
+
+### Scenario 13: Standard Utility Allowance — Elderly Individual
+
+**What we're checking**: An elderly household (uncapped shelter deduction) where the SUA is binding. Committed expected benefit: **$2,533/yr ($211/mo)**.
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66603`, Select county `Shawnee`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1959` (age 67), Relationship: Head of Household, Not a student, Not pregnant, Not disabled (age 60+ exemption)
+- **Income**: Social Security retirement income: `$14,000` per year (~$1,167/month)
+- **Expenses**: Monthly rent: `$1,000`, Heating/cooling utilities (qualifies for HCSUA $469/mo)
+- **Assets**: Below the $4,500 elderly/disabled limit
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: SUA validation on the elderly/disabled path; SUA-sensitive (−$248/yr if HCSUA $469→$400). PolicyEngine-verified on `policyengine-us` 1.739.4.
+
+---
+
+### Scenario 14: Standard Utility Allowance — Family of Three
+
+**What we're checking**: A three-person working household below the maximum allotment with a binding shelter deduction. Committed expected benefit: **$4,738/yr ($395/mo)**.
+
+**Expected**: Eligible
+
+**Steps**:
+- **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
+- **Household**: Number of people: `3`
+- **Person 1**: Birth month/year: `January 1991` (age 35), Relationship: Head of Household, Not a student, No disability, U.S. citizen, Employment income: `$30,000` per year ($2,500/month)
+- **Person 2**: Birth month/year: `January 1993` (age 33), Relationship: Spouse, No income, No disability, U.S. citizen
+- **Person 3**: Birth month/year: `January 2021` (age 5), Relationship: Child, No income
+- **Expenses**: Monthly rent: `$900`, Heating/cooling utilities (qualifies for HCSUA $469/mo)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: SUA validation at a larger household size; SUA-sensitive (−$248/yr if HCSUA $469→$400). PolicyEngine-verified on `policyengine-us` 1.739.4.
+
+
+## PE Verification
+
+Full detail in the MFB-1049 "PE Verification — final verdict" comment. Summary: **no PE request required, nothing blocks implementation.** KS uses the federal SNAP calculator (`KsSnap(Snap)`) with no eligibility variance; the KS SUA values ($469/$345/$44, eff. 2025-10-01) and all FY2026 standards (max allotment, deductions, shelter cap, asset/income limits) match KEESM/FNS in PolicyEngine. Open SNAP issues triaged and cleared for MFB — #8296 (COFA) and OBBBA non-citizen narrowing bypassed via the `CITIZEN` default; #7745 (OBBBA HCSUA restriction) doesn't affect MFB (actual-expense pathway); #8133/#8134 (student-filter bugs) don't reach MFB; the 3-month ABAWD time-limit clock is an architectural PE limitation.
+
+
+## Research Sources
+
+- [KS DCF Food Assistance (SNAP)](https://www.dcf.ks.gov/services/ees/pages/food/foodassistance.aspx)
+- [KS DCF Food Assistance FAQ](https://www.dcf.ks.gov/services/ees/Pages/Food/FoodAssistanceFAQs.aspx)
+- [KEESM Appendix F-2 — Food Assistance Program Standards (eff. 10/1/2025)](https://content.dcf.ks.gov/EES/KEESM/Appendix/F-2%20FA%20Program%20Standards.pdf)
+- [KEESM Section 2510 — Categorical Eligibility](https://content.dcf.ks.gov/ees/KEESM/current/keesm2510.htm)
+- [KEESM Student Eligibility Criteria for Food Assistance](https://content.dcf.ks.gov/ees/keeswebhelp/nonmedical-keeswebhelp/Student_Eligibility_Criteria_for_Food_Assistance.htm)
+- [FNS SNAP Recipient Eligibility](https://www.fns.usda.gov/snap/recipient/eligibility)
+- [FNS BBCE State Chart](https://www.fns.usda.gov/snap/broad-based-categorical-eligibility) (KS not listed)
+- [FNS FY2026 COLA](https://www.fns.usda.gov/snap/allotment/cola/fy26)
+- [FNS ABAWD Waivers FY2025–2029](https://www.fns.usda.gov/snap/abawd/waivers/2025-2029) (KS not waived)
+- [Public Health Law Center — KS Drug Felony](https://www.publichealthlawcenter.org/resources/snap-ban-opt-out-states-map/ks)
+- [Legal Information Institute — 7 U.S.C. § 2014](https://www.law.cornell.edu/uscode/text/7/2014)
+
+
+## JSON Test Cases
+
+File: `validations/management/commands/import_validations/data/ks_snap.json`
+
+Scenarios 1–14. Expected `eligible`:
+- `true`: 1, 2, 3, 7, 8, 10, 12, 13, 14
+- `false`: 4, 5, 6, 9, 11
+
+Value scenarios 12–14 carry committed amounts ($2,461 / $2,533 / $4,738 per year), computed on `policyengine-us` 1.739.4.
+
+
+## Generated Program Configuration
+
+File: `programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json` (PR #1586). Config carries no `warning_message`, 7 required documents, and 2 navigators (Mirror Inc., Harvesters).
+
+Two config updates this spec recommends:
+- **`legal_status_required`** → `citizen`, `gc_5plus`, `gc_5less` (drop `refugee`, `non_citizen`, `otherWithWorkPermission` — no longer SNAP-eligible post-OBBBA; see the dev thread on the ticket).
+- **Program description** → add a child-support-cooperation line (criterion 13). Suggested: append to the eligibility paragraph — *"Single parents may need to cooperate with child support services to get benefits. Some exceptions apply, such as for safety reasons."*
+
+
+## Version note
+
+Expected values for scenarios 12–14 were computed on `policyengine-us` 1.739.4. MFB serves SNAP via the hosted PolicyEngine API at the version in `PolicyEngineConfig` (defaults to blank → PE "current," which as of June 2026 carries the FY2026 KS SUA). If the config is pinned to a release predating the FY2026 SUA load, re-run scenarios 12–14 on that version before locking.
+
+
+## Changelog
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-06-21 | Discovery (KS) | Initial KS spec adapted from `wa/snap/spec.md`; replaced WA BBCE criteria with standard federal tests (130% gross, 100% net, $3,000/$4,500 asset limit); KS SUA = $469; SUA-isolating value scenarios with PolicyEngine-verified amounts. |
+| 2026-06-21 | Discovery QA | Removed administrative/process items (SSN, identity/interview, IPV) from eligibility criteria; reordered with priority/screenable criteria first; added a handling suggestion (inclusivity assumption or program-description surfacing) to every data gap; verified FY2026 asset limit ($3,000/$4,500); expanded scenarios to cover net-test failure, asset test, categorical (SSI) eligibility, and student exemption (14 total). |
+| 2026-06-21 | Discovery QA | Citation fidelity pass — verified every spec citation against live primary sources. Two fixes: criterion 14 (drug felony) `7 U.S.C. § 2015(k)` → `21 U.S.C. § 862a` (2015 covers benefit-trafficking, not the felony ban); criterion 15 (fleeing felon) dropped the unverifiable `7 U.S.C. § 2015(k)`, kept `7 CFR 273.11(n)`. Confirmed `7 CFR 273.11(o)-(p)` is correct for child-support cooperation. All other CFR/USC/KEESM cites verified. |
+| 2026-06-21 | Discovery QA | Ran all eligibility scenarios through PolicyEngine (1.739.4): scenarios 1–10 confirm their eligible/ineligible outcomes, 12–14 confirm committed SUA amounts; scenario 11 (duplicate-benefit) is handled by the `already_has` results-layer workflow (`has_benefit("ks_snap")`), verified by design. Student scenarios are handled by the federal calculator's `is_snap_ineligible_student` dependency, computed from screener fields and passed to PE as an input. |
+| 2026-06-21 | Discovery QA | Added missing criteria: **child support cooperation** (criterion 13 — KS-specific state option mandated under the HOPE Act, verified via Kansas Action for Children / KEESM) and a distinct **general work requirement / work registrant 18–59** (criterion 11, KS HOPE Act 30-hr + mandatory E&T), split from the ABAWD time-limit criterion (12); folded the standalone voluntary-quit item into the general work requirement. Reformatted all test scenarios to match the `wa/snap/spec.md` structure. |

--- a/programs/programs/policyengine/calculators/dependencies/household.py
+++ b/programs/programs/policyengine/calculators/dependencies/household.py
@@ -36,6 +36,10 @@ class WaStateCodeDependency(StateCode):
     state = "WA"
 
 
+class KsStateCodeDependency(StateCode):
+    state = "KS"
+
+
 class CountyDependency(Household):
     field: ClassVar[str] = "county_str"
     dependencies: ClassVar[list[str]] = ["county"]

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
@@ -44,6 +44,22 @@ class TestWaStateCodeDependency(TestCase):
         self.assertEqual(dep.field, "state_code")
 
 
+class TestKsStateCodeDependency(TestCase):
+    """Tests for KsStateCodeDependency class used by KsSnap calculator."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="66603", county="Shawnee County", household_size=1, completed=False
+        )
+
+    def test_value_returns_ks_state_code(self):
+        dep = household.KsStateCodeDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), "KS")
+        self.assertEqual(dep.field, "state_code")
+
+
 class TestCountyDependency(TestCase):
     """Tests for CountyDependency class and its subclasses."""
 

--- a/programs/programs/policyengine/calculators/registry.py
+++ b/programs/programs/policyengine/calculators/registry.py
@@ -30,6 +30,11 @@ from programs.programs.il.pe import (
     il_spm_calculators,
     il_tax_unit_calculators,
 )
+from programs.programs.ks.pe import (
+    ks_member_calculators,
+    ks_spm_calculators,
+    ks_tax_unit_calculators,
+)
 from programs.programs.ma.pe import (
     ma_member_calculators,
     ma_spm_calculators,
@@ -47,6 +52,7 @@ all_member_calculators: dict[str, type[PolicyEngineMembersCalculator]] = {
     **co_member_calculators,
     **federal_member_calculators,
     **il_member_calculators,
+    **ks_member_calculators,
     **ma_member_calculators,
     **nc_member_calculators,
     **tx_member_calculators,
@@ -57,6 +63,7 @@ all_spm_unit_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {
     **co_spm_calculators,
     **federal_spm_unit_calculators,
     **il_spm_calculators,
+    **ks_spm_calculators,
     **ma_spm_calculators,
     **nc_spm_calculators,
     **tx_spm_calculators,
@@ -67,6 +74,7 @@ all_tax_unit_calculators: dict[str, type[PolicyEngineTaxUnitCalulator]] = {
     **co_tax_unit_calculators,
     **federal_tax_unit_calculators,
     **il_tax_unit_calculators,
+    **ks_tax_unit_calculators,
     **ma_tax_unit_calculators,
     **tx_tax_unit_calculators,
     **wa_tax_calculators,


### PR DESCRIPTION
## Context & Motivation

Adds Kansas Food Assistance (SNAP) as a PolicyEngine **federal** SNAP program for the KS white label.

- Linear ticket: [MFB-1049](https://linear.app/myfriendben/issue/MFB-1049)
- Label: **PE Federal** — uses PolicyEngine's federal `snap` calculator (PE variable `snap`).

This is a config-only federal program. SNAP has no Kansas-specific calculator variance; Kansas's state elections (BBCE, vehicle exemptions, utility regions) are keyed off the state code in PolicyEngine's SNAP parameters, so passing the KS state code is sufficient. Verified against `policyengine-us`: KS appears only as a parameterized state row in nationwide SNAP tables — no KS-specific SNAP variable or override.

> Part of KS Launch. Shares KS scaffolding (`programs/programs/ks/__init__.py`, `ks/pe/member.py`) with sibling KS program PRs — expect minor merge conflicts in the `ks_calculators` dict and pe/member.py to resolve at merge time.

## Changes Made

- Added `ks_snap_initial_config.json` (program config, attached on the ticket, written exactly as-is).
- Created `programs/programs/ks/pe/` package:
  - `spm.py` — `KsSnap`, extending the federal `Snap` SPM calculator with the KS state-code dependency.
  - `member.py` — placeholder for future KS member-level PE programs.
  - `__init__.py` — exports `ks_member_calculators`, `ks_spm_calculators`, `ks_tax_unit_calculators` (only `ks_snap` populated).
- Added `KsStateCodeDependency` (`state="KS"`) to `dependencies/household.py`.
- Registered the KS PE calculators in `policyengine/calculators/registry.py`.
- Added a `KsStateCodeDependency` unit test mirroring the TX/WA pattern.

## Testing

- Migrations to run: none.
- Configuration updates needed: `python manage.py import_program_config programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json` — imported cleanly locally (program `ks_snap`, created inactive).
- Manual testing steps: `python manage.py test programs.programs.policyengine.calculators.dependencies.tests.test_household` (10 passing). No per-program validation file — federal SNAP relies on existing federal calculator tests.

## Deployment

- Post-deployment scripts needed: run the `import_program_config` command for `ks_snap_initial_config.json` per environment.
- Admin updates needed: activate the program (`active=True`) when ready to launch.

## Notes for Reviewers

- `show_in_has_benefits_step: true` is set (matches every other state's SNAP). SNAP receipt confers categorical/presumptive eligibility on many programs (verified via grep: `presumptive_eligibility`/`categorically_eligible`/`has_benefit("...snap")` across CO/TX/WA/NC), and sibling KS programs will read KS SNAP via `has_benefit("ks_snap")` / `has_base_benefit("snap")`.
- Program imported as inactive; activation is a deliberate launch step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kansas SNAP support in the app’s program configuration, including program details, required documents, and navigator/contact information.
  * Enabled Kansas-specific eligibility calculation and integrated it into the overall calculator registry.
  * Added a Kansas state code dependency used by the SNAP workflow.

* **Documentation**
  * Added a detailed Kansas SNAP implementation spec with eligibility rules and example scenarios.

* **Tests**
  * Added coverage for the Kansas state code dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->