### PR TITLE
MA: Remove MFB-side CSFP county filter (rely on PE)

### DIFF
--- a/programs/programs/ma/pe/member.py
+++ b/programs/programs/ma/pe/member.py
@@ -356,11 +356,6 @@ class MaCsfp(CommoditySupplementalFoodProgram):
         dependency.household.MaCountyDependency,
     ]
 
-    def member_value(self, member: HouseholdMember):
-        if self.screen.has_benefit("ma_csfp"):
-            return 0
-        return super().member_value(member)
-
 
 class MaEarlyHeadStart(PolicyEngineMembersCalculator):
     pe_name = "early_head_start"

--- a/programs/programs/ma/pe/member.py
+++ b/programs/programs/ma/pe/member.py
@@ -350,33 +350,11 @@ class MaHeadStart(PolicyEngineMembersCalculator):
 
 
 class MaCsfp(CommoditySupplementalFoodProgram):
-    """
-    Massachusetts Commodity Supplemental Food Program (CSFP) calculator.
-    Extends the federal CSFP calculator with MA state code dependency and county filtering.
-    Only available in specific MA counties served by Greater Boston Food Bank.
-    """
-
-    eligible_counties = [
-        "Bristol",
-        "Essex",
-        "Middlesex",
-        "Norfolk",
-        "Plymouth",
-        "Suffolk",
-        "Worcester",
-    ]
-
     pe_inputs = [
         *CommoditySupplementalFoodProgram.pe_inputs,
         dependency.household.MaStateCodeDependency,
+        dependency.household.MaCountyDependency,
     ]
-
-    def member_value(self, member: HouseholdMember):
-        # County filtering - return 0 if not in eligible county
-        if self.screen.county not in self.eligible_counties:
-            return 0
-
-        return super().member_value(member)
 
 
 class MaEarlyHeadStart(PolicyEngineMembersCalculator):

--- a/programs/programs/ma/pe/member.py
+++ b/programs/programs/ma/pe/member.py
@@ -356,6 +356,11 @@ class MaCsfp(CommoditySupplementalFoodProgram):
         dependency.household.MaCountyDependency,
     ]
 
+    def member_value(self, member: HouseholdMember):
+        if self.screen.has_benefit("ma_csfp"):
+            return 0
+        return super().member_value(member)
+
 
 class MaEarlyHeadStart(PolicyEngineMembersCalculator):
     pe_name = "early_head_start"

--- a/programs/programs/ma/pe/tests/test_csfp.py
+++ b/programs/programs/ma/pe/tests/test_csfp.py
@@ -3,16 +3,14 @@ Unit tests for MaCsfp PolicyEngine calculator class.
 
 These tests verify MA-specific calculator logic for CSFP including:
 - MaCsfp calculator registration and configuration
