### PR TITLE
MFB-1036: Add Google Places autocomplete to Calculate Impact address field

### DIFF
--- a/benefits/settings.py
+++ b/benefits/settings.py
@@ -84,6 +84,7 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "nps": "3/hour",  # Limit NPS submissions to prevent abuse
         "rem": "30/hour",  # Limit REM impact proxy requests to protect the upstream API key
+        "places": "200/hour",  # Limit Places Autocomplete proxy requests per IP
     },
 }
 
@@ -417,6 +418,7 @@ UNFOLD = {
 }
 
 REWIRING_AMERICA_API_KEY = config("REWIRING_AMERICA_API_KEY", default="")
+GOOGLE_MAPS_API_KEY = config("GOOGLE_MAPS_API_KEY", default="")
 
 # generate uml with: ./manage.py graph_models --pydot
 # adding -d will exclude the fields

--- a/integrations/clients/google_places.py
+++ b/integrations/clients/google_places.py
@@ -1,0 +1,27 @@
+import requests
+from django.conf import settings
+
+
+class GooglePlacesClient:
+    BASE_URL = "https://maps.googleapis.com"
+
+    def autocomplete_address(self, input_text: str) -> list[dict]:
+        response = requests.get(
+            f"{self.BASE_URL}/maps/api/place/autocomplete/json",
+            params={
+                "input": input_text,
+                "types": "address",
+                "components": "country:us",
+                "key": settings.GOOGLE_MAPS_API_KEY,
+            },
+            timeout=5,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [
+            {
+                "description": p["description"].removesuffix(", USA"),
+                "place_id": p["place_id"],
+            }
+            for p in data.get("predictions", [])
+        ]

--- a/integrations/clients/google_places.py
+++ b/integrations/clients/google_places.py
@@ -1,16 +1,25 @@
 import hashlib
+import logging
+from typing import TypedDict
 
 import requests
 from django.conf import settings
 from django.core.cache import cache
 
+logger = logging.getLogger(__name__)
+
 AUTOCOMPLETE_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days
+
+
+class AddressPrediction(TypedDict):
+    description: str
+    place_id: str
 
 
 class GooglePlacesClient:
     BASE_URL = "https://maps.googleapis.com"
 
-    def autocomplete_address(self, input_text: str) -> list[dict]:
+    def autocomplete_address(self, input_text: str) -> list[AddressPrediction]:
         cache_key = "places_autocomplete_" + hashlib.md5(input_text.lower().encode()).hexdigest()
         cached = cache.get(cache_key)
         if cached is not None:
@@ -28,7 +37,10 @@ class GooglePlacesClient:
         )
         response.raise_for_status()
         data = response.json()
