### PR TITLE
MFB-1131: Updating error message to be cleaner 

### DIFF
--- a/screener/tests/test_rem_impact.py
+++ b/screener/tests/test_rem_impact.py
@@ -207,6 +207,37 @@ class TestRemImpactView(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
         self.assertIn("error", response.data)
 
+    # ── 422: address-level errors ─────────────────────────────────────────────
+
+    @patch("screener.views.RewiringAmericaClient.fetch_rem_impact")
+    def test_rem_400_with_known_address_error_type_returns_422(self, mock_fetch):
+        for error_type in (
+            "multifamily_not_supported",
+            "building_type_not_supported",
+            "address_not_parsable",
+            "building_not_supported",
+        ):
+            with self.subTest(error_type=error_type):
+                err = requests.HTTPError()
+                # REM wraps the typed error one level deep: {"detail": {"type": ..., "msg": ...}}
+                err.response = Mock(
+                    status_code=400,
+                    json=lambda t=error_type: {"detail": {"type": t, "msg": "some message"}},
+                )
+                mock_fetch.side_effect = err
+                response = self.client.get(self.URL, self.VALID_PARAMS)
+                self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+                self.assertEqual(response.data["error"], "address_not_supported")
+                self.assertIn("detail", response.data)
+
+    @patch("screener.views.RewiringAmericaClient.fetch_rem_impact")
+    def test_rem_400_with_unknown_error_type_still_returns_502(self, mock_fetch):
+        err = requests.HTTPError()
+        err.response = Mock(status_code=400, json=lambda: {"detail": {"type": "some_future_type", "msg": "x"}})
+        mock_fetch.side_effect = err
+        response = self.client.get(self.URL, self.VALID_PARAMS)
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
     # ── 200: happy path ───────────────────────────────────────────────────────
 
     @patch("screener.views.RewiringAmericaClient.fetch_rem_impact")

--- a/screener/views.py
+++ b/screener/views.py
@@ -827,6 +827,28 @@ class RemImpactView(views.APIView):
                 detail = e.response.json()
             except Exception:
                 detail = e.response.text
+            # REM returns 400 with a typed detail dict for address-level errors the frontend
+            # can surface meaningfully. Known types (per docs.rewiringamerica.org/api/
+            # residential-electrification-model#get-by-address):
+            #   multifamily_not_supported, building_type_not_supported,
+            #   address_not_parsable, building_not_supported
+            # Return 422 so the frontend can distinguish these from backend/network failures.
+            _ADDRESS_ERROR_TYPES = {
+                "multifamily_not_supported",
+                "building_type_not_supported",
+                "address_not_parsable",
+                "building_not_supported",
+            }
+            nested = detail.get("detail") if isinstance(detail, dict) else None
+            if (
+                e.response.status_code < 500
+                and isinstance(nested, dict)
+                and nested.get("type") in _ADDRESS_ERROR_TYPES
+            ):
+                return Response(
+                    {"error": "address_not_supported", "detail": detail},
+                    status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                )
             return Response(
                 {"error": f"Rewiring America API error: {e.response.status_code}", "detail": detail},
                 status=status.HTTP_502_BAD_GATEWAY,

--- a/screener/views.py
+++ b/screener/views.py
@@ -840,11 +840,7 @@ class RemImpactView(views.APIView):
                 "building_not_supported",
             }
             nested = detail.get("detail") if isinstance(detail, dict) else None
-            if (
-                e.response.status_code < 500
-                and isinstance(nested, dict)
-                and nested.get("type") in _ADDRESS_ERROR_TYPES
-            ):
+            if e.response.status_code < 500 and isinstance(nested, dict) and nested.get("type") in _ADDRESS_ERROR_TYPES:
                 return Response(
                     {"error": "address_not_supported", "detail": detail},
                     status=status.HTTP_422_UNPROCESSABLE_ENTITY,


### PR DESCRIPTION
## Context & Motivation

The CESN Heat Pump Calculator proxies requests to the Rewiring America REM API (`/api/v1/rem/address`). For certain addresses (e.g. multi-family buildings, unrecognized building types), REM returns a structured 400 error with a machine-readable `type` field. Previously, the proxy collapsed all upstream errors into a generic 502, so the frontend had no way to distinguish "this address isn't supported" from a backend or network failure — both showed the same generic error message.

- Related PR: MyFriendBen/benefits-calculator#2133

## Changes Made

- **`screener/views.py` — `RemImpactView`**: When the REM API returns a 4xx HTTP error whose JSON body matches the shape `{"detail": {"type": "<known_type>", ...}}`, the view now returns HTTP **422 Unprocessable Entity** with `{"error": "address_not_supported", "detail": <rem_detail>}` instead of 502. All other upstream errors (unknown error types, 5xx responses, network failures) continue to return 502 unchanged.
  - Known address error types handled (per [REM API docs](https://docs.rewiringamerica.org/api/residential-electrification-model#get-by-address)): `multifamily_not_supported`, `building_type_not_supported`, `address_not_parsable`, `building_not_supported`
- **`screener/tests/test_rem_impact.py`**: Two new tests added to `TestRemImpactView`:
  - `test_rem_400_with_known_address_error_type_returns_422` — verifies all four known types return 422 with `error: "address_not_supported"` (uses `subTest`)
  - `test_rem_400_with_unknown_error_type_still_returns_502` — verifies an unrecognized type still falls through to 502

## Testing

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  1. Submit a Calculate Impact request for `1777 Larimer St, Denver, CO 80202` (a multi-family address)
  2. Confirm the backend returns HTTP 422 with `{"error": "address_not_supported", ...}` rather than 502
  3. Confirm a valid single-family address still returns 200 with bill and emissions delta
  4. Run `python -m pytest screener/tests/test_rem_impact.py` — all 23 tests should pass

## Deployment

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None — this is a backend-only contract change; the corresponding frontend error message is wired up in MyFriendBen/benefits-calculator#2133, which should be deployed alongside or after this PR

## Notes for Reviewers

- Known limitations: Only the four error `type` values documented at the time of writing are mapped to 422. If Rewiring America adds new address-level error types in the future, they will fall through to 502 until the `_ADDRESS_ERROR_TYPES` set in `RemImpactView` is updated.
- The REM error body nests the `type` field one level deep (`{"detail": {"type": ..., "msg": ...}}`), not at the top level — this is why we extract `nested = detail.get("detail")` before checking the type.