-- MA-specific pe_inputs (MaStateCodeDependency)
-- County filtering behavior
+- MA-specific pe_inputs (MaStateCodeDependency, MaCountyDependency)
 """
 
 from django.test import TestCase
-from unittest.mock import Mock, MagicMock
 
 from programs.programs.federal.pe.member import CommoditySupplementalFoodProgram
 from programs.programs.policyengine.calculators.dependencies import household
-from programs.programs.policyengine.calculators.dependencies.household import MaStateCodeDependency
+from programs.programs.policyengine.calculators.dependencies.household import MaStateCodeDependency, MaCountyDependency
 from programs.programs.ma.pe import ma_pe_calculators
 from programs.programs.ma.pe.member import MaCsfp
 
@@ -21,223 +19,37 @@ class TestMaCsfp(TestCase):
     """Tests for MaCsfp calculator class."""
 
     def test_exists_and_is_subclass_of_csfp(self):
-        """
-        Test that MaCsfp calculator class exists and is registered.
-
-        This verifies the calculator has been set up in the codebase.
-        """
-        # Verify MaCsfp is a subclass of CommoditySupplementalFoodProgram
         self.assertTrue(issubclass(MaCsfp, CommoditySupplementalFoodProgram))
-
-        # Verify it has the expected properties
         self.assertEqual(MaCsfp.pe_name, "commodity_supplemental_food_program")
-        self.assertIsNotNone(MaCsfp.pe_inputs)
-        self.assertGreater(len(MaCsfp.pe_inputs), 0)
 
     def test_is_registered_in_ma_pe_calculators(self):
-        """Test that MA CSFP is registered in the calculators dictionary."""
-        # Verify ma_csfp is in the calculators dictionary
         self.assertIn("ma_csfp", ma_pe_calculators)
-
-        # Verify it points to the correct class
         self.assertEqual(ma_pe_calculators["ma_csfp"], MaCsfp)
 
-    def test_pe_inputs_includes_all_parent_inputs_plus_ma_specific(self):
-        """
-        Test that MaCsfp has all expected pe_inputs from parent and MA-specific.
-
-        MaCsfp should inherit all inputs from parent CommoditySupplementalFoodProgram class plus add
-        MA-specific dependencies like MaStateCodeDependency.
-        """
-        # MaCsfp should have all parent inputs plus MaStateCodeDependency
-        self.assertGreater(len(MaCsfp.pe_inputs), len(CommoditySupplementalFoodProgram.pe_inputs))
-
-        # Verify MaStateCodeDependency is in the list
-        self.assertIn(household.MaStateCodeDependency, MaCsfp.pe_inputs)
-
-        # Verify all parent inputs are present
-        for parent_input in CommoditySupplementalFoodProgram.pe_inputs:
-            self.assertIn(parent_input, MaCsfp.pe_inputs)
-
     def test_pe_inputs_includes_ma_state_code_dependency(self):
-        """
-        Test that MaStateCodeDependency is properly added to MA CSFP inputs.
-
-        This is the key MA-specific dependency that sets state_code="MA" for
-        PolicyEngine calculations.
-        """
-        # Verify MaStateCodeDependency is in pe_inputs
         self.assertIn(MaStateCodeDependency, MaCsfp.pe_inputs)
-
-        # Verify it's configured correctly
         self.assertEqual(MaStateCodeDependency.state, "MA")
         self.assertEqual(MaStateCodeDependency.field, "state_code")
 
+    def test_pe_inputs_includes_ma_county_dependency(self):
+        self.assertIn(MaCountyDependency, MaCsfp.pe_inputs)
+        self.assertEqual(MaCountyDependency.state_dependency_class, MaStateCodeDependency)
+
+    def test_pe_inputs_includes_all_parent_inputs(self):
+        for parent_input in CommoditySupplementalFoodProgram.pe_inputs:
+            self.assertIn(parent_input, MaCsfp.pe_inputs)
+
     def test_pe_inputs_includes_age_dependency(self):
-        """Test that MaCsfp inherits AgeDependency from parent CommoditySupplementalFoodProgram class."""
         from programs.programs.policyengine.calculators.dependencies.member import AgeDependency
 
         self.assertIn(AgeDependency, MaCsfp.pe_inputs)
         self.assertEqual(AgeDependency.field, "age")
 
     def test_pe_inputs_includes_school_meal_countable_income_dependency(self):
-        """Test that MaCsfp inherits SchoolMealCountableIncomeDependency from parent CommoditySupplementalFoodProgram class."""
         from programs.programs.policyengine.calculators.dependencies.spm import SchoolMealCountableIncomeDependency
 
         self.assertIn(SchoolMealCountableIncomeDependency, MaCsfp.pe_inputs)
         self.assertEqual(SchoolMealCountableIncomeDependency.field, "school_meal_countable_income")
 
     def test_has_same_pe_outputs_as_parent(self):
-        """Test that MaCsfp has the same pe_outputs as parent CommoditySupplementalFoodProgram class."""
-        # MaCsfp should use the same outputs as parent
         self.assertEqual(MaCsfp.pe_outputs, CommoditySupplementalFoodProgram.pe_outputs)
-
-    def test_eligible_counties_are_defined(self):
-        """Test that MaCsfp has eligible counties defined."""
-        expected_counties = [
-            "Bristol",
-            "Essex",
-            "Middlesex",
-            "Norfolk",
-            "Plymouth",
-            "Suffolk",
-            "Worcester",
-        ]
-        self.assertEqual(MaCsfp.eligible_counties, expected_counties)
-
-    def test_member_value_returns_pe_value_when_in_eligible_county(self):
-        """
-        Test that member_value returns PolicyEngine value when member is in eligible county.
-
-        When a screen's county is in the eligible_counties list, the full
-        PolicyEngine-calculated value should be returned.
-        """
-        # Create a mock MaCsfp calculator instance
-        mock_screen = Mock()
-        mock_screen.county = "Suffolk"  # Eligible county
-
-        calculator = MaCsfp(mock_screen, Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock the get_member_variable method to return a value
-        pe_value = 600
-        calculator.get_member_variable = Mock(return_value=pe_value)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Verify the result is the PolicyEngine value
-        self.assertEqual(result, pe_value)
-        calculator.get_member_variable.assert_called_once_with(1)
-
-    def test_member_value_returns_zero_when_not_in_eligible_county(self):
-        """
-        Test that member_value returns 0 when member is not in eligible county.
-
-        If the screen's county is not in the eligible_counties list, the member
-        should not be eligible and member_value should return 0.
-        """
-        # Create a mock MaCsfp calculator instance
-        mock_screen = Mock()
-        mock_screen.county = "Berkshire"  # Not an eligible county
-
-        calculator = MaCsfp(mock_screen, Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock the get_member_variable method to return a value
-        pe_value = 600
-        calculator.get_member_variable = Mock(return_value=pe_value)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Verify the result is 0 (county not eligible)
-        self.assertEqual(result, 0)
-        # get_member_variable should NOT be called because county check fails first
-        calculator.get_member_variable.assert_not_called()
-
-    def test_member_value_county_check_happens_before_pe_call(self):
-        """
-        Test that county eligibility check occurs before calling PolicyEngine.
-
-        The county check should short-circuit and not make the PE API call
-        if the county is not eligible.
-        """
-        # Create a mock MaCsfp calculator instance
-        mock_screen = Mock()
-        mock_screen.county = "Hampden"  # Not an eligible county
-
-        calculator = MaCsfp(mock_screen, Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock the get_member_variable method
-        calculator.get_member_variable = Mock(return_value=600)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Should return 0 without calling PE
-        self.assertEqual(result, 0)
-        calculator.get_member_variable.assert_not_called()
-
-    def test_member_value_with_each_eligible_county(self):
-        """
-        Test that member_value returns PE value for each eligible county.
-
-        Verify all 7 eligible counties work correctly.
-        """
-        pe_value = 600
-
-        for county in MaCsfp.eligible_counties:
-            with self.subTest(county=county):
-                mock_screen = Mock()
-                mock_screen.county = county
-
-                calculator = MaCsfp(mock_screen, Mock(), Mock())
-                calculator._sim = MagicMock()
-                calculator.get_member_variable = Mock(return_value=pe_value)
-
-                member = Mock()
-                member.id = 1
-
-                result = calculator.member_value(member)
-                self.assertEqual(result, pe_value)
-
-    def test_member_value_with_zero_pe_value_and_eligible_county(self):
-        """
-        Test that member_value returns 0 when PolicyEngine returns 0, even in eligible county.
-
-        If PolicyEngine determines no benefit value (e.g., member is under 60),
-        it should be returned as-is even though county is eligible.
-        """
-        # Create a mock MaCsfp calculator instance
-        mock_screen = Mock()
-        mock_screen.county = "Suffolk"  # Eligible county
-
-        calculator = MaCsfp(mock_screen, Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock zero PolicyEngine value
-        calculator.get_member_variable = Mock(return_value=0)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Should return 0 (PE says not eligible)
-        self.assertEqual(result, 0)

--- a/programs/programs/policyengine/calculators/dependencies/household.py
+++ b/programs/programs/policyengine/calculators/dependencies/household.py
@@ -72,6 +72,10 @@ class IlCountyDependency(CountyDependency):
     state_dependency_class = IlStateCodeDependency
 
 
+class MaCountyDependency(CountyDependency):
+    state_dependency_class = MaStateCodeDependency
+
+
 class TxCountyDependency(CountyDependency):
     state_dependency_class = TxStateCodeDependency
 

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
@@ -1,39 +1,85 @@
 """