-        results = [
+        api_status = data.get("status")
+        if api_status not in ("OK", "ZERO_RESULTS"):
+            logger.warning("Google Places API returned status %s for input %r", api_status, input_text)
+        results: list[AddressPrediction] = [
             {
                 "description": p["description"].removesuffix(", USA"),
                 "place_id": p["place_id"],

--- a/integrations/clients/google_places.py
+++ b/integrations/clients/google_places.py
@@ -40,6 +40,7 @@ class GooglePlacesClient:
         api_status = data.get("status")
         if api_status not in ("OK", "ZERO_RESULTS"):
             logger.warning("Google Places API returned status %s for input %r", api_status, input_text)
+            raise requests.RequestException(f"Google Places API error status: {api_status}")
         results: list[AddressPrediction] = [
             {
                 "description": p["description"].removesuffix(", USA"),

--- a/integrations/clients/google_places.py
+++ b/integrations/clients/google_places.py
@@ -1,11 +1,21 @@
+import hashlib
+
 import requests
 from django.conf import settings
+from django.core.cache import cache
+
+AUTOCOMPLETE_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days
 
 
 class GooglePlacesClient:
     BASE_URL = "https://maps.googleapis.com"
 
     def autocomplete_address(self, input_text: str) -> list[dict]:
+        cache_key = "places_autocomplete_" + hashlib.md5(input_text.lower().encode()).hexdigest()
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
         response = requests.get(
             f"{self.BASE_URL}/maps/api/place/autocomplete/json",
             params={
@@ -18,10 +28,12 @@ class GooglePlacesClient:
         )
         response.raise_for_status()
         data = response.json()
-        return [
+        results = [
             {
                 "description": p["description"].removesuffix(", USA"),
                 "place_id": p["place_id"],
             }
             for p in data.get("predictions", [])
         ]
+        cache.set(cache_key, results, AUTOCOMPLETE_CACHE_TTL)
+        return results

--- a/screener/tests/test_places_autocomplete.py
+++ b/screener/tests/test_places_autocomplete.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for the Google Places Autocomplete proxy:
+  - GooglePlacesClient.autocomplete_address
+  - PlacesAutocompleteView (empty input / 502 / happy-path)
+"""
+
+import requests
+from unittest.mock import patch, Mock
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from integrations.clients.google_places import GooglePlacesClient
+
+
+class TestGooglePlacesClient(TestCase):
+    """Unit tests for GooglePlacesClient.autocomplete_address."""
+
+    MOCK_GOOGLE_RESPONSE = {
+        "predictions": [
+            {"description": "123 Main St, Denver, CO 80014, USA", "place_id": "abc123"},
+            {"description": "123 Main Ave, Boulder, CO 80302, USA", "place_id": "def456"},
+        ],
+        "status": "OK",
+    }
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_returns_parsed_predictions(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: self.MOCK_GOOGLE_RESPONSE)
+        mock_get.return_value.raise_for_status = Mock()
+
+        client = GooglePlacesClient()
+        results = client.autocomplete_address("123 Main")
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["place_id"], "abc123")
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_strips_usa_suffix_from_descriptions(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: self.MOCK_GOOGLE_RESPONSE)
+        mock_get.return_value.raise_for_status = Mock()
+
+        results = GooglePlacesClient().autocomplete_address("123 Main")
+
+        self.assertEqual(results[0]["description"], "123 Main St, Denver, CO 80014")
+        self.assertEqual(results[1]["description"], "123 Main Ave, Boulder, CO 80302")
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_passes_correct_params_to_google(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: {"predictions": []})
+        mock_get.return_value.raise_for_status = Mock()
+
+        GooglePlacesClient().autocomplete_address("456 Oak")
+
+        _, kwargs = mock_get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["input"], "456 Oak")
+        self.assertEqual(params["types"], "address")
+        self.assertEqual(params["components"], "country:us")
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_returns_empty_list_when_no_predictions(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: {"predictions": [], "status": "ZERO_RESULTS"})
+        mock_get.return_value.raise_for_status = Mock()
+
+        results = GooglePlacesClient().autocomplete_address("zzz")
+
+        self.assertEqual(results, [])
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_preserves_non_usa_descriptions_unchanged(self, mock_get):
+        mock_get.return_value = Mock(
+            json=lambda: {
+                "predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}]
+            }
+        )
+        mock_get.return_value.raise_for_status = Mock()
+
+        results = GooglePlacesClient().autocomplete_address("123 Main")
+
+        self.assertEqual(results[0]["description"], "123 Main St, Denver, CO 80014")
+
+
+class TestPlacesAutocompleteView(APITestCase):
+    """Integration tests for GET /api/places/autocomplete/."""
+
+    URL = "/api/places/autocomplete/"
+
+    MOCK_PREDICTIONS = [
+        {"description": "123 Main St, Denver, CO 80014", "place_id": "abc123"},
+        {"description": "123 Main Ave, Boulder, CO 80302", "place_id": "def456"},
+    ]
+
+    def setUp(self):
+        patcher = patch("screener.views.PlacesRateThrottle.allow_request", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # ── empty / missing input ─────────────────────────────────────────────────
+
+    def test_returns_empty_list_when_input_param_is_missing(self):
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_returns_empty_list_when_input_is_blank(self):
+        response = self.client.get(self.URL, {"input": "   "})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    # ── 502: upstream errors ──────────────────────────────────────────────────
+
+    @patch("screener.views.GooglePlacesClient.autocomplete_address")
+    def test_google_http_error_returns_502(self, mock_autocomplete):
+        err = requests.HTTPError()
+        err.response = Mock(status_code=403)
+        mock_autocomplete.side_effect = err
+        response = self.client.get(self.URL, {"input": "123 Main"})
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+        self.assertIn("error", response.data)
+
+    @patch("screener.views.GooglePlacesClient.autocomplete_address")
+    def test_network_failure_returns_502(self, mock_autocomplete):
+        mock_autocomplete.side_effect = requests.RequestException("timeout")
+        response = self.client.get(self.URL, {"input": "123 Main"})
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+        self.assertIn("error", response.data)
+        self.assertIn("detail", response.data)
+
+    # ── 200: happy path ───────────────────────────────────────────────────────
+
+    @patch("screener.views.GooglePlacesClient.autocomplete_address")
+    def test_happy_path_returns_predictions(self, mock_autocomplete):
+        mock_autocomplete.return_value = self.MOCK_PREDICTIONS
+        response = self.client.get(self.URL, {"input": "123 Main"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["description"], "123 Main St, Denver, CO 80014")
+        self.assertEqual(response.data[0]["place_id"], "abc123")
+
+    @patch("screener.views.GooglePlacesClient.autocomplete_address")
+    def test_input_is_trimmed_before_forwarding(self, mock_autocomplete):
+        mock_autocomplete.return_value = []
+        self.client.get(self.URL, {"input": "  123 Main  "})
+        mock_autocomplete.assert_called_once_with("123 Main")
+
+    @patch("screener.views.GooglePlacesClient.autocomplete_address")
+    def test_returns_empty_list_when_no_predictions(self, mock_autocomplete):
+        mock_autocomplete.return_value = []
+        response = self.client.get(self.URL, {"input": "zzz"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])

--- a/screener/tests/test_places_autocomplete.py
+++ b/screener/tests/test_places_autocomplete.py
@@ -71,9 +71,7 @@ class TestGooglePlacesClient(TestCase):
     @patch("integrations.clients.google_places.requests.get")
     def test_preserves_non_usa_descriptions_unchanged(self, mock_get):
         mock_get.return_value = Mock(
-            json=lambda: {
-                "predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}]
-            }
+            json=lambda: {"predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}]}
         )
         mock_get.return_value.raise_for_status = Mock()
 

--- a/screener/tests/test_places_autocomplete.py
+++ b/screener/tests/test_places_autocomplete.py
@@ -7,6 +7,7 @@ Unit tests for the Google Places Autocomplete proxy:
 import requests
 from unittest.mock import patch, Mock
 
+from django.core.cache import cache
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -78,6 +79,31 @@ class TestGooglePlacesClient(TestCase):
         results = GooglePlacesClient().autocomplete_address("123 Main")
 
         self.assertEqual(results[0]["description"], "123 Main St, Denver, CO 80014")
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_cache_hit_skips_api_call(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: self.MOCK_GOOGLE_RESPONSE)
+        mock_get.return_value.raise_for_status = Mock()
+
+        client = GooglePlacesClient()
+        client.autocomplete_address("123 Main")
+        client.autocomplete_address("123 Main")
+
+        mock_get.assert_called_once()
+
+    @patch("integrations.clients.google_places.requests.get")
+    def test_cache_key_is_case_insensitive(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: self.MOCK_GOOGLE_RESPONSE)
+        mock_get.return_value.raise_for_status = Mock()
+
+        client = GooglePlacesClient()
+        client.autocomplete_address("123 Main")
+        client.autocomplete_address("123 MAIN")
+
+        mock_get.assert_called_once()
+
+    def tearDown(self):
+        cache.clear()
 
 
 class TestPlacesAutocompleteView(APITestCase):

--- a/screener/tests/test_places_autocomplete.py
+++ b/screener/tests/test_places_autocomplete.py
@@ -102,6 +102,21 @@ class TestGooglePlacesClient(TestCase):
 
         mock_get.assert_called_once()
 
+    @patch("integrations.clients.google_places.requests.get")
+    def test_error_status_raises_and_is_not_cached(self, mock_get):
+        mock_get.return_value = Mock(json=lambda: {"predictions": [], "status": "REQUEST_DENIED"})
+        mock_get.return_value.raise_for_status = Mock()
+
+        client = GooglePlacesClient()
+        with self.assertRaises(requests.RequestException):
+            client.autocomplete_address("123 Main")
+
+        # A second call must hit the API again — error responses must not be cached.
+        with self.assertRaises(requests.RequestException):
+            client.autocomplete_address("123 Main")
+
+        self.assertEqual(mock_get.call_count, 2)
+
     def tearDown(self):
         cache.clear()
 
@@ -134,6 +149,13 @@ class TestPlacesAutocompleteView(APITestCase):
         self.assertEqual(response.data, [])
 
     # ── 502: upstream errors ──────────────────────────────────────────────────
+
+    @patch("screener.views.GooglePlacesClient.autocomplete_address")
+    def test_google_api_error_status_returns_502(self, mock_autocomplete):
+        mock_autocomplete.side_effect = requests.RequestException("Google Places API error status: REQUEST_DENIED")
+        response = self.client.get(self.URL, {"input": "123 Main"})
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+        self.assertIn("error", response.data)
 
     @patch("screener.views.GooglePlacesClient.autocomplete_address")
     def test_google_http_error_returns_502(self, mock_autocomplete):

--- a/screener/tests/test_places_autocomplete.py
+++ b/screener/tests/test_places_autocomplete.py
@@ -49,7 +49,7 @@ class TestGooglePlacesClient(TestCase):
 
     @patch("integrations.clients.google_places.requests.get")
     def test_passes_correct_params_to_google(self, mock_get):
-        mock_get.return_value = Mock(json=lambda: {"predictions": []})
+        mock_get.return_value = Mock(json=lambda: {"predictions": [], "status": "ZERO_RESULTS"})
         mock_get.return_value.raise_for_status = Mock()
 
         GooglePlacesClient().autocomplete_address("456 Oak")
@@ -72,7 +72,7 @@ class TestGooglePlacesClient(TestCase):
     @patch("integrations.clients.google_places.requests.get")
     def test_preserves_non_usa_descriptions_unchanged(self, mock_get):
         mock_get.return_value = Mock(
-            json=lambda: {"predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}]}
+            json=lambda: {"predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}], "status": "OK"}
         )
         mock_get.return_value.raise_for_status = Mock()
 

--- a/screener/tests/test_places_autocomplete.py
+++ b/screener/tests/test_places_autocomplete.py
@@ -72,7 +72,10 @@ class TestGooglePlacesClient(TestCase):
     @patch("integrations.clients.google_places.requests.get")
     def test_preserves_non_usa_descriptions_unchanged(self, mock_get):
         mock_get.return_value = Mock(
-            json=lambda: {"predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}], "status": "OK"}
+            json=lambda: {
+                "predictions": [{"description": "123 Main St, Denver, CO 80014", "place_id": "xyz"}],
+                "status": "OK",
+            }
         )
         mock_get.return_value.raise_for_status = Mock()
 

--- a/screener/urls.py
+++ b/screener/urls.py
@@ -39,4 +39,9 @@ urlpatterns = [
         views.RemImpactView.as_view(),
         name="rem-impact",
     ),
+    path(
+        "places/autocomplete/",
+        views.PlacesAutocompleteView.as_view(),
+        name="places-autocomplete",
+    ),
 ]

--- a/screener/views.py
+++ b/screener/views.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from integrations.clients.rewiring_america import RewiringAmericaClient
+from integrations.clients.google_places import GooglePlacesClient
 from integrations.services.communications import MessageUser
 from programs.programs.policyengine import versions as pe_versions
 from programs.models import Referrer
@@ -702,6 +703,23 @@ class NPSRateThrottle(throttling.AnonRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": hashed}
 
 
+class PlacesRateThrottle(throttling.AnonRateThrottle):
+    """
+    Rate throttle for Google Places Autocomplete proxy requests.
+    Rate is configured via DEFAULT_THROTTLE_RATES["places"] in settings.
+    Uses a hashed IP as the cache key to avoid storing raw IPs.
+    """
+
+    scope = "places"
+
+    def get_cache_key(self, request, view):
+        ident = self.get_ident(request)
+        if ident is None:
+            return None
+        hashed = hashlib.sha256(ident.encode()).hexdigest()
+        return self.cache_format % {"scope": self.scope, "ident": hashed}
+
+
 class NPSScoreView(views.APIView):
     """
     API endpoint for submitting NPS (Net Promoter Score) feedback.
@@ -862,3 +880,36 @@ class RemImpactView(views.APIView):
 
         serializer = RemImpactSerializer(raw)
         return Response(serializer.data)
+
+
+class PlacesAutocompleteView(views.APIView):
+    """
+    Proxies address autocomplete requests to the Google Places API,
+    keeping the API key server-side. Returns US street address predictions
+    restricted to street-level addresses.
+    """
+
+    permission_classes = [permissions.AllowAny]
+    throttle_classes = [PlacesRateThrottle]
+
+    def get(self, request, **_kwargs) -> Response:
+        input_text = request.query_params.get("input", "").strip()
+
+        if not input_text:
+            return Response([], status=status.HTTP_200_OK)
+
+        try:
+            client = GooglePlacesClient()
+            predictions = client.autocomplete_address(input_text)
+        except requests.HTTPError as e:
+            return Response(
+                {"error": f"Google Places API error: {e.response.status_code}"},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        except requests.RequestException as e:
+            return Response(
+                {"error": "Google Places request failed.", "detail": str(e)},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(predictions)

--- a/screener/views.py
+++ b/screener/views.py
@@ -902,8 +902,9 @@ class PlacesAutocompleteView(views.APIView):
             client = GooglePlacesClient()
             predictions = client.autocomplete_address(input_text)
         except requests.HTTPError as e:
+            http_status = e.response.status_code if e.response is not None else "unknown"
             return Response(
-                {"error": f"Google Places API error: {e.response.status_code}"},
+                {"error": f"Google Places API error: {http_status}"},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
         except requests.RequestException as e:

--- a/screener/views.py
+++ b/screener/views.py
@@ -669,55 +669,27 @@ def urgent_need_results(screen: Screen, data):
     return eligible_urgent_needs
 
 
-class RemRateThrottle(throttling.AnonRateThrottle):
-    """
-    Rate throttle for REM impact proxy requests to prevent API key abuse.
-    Rate is configured via DEFAULT_THROTTLE_RATES["rem"] in settings.
-    Uses a hashed IP as the cache key to avoid storing raw IPs.
-    """
+class HashedIPAnonRateThrottle(throttling.AnonRateThrottle):
+    """AnonRateThrottle that keys on a hashed IP so raw IPs aren't stored."""
 
+    def get_cache_key(self, request, view):
+        ident = self.get_ident(request)
+        if ident is None:
+            return None
+        hashed = hashlib.sha256(ident.encode()).hexdigest()
+        return self.cache_format % {"scope": self.scope, "ident": hashed}
+
+
+class RemRateThrottle(HashedIPAnonRateThrottle):
     scope = "rem"
 
-    def get_cache_key(self, request, view):
-        ident = self.get_ident(request)
-        if ident is None:
-            return None
-        hashed = hashlib.sha256(ident.encode()).hexdigest()
-        return self.cache_format % {"scope": self.scope, "ident": hashed}
 
-
-class NPSRateThrottle(throttling.AnonRateThrottle):
-    """
-    Rate throttle for NPS submissions to prevent abuse.
-    Rate is configured via DEFAULT_THROTTLE_RATES["nps"] in settings.
-    Uses a hashed IP as the cache key to avoid storing raw IPs.
-    """
-
+class NPSRateThrottle(HashedIPAnonRateThrottle):
     scope = "nps"
 
-    def get_cache_key(self, request, view):
-        ident = self.get_ident(request)
-        if ident is None:
-            return None
-        hashed = hashlib.sha256(ident.encode()).hexdigest()
-        return self.cache_format % {"scope": self.scope, "ident": hashed}
 
-
-class PlacesRateThrottle(throttling.AnonRateThrottle):
-    """
-    Rate throttle for Google Places Autocomplete proxy requests.
-    Rate is configured via DEFAULT_THROTTLE_RATES["places"] in settings.
-    Uses a hashed IP as the cache key to avoid storing raw IPs.
-    """
-
+class PlacesRateThrottle(HashedIPAnonRateThrottle):
     scope = "places"
-
-    def get_cache_key(self, request, view):
-        ident = self.get_ident(request)
-        if ident is None:
-            return None
-        hashed = hashlib.sha256(ident.encode()).hexdigest()
-        return self.cache_format % {"scope": self.scope, "ident": hashed}
 
 
 class NPSScoreView(views.APIView):


### PR DESCRIPTION
# MFB-1036 (Backend): Google Places Autocomplete proxy endpoint

## Context & Motivation

- Fixes [MFB-1036](https://linear.app/myfriendben/issue/MFB-1036/heat-pump-step-2b1-add-google-places-autocomplete-to-calculate-impact)
- Related PR: frontend changes in `frontend.md`

The Bill Impact Calculator on the Heat Pump Journey collects a home address to pass to the Rewiring America REM API. Rather than loading the Google Maps JS SDK in the browser (which would expose the API key in the client bundle), we proxy autocomplete requests through the Django backend — the same pattern used for the REM API proxy (`RemImpactView`). The API key lives only on the server.

## Changes Made

- **`integrations/clients/google_places.py`** (new) — `GooglePlacesClient` with a single `autocomplete_address(input_text)` method. Calls `maps.googleapis.com/maps/api/place/autocomplete/json` with `types=address` and `components=country:us`, strips the trailing `, USA` suffix from each prediction's description, and returns a `list[AddressPrediction]` (`TypedDict` with `description` and `place_id` string fields). Reads `settings.GOOGLE_MAPS_API_KEY`. Results are cached using Django's `default` cache backend with a 7-day TTL; the cache key is `places_autocomplete_<md5(input.lower())>` so repeated and case-variant queries skip the upstream API entirely. If Google's JSON response carries a status other than `OK` or `ZERO_RESULTS` (e.g. `REQUEST_DENIED` from a missing or misconfigured key), a `WARNING` is logged and a `requests.RequestException` is raised — the error response is not cached, and the caller surfaces a 502.

- **`benefits/settings.py`** — Added `GOOGLE_MAPS_API_KEY = config("GOOGLE_MAPS_API_KEY", default="")`. Added `"places": "200/hour"` to `DEFAULT_THROTTLE_RATES` (throttles per hashed IP, matching the existing `rem` throttle pattern).

- **`screener/views.py`** — Extracted `HashedIPAnonRateThrottle` base class with the shared `get_cache_key` logic (hashes the client IP via SHA-256 so raw IPs are never stored in the cache). `RemRateThrottle`, `NPSRateThrottle`, and `PlacesRateThrottle` now each subclass it with just a `scope` declaration. Added `PlacesAutocompleteView` (`AllowAny`, returns empty list on blank input, 502 on upstream HTTP or network errors). The `HTTPError` handler safely reads `e.response.status_code` only when `e.response is not None`, falling back to `"unknown"` to avoid `AttributeError` in edge cases where the exception carries no response object. Imported `GooglePlacesClient`.

- **`screener/urls.py`** — Registered `places/autocomplete/` at `api/places/autocomplete/`. No white-label segment — this endpoint is not tenant-specific.

- **`benefits-api/.env`** — Added `GOOGLE_MAPS_API_KEY=` as an empty placeholder so other developers know the variable is required.

- **`screener/tests/test_places_autocomplete.py`** (new) — 16 tests covering `GooglePlacesClient` (param passing, USA suffix stripping, empty predictions, already-clean descriptions, cache hit skips API call, cache key is case-insensitive, error status raises and is not cached) and `PlacesAutocompleteView` (missing/blank input → 200 empty list, Google API error status → 502, HTTP error → 502, network error → 502, happy path, input trimming).

## Testing

- **Migrations to run:** None.
- **Configuration updates needed:** Set `GOOGLE_MAPS_API_KEY` locally in `benefits-api/.env` with a valid Google Places API key. See the API key note below before provisioning.
- **Environment variables/settings to add:** `GOOGLE_MAPS_API_KEY` in `benefits-api/.env` (local) and as a Heroku config var for staging/production.
- **Manual testing steps:**
  1. Add a valid `GOOGLE_MAPS_API_KEY` to `benefits-api/.env`.
  2. Start the Django dev server.
  3. `curl "http://localhost:8000/api/places/autocomplete/?input=123+Main"` — confirm a JSON array of `{description, place_id}` objects is returned.
  4. Confirm descriptions do not include `, USA`.
  5. `curl "http://localhost:8000/api/places/autocomplete/"` (no input) — confirm `[]` is returned.
  6. Repeat step 3 — the second call returns from cache without hitting the Places API (confirm by checking server logs for outbound requests).
  7. Run `python manage.py test screener.tests.test_places_autocomplete --no-input` — all 16 tests should pass.

## Deployment

- **Post-deployment scripts needed:** None.
- **Production config updates:** Add `GOOGLE_MAPS_API_KEY` as a Heroku config var on both staging and production. This is required before the frontend autocomplete feature will function — the frontend will still render (with a non-functional address field) if the key is absent, but API calls will return 502.
- **Admin updates needed:** None.
- **Notify team/users of:** Notify Caton that the API key must be provisioned with **no HTTP referrer restrictions** (referrer restrictions are enforced by checking the browser `Referer` header, which server-to-server requests do not send — Google will return `REQUEST_DENIED` for a referrer-restricted key). The correct setup is either unrestricted or IP-restricted, with an **API restriction** scoped to the Places API in Google Cloud Console.

## Notes for Reviewers

- **Caching backend:** The cache uses Django's `default` backend — `LocMemCache` (per-process, in-memory) in local dev, and also in production unless `REDIS_URL` is set. With multiple Heroku dynos each dyno maintains its own warm cache independently, which still eliminates repeat calls within a worker. The `"redis"` backend (cross-dyno) can be wired in later if needed by swapping `cache` for `caches["redis"]` in `google_places.py`.
- **Known limitations:** `AnonRateThrottle` throttles by IP, so users behind a shared IP (office, school) share the `200/hour` limit. This is consistent with how `RemRateThrottle` works and acceptable at current scale.
- **Future considerations:** If USPS delivery-point validation (`dpvConfirmation`) is required, the Google Address Validation API can be added as a second endpoint. Because the autocomplete session would then be linked to a validation request, the autocomplete portion would become free per Google's billing rules.