### PR TITLE
NC: Update estimated savings amount for Medicare Savings Programs

### DIFF
--- a/programs/programs/nc/medicaid/nc_medicare_savings/calculator.py
+++ b/programs/programs/nc/medicaid/nc_medicare_savings/calculator.py
@@ -7,7 +7,7 @@ class MedicareSavingsNC(MedicareSavings):
     ineligible_insurance_types: ClassVar[tuple[str, ...]] = ("va", "medicaid")
     asset_limit: ClassVar[dict[str, int]] = {"single": 9_660, "married": 14_470}
     min_income_percent: ClassVar[float] = 1.0
-    # NC-specific: 2026 Medicare Part B premium ($203/month per eligible member)
+    # NC-specific: 2026 Medicare Part B premium ($202.90/month → rounded to $203/month per eligible member)
     # Source: https://www.cms.gov/newsroom/fact-sheets/2026-medicare-parts-b-premiums-deductibles
     member_amount: ClassVar[int] = 203 * 12
 

--- a/programs/programs/nc/medicaid/nc_medicare_savings/calculator.py
+++ b/programs/programs/nc/medicaid/nc_medicare_savings/calculator.py
@@ -7,6 +7,9 @@ class MedicareSavingsNC(MedicareSavings):
     ineligible_insurance_types: ClassVar[tuple[str, ...]] = ("va", "medicaid")
     asset_limit: ClassVar[dict[str, int]] = {"single": 9_660, "married": 14_470}
     min_income_percent: ClassVar[float] = 1.0
+    # NC-specific: 2026 Medicare Part B premium ($203/month per eligible member)
+    # Source: https://www.cms.gov/newsroom/fact-sheets/2026-medicare-parts-b-premiums-deductibles
+    member_amount: ClassVar[int] = 203 * 12
 
     def member_eligible(self, e: MemberEligibility):
         member = e.member


### PR DESCRIPTION
## Context & Motivation

- Fixes #[MFB-1167](https://linear.app/myfriendben/issue/MFB-1167/nc-update-estimated-savings-amount-for-medicare-savings-programs) NC: Update estimated savings amount for Medicare Savings Programs

## Changes Made

<img width="1001" height="820" alt="Screenshot 2026-06-22 135623" src="https://github.com/user-attachments/assets/bfdfa601-c624-4f24-bf73-552e40d64d0a" />

- Update the estimated monthly savings value for Medicare Savings Programs in the NC configuration from $185/month to $203/month per eligible household member.
Source: https://www.cms.gov/newsroom/fact-sheets/2026-medicare-parts-b-premiums-deductibles

## Testing

- Migrations to run: no
- Configuration updates needed: no
- Environment variables/settings to add: no
- Manual testing steps: 

| # | Scenario | Age | Income | Insurance | Eligible | Benefit Value |
|---|----------|-----|---------|-----------|----------|---------------|
| 1 | Happy path | 67 | $1,500/month pension | Medicare | ✅ | $2,436 |
| 2 | Happy path — no insurance | 67 | $1,500/month pension | None | ✅ | $2,436 |
| 3 | Under income (below 100% FPL floor, NC-specific) | 67 | $1,200/month pension | Medicare | ❌ | — |
| 4 | Over income (above 135% FPL) | 67 | $1,800/month pension | Medicare | ❌ | — |
| 5 | Age below minimum | 64 | $1,500/month pension | Medicare | ❌ | — |
| 6 | VA insurance (NC excludes VA) | 67 | $1,500/month pension | VA | ❌ | — |
| 7 | Medicaid insurance (NC excludes Medicaid) | 67 | $1,500/month pension | Medicaid | ❌ | — |
| 8 | Excess assets ($10,000 > NC single limit $9,660) | 67 | $1,500/month pension | Medicare | ❌ | — |

## Deployment

- Post-deployment scripts needed: no
- Production config updates: no
- Admin updates needed: no
- Notify team/users of:

## Notes for Reviewers

Once the code change is merged, all NC Medicare Savings Program validation tests will for Medicare in NC will fail and need to be revalidated because of the updated value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated North Carolina Medicare Savings calculations to use the 2026 Medicare Part B premium amount for eligible members.
  * This helps ensure savings estimates stay aligned with the latest premium rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->