-Unit tests for household-level PolicyEngine dependencies used by TxSnap.
+Unit tests for household-level PolicyEngine dependencies.
 
-These dependencies calculate household-level values used by PolicyEngine
-to determine TX SNAP eligibility and benefit amounts.
+These tests verify all classes in
+programs/programs/policyengine/calculators/dependencies/household.py:
+state-code dependencies, county dependencies, zip-code dependency, and
+the public-housing dependency.
 """
 
 from django.test import TestCase
-from screener.models import Screen, WhiteLabel
+from screener.models import Expense, Screen, WhiteLabel
 from programs.programs.policyengine.calculators.dependencies import household
 
 
-class TestTxStateCodeDependency(TestCase):
-    """Tests for TxStateCodeDependency class used by TxSnap calculator."""
-
+class TestCoStateCodeDependency(TestCase):
     def setUp(self):
-        """Set up test data for state dependency tests."""
         self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="80202", county="Denver County", household_size=1, completed=False
+        )
 
+    def test_value_returns_co_state_code(self):
+        dep = household.CoStateCodeDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), "CO")
+        self.assertEqual(dep.field, "state_code")
+
+
+class TestNcStateCodeDependency(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="27601", county="Wake County", household_size=1, completed=False
+        )
+
+    def test_value_returns_nc_state_code(self):
+        dep = household.NcStateCodeDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), "NC")
+        self.assertEqual(dep.field, "state_code")
+
+
+class TestMaStateCodeDependency(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
+        )
+
+    def test_value_returns_ma_state_code(self):
+        dep = household.MaStateCodeDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), "MA")
+        self.assertEqual(dep.field, "state_code")
+
+
+class TestIlStateCodeDependency(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="60601", county="Cook County", household_size=1, completed=False
+        )
+
+    def test_value_returns_il_state_code(self):
+        dep = household.IlStateCodeDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), "IL")
+        self.assertEqual(dep.field, "state_code")
+
+
+class TestTxStateCodeDependency(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
         self.screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="Test County", household_size=1, completed=False
         )
 
     def test_value_returns_tx_state_code(self):
-        """Test value() returns TX state code."""
         dep = household.TxStateCodeDependency(self.screen, None, {})
         self.assertEqual(dep.value(), "TX")
         self.assertEqual(dep.field, "state_code")
 
 
 class TestWaStateCodeDependency(TestCase):
-    """Tests for WaStateCodeDependency class used by WaLifeline calculator."""
-
     def setUp(self):
         self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
-
         self.screen = Screen.objects.create(
             white_label=self.white_label, zipcode="98101", county="King County", household_size=1, completed=False
         )
@@ -45,13 +91,35 @@ class TestWaStateCodeDependency(TestCase):
 
 
 class TestCountyDependency(TestCase):
-    """Tests for CountyDependency class and its subclasses."""
+    """Tests for CountyDependency base class and all concrete subclasses."""
 
     def setUp(self):
         self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
 
+    # --- subclass configuration ---
+
+    def test_nc_county_dependency_state_dependency_class(self):
+        self.assertIs(household.NcCountyDependency.state_dependency_class, household.NcStateCodeDependency)
+
+    def test_il_county_dependency_state_dependency_class(self):
+        self.assertIs(household.IlCountyDependency.state_dependency_class, household.IlStateCodeDependency)
+
+    def test_ma_county_dependency_state_dependency_class(self):
+        self.assertIs(household.MaCountyDependency.state_dependency_class, household.MaStateCodeDependency)
+
+    def test_tx_county_dependency_state_dependency_class(self):
+        self.assertIs(household.TxCountyDependency.state_dependency_class, household.TxStateCodeDependency)
+
+    def test_ma_county_dependency_value_formats_correctly(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
+        )
+        dep = household.MaCountyDependency(screen, None, {})
+        self.assertEqual(dep.value(), "SUFFOLK_COUNTY_MA")
+
+    # --- shared normalization (via NcCountyDependency as representative subclass) ---
+
     def test_county_without_county_suffix_appends_county(self):
-        """County names without 'County' should have '_COUNTY_' appended."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="Suffolk", household_size=1, completed=False
         )
@@ -59,7 +127,6 @@ class TestCountyDependency(TestCase):
         self.assertEqual(dep.value(), "SUFFOLK_COUNTY_NC")
 
     def test_county_with_county_suffix_does_not_duplicate(self):
-        """County names already containing 'County' should not get it duplicated."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="Denver County", household_size=1, completed=False
         )
@@ -67,7 +134,6 @@ class TestCountyDependency(TestCase):
         self.assertEqual(dep.value(), "DENVER_COUNTY_NC")
 
     def test_county_normalization_removes_special_characters(self):
-        """Special characters should be removed from county names."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="St. Mary's County", household_size=1, completed=False
         )
@@ -75,7 +141,6 @@ class TestCountyDependency(TestCase):
         self.assertEqual(dep.value(), "ST_MARYS_COUNTY_TX")
 
     def test_county_normalization_handles_multiple_spaces(self):
-        """Multiple spaces should be normalized to single underscores."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="New   York", household_size=1, completed=False
         )
@@ -83,7 +148,6 @@ class TestCountyDependency(TestCase):
         self.assertEqual(dep.value(), "NEW_YORK_COUNTY_IL")
 
     def test_county_strips_whitespace(self):
-        """Leading and trailing whitespace should be stripped."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="  Travis County  ", household_size=1, completed=False
         )
@@ -91,7 +155,6 @@ class TestCountyDependency(TestCase):
         self.assertEqual(dep.value(), "TRAVIS_COUNTY_TX")
 
     def test_county_missing_raises_error(self):
-        """Missing county should raise ValueError."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county=None, household_size=1, completed=False
         )
@@ -101,7 +164,6 @@ class TestCountyDependency(TestCase):
         self.assertEqual(str(context.exception), "county missing")
 
     def test_base_class_without_state_dependency_raises_error(self):
-        """Base CountyDependency without state_dependency_class should raise ValueError."""
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="78701", county="Test County", household_size=1, completed=False
         )
@@ -109,3 +171,50 @@ class TestCountyDependency(TestCase):
         with self.assertRaises(ValueError) as context:
             dep.value()
         self.assertIn("must define state_dependency_class", str(context.exception))
+
+
+class TestZipCodeDependency(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+
+    def test_value_returns_zipcode(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
+        )
+        dep = household.ZipCodeDependency(screen, None, {})
+        self.assertEqual(dep.value(), "02101")
+
+    def test_field_and_dependencies(self):
+        self.assertEqual(household.ZipCodeDependency.field, "zip_code")
+        self.assertIn("zipcode", household.ZipCodeDependency.dependencies)
+
+
+class TestIsInPublicHousingDependency(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+
+    def test_returns_true_when_subsidized_rent_expense_present(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
+        )
+        Expense.objects.create(screen=screen, type="subsidizedRent", amount=500, frequency="monthly")
+        dep = household.IsInPublicHousingDependency(screen, None, {})
+        self.assertTrue(dep.value())
+
+    def test_returns_false_when_no_subsidized_rent_expense(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
+        )
+        Expense.objects.create(screen=screen, type="rent", amount=1000, frequency="monthly")
+        dep = household.IsInPublicHousingDependency(screen, None, {})
+        self.assertFalse(dep.value())
+
+    def test_returns_false_when_no_expenses(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
+        )
+        dep = household.IsInPublicHousingDependency(screen, None, {})
+        self.assertFalse(dep.value())
+
+    def test_field(self):
+        self.assertEqual(household.IsInPublicHousingDependency.field, "is_in_public_housing")

--- a/validations/management/commands/import_validations/data/ma_csfp.json
+++ b/validations/management/commands/import_validations/data/ma_csfp.json
@@ -195,32 +195,6 @@
     }
   },
   {
-    "notes": "MA CSFP - Eligible: Senior in Worcester County with monthly income below 150% FPL",
-    "household": {
-      "white_label": "ma",
-      "zipcode": "01601",
-      "county": "Worcester",
-      "household_size": 1,
-      "household_members": [
-        {
-          "relationship": "headOfHousehold",
-          "age": 63,
-          "has_income": true,
-          "income_streams": [
-            { "type": "wages", "amount": 1733, "frequency": "monthly" }
-          ],
-          "insurance": { "none": true }
-        }
-      ],
-      "expenses": []
-    },
-    "expected_results": {
-      "program_name": "ma_csfp",
-      "eligible": true,
-      "value": 601
-    }
-  },
-  {
     "notes": "MA CSFP - Eligible: Senior with zero income in Essex County",
     "household": {
       "white_label": "ma",

--- a/validations/management/commands/import_validations/data/ma_csfp.json
+++ b/validations/management/commands/import_validations/data/ma_csfp.json
@@ -51,7 +51,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Ineligible: Non-eligible county (Berkshire not served by PE county filter)",
+    "notes": "MA CSFP - Ineligible: Berkshire is not an eligible county for CSFP",
     "household": {
       "white_label": "ma",
       "zipcode": "01201",
@@ -297,7 +297,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Ineligible: Non-eligible county (Hampden not served by PE county filter)",
+    "notes": "MA CSFP - Ineligible: Hampden is not an eligible county for CSFP",
     "household": {
       "white_label": "ma",
       "zipcode": "01103",
@@ -322,7 +322,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Ineligible: Non-eligible county (Franklin not served by PE county filter)",
+    "notes": "MA CSFP - Ineligible: Franklin is not an eligible county for CSFP",
     "household": {
       "white_label": "ma",
       "zipcode": "01301",

--- a/validations/management/commands/import_validations/data/ma_csfp.json
+++ b/validations/management/commands/import_validations/data/ma_csfp.json
@@ -22,7 +22,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {
@@ -130,11 +130,11 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {
-    "notes": "MA CSFP - Eligible: Two seniors 60+ in household (both qualify for $330 each)",
+    "notes": "MA CSFP - Eligible: Two seniors 60+ in household (both qualify for $601 each)",
     "household": {
       "white_label": "ma",
       "zipcode": "02101",
@@ -165,7 +165,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 660
+      "value": 1202
     }
   },
   {
@@ -175,7 +175,7 @@
       "zipcode": "02101",
       "county": "Suffolk",
       "household_size": 1,
-      "has_csfp": true,
+      "current_benefits": ["ma_csfp"],
       "household_members": [
         {
           "relationship": "headOfHousehold",
@@ -195,7 +195,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Eligible: Weekly income converted to monthly stays under 150% FPL in Worcester County",
+    "notes": "MA CSFP - Eligible: Senior in Worcester County with monthly income below 150% FPL",
     "household": {
       "white_label": "ma",
       "zipcode": "01601",
@@ -207,7 +207,7 @@
           "age": 63,
           "has_income": true,
           "income_streams": [
-            { "type": "wages", "amount": 400, "frequency": "weekly" }
+            { "type": "wages", "amount": 1733, "frequency": "monthly" }
           ],
           "insurance": { "none": true }
         }
@@ -217,7 +217,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {
@@ -241,7 +241,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {
@@ -267,7 +267,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {
@@ -293,7 +293,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {
@@ -319,7 +319,7 @@
     "expected_results": {
       "program_name": "ma_csfp",
       "eligible": true,
-      "value": 330
+      "value": 601
     }
   },
   {

--- a/validations/management/commands/import_validations/data/ma_csfp.json
+++ b/validations/management/commands/import_validations/data/ma_csfp.json
@@ -51,7 +51,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Ineligible: Non-eligible county (Berkshire not in eligible list)",
+    "notes": "MA CSFP - Ineligible: Non-eligible county (Berkshire not served by PE county filter)",
     "household": {
       "white_label": "ma",
       "zipcode": "01201",
@@ -323,7 +323,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Ineligible: Non-eligible county (Hampden not in eligible list)",
+    "notes": "MA CSFP - Ineligible: Non-eligible county (Hampden not served by PE county filter)",
     "household": {
       "white_label": "ma",
       "zipcode": "01103",
@@ -348,7 +348,7 @@
     }
   },
   {
-    "notes": "MA CSFP - Ineligible: Non-eligible county (Franklin not in eligible list)",
+    "notes": "MA CSFP - Ineligible: Non-eligible county (Franklin not served by PE county filter)",
     "household": {
       "white_label": "ma",
       "zipcode": "01301",


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Closes [MFB-1044](https://linear.app/myfriendben/issue/MFB-1044/ma-remove-mfb-side-csfp-county-filter-rely-on-pe)
- PE has merged the CSFP county-filter update for MA (MFB-1063, Done), so the MFB-side layer is now redundant and risks drifting from PE's source of truth.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- Removed `eligible_counties` list and `member_value` county-filter override from `MaCsfp` in `ma/pe/member.py`
- Added `MaCountyDependency` to `MaCsfp.pe_inputs` so PE receives `county_str` and can apply its own county filter
- Added `MaCountyDependency` class to `policyengine/calculators/dependencies/household.py` (follows same pattern as `NcCountyDependency`, `IlCountyDependency`, `TxCountyDependency`)
- Removed 6 tests that covered MFB-side county-filter behavior; updated remaining tests to assert named PE input dependencies
- Updated `ma_csfp.json` validation notes for ineligible-county scenarios to reflect PE now handles the filtering

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - Run `python manage.py test programs.programs.ma.pe.tests.test_csfp`
  - Run validations for `ma_csfp` against a live PE environment to confirm served counties (e.g. Suffolk) return eligible and unserved counties (e.g. Berkshire, Hampden, Franklin) return ineligible

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: none

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- The county-ineligibility scenarios in `ma_csfp.json` still expect `false` — the mechanism changed (PE instead of MFB) but the expected outcomes are the same. Running validations post-deploy will confirm PE's filter matches what we had.
- `MaCountyDependency` formats county as `SUFFOLK_COUNTY_MA` (same normalization logic as other state county dependencies) — PE must accept this format for MA CSFP county lookups.