### PR TITLE
KS SNAP: fix categorical/disability inputs, correct spec values, expand coverage

### DIFF
--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -10,24 +10,15 @@ SNAP_BASE_INPUTS = [
     dependency.member.AgeDependency,
     dependency.member.MedicalExpenseDependency,
     dependency.member.IsDisabledDependency,
-    # Reported SSI receipt. PE's `meets_snap_categorical_eligibility` keys off the computed
-    # `ssi` variable, so a real SSI recipient whose unearned income is high enough that PE
-    # recomputes `ssi = 0` would otherwise be denied categorical eligibility (and the
-    # elderly/disabled asset limit). Feeding reported SSI as the `ssi` input — the same
-    # pattern other calculators use — lets actual receipt drive categorical eligibility.
+    # SSI and TANF cash receipt drive SNAP categorical eligibility (income/asset tests
+    # bypassed); both feed the reported amount so PE consumers that read the dollar value
+    # (e.g. spm_unit_benefits, tx_ceap income) stay correct.
     dependency.member.Ssi,
-    # Reported TANF cash receipt. A household receiving cash TANF is categorically eligible for
-    # SNAP — income and asset tests bypassed (7 CFR 273.2(j)(2)). PE honors `tanf` in its SNAP
-    # `categorical_eligibility` list, so feeding reported receipt as the `tanf` input drives
-    # categorical eligibility the same way `Ssi` does. (The dependency reads has_base_benefit so
-    # every white-label variant — ks_tanf, co_tanf, ma_tafdc … — counts.)
     dependency.spm.Tanf,
-    # PE's SNAP elderly/disabled treatment (uncapped excess-shelter deduction and the higher
-    # $4,500 asset limit) keys off `is_usda_disabled`, which requires receipt of a qualifying
-    # disability program — NOT the generic `is_disabled` flag. SsdiReportedDependency feeds
-    # the SSDI benefit amount so a disabled applicant on SSDI gets the disabled treatment
-    # (otherwise the shelter deduction is wrongly capped). MeetsSsiDisabilityCriteriaDependency
-    # is version-gated and only takes effect once a supporting PE version is pinned.
+    # Disabled treatment (uncapped shelter deduction, $4,500 asset limit) requires disability-
+    # program receipt via is_usda_disabled, not the generic is_disabled flag: SsdiReportedDependency
+    # feeds the SSDI amount, MeetsSsiDisabilityCriteriaDependency the SSI-disability input PE needs
+    # (both version-gated; see the dependency classes).
     dependency.member.SsdiReportedDependency,
     dependency.member.MeetsSsiDisabilityCriteriaDependency,
     dependency.spm.SnapEmergencyAllotmentDependency,

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -10,6 +10,20 @@ SNAP_BASE_INPUTS = [
     dependency.member.AgeDependency,
     dependency.member.MedicalExpenseDependency,
     dependency.member.IsDisabledDependency,
+    # Reported SSI receipt. PE's `meets_snap_categorical_eligibility` keys off the computed
+    # `ssi` variable, so a real SSI recipient whose unearned income is high enough that PE
+    # recomputes `ssi = 0` would otherwise be denied categorical eligibility (and the
+    # elderly/disabled asset limit). Feeding reported SSI as the `ssi` input — the same
+    # pattern other calculators use — lets actual receipt drive categorical eligibility.
+    dependency.member.Ssi,
+    # PE's SNAP elderly/disabled treatment (uncapped excess-shelter deduction and the higher
+    # $4,500 asset limit) keys off `is_usda_disabled`, which requires receipt of a qualifying
+    # disability program — NOT the generic `is_disabled` flag. SsdiReportedDependency feeds
+    # the SSDI benefit amount so a disabled applicant on SSDI gets the disabled treatment
+    # (otherwise the shelter deduction is wrongly capped). MeetsSsiDisabilityCriteriaDependency
+    # is version-gated and only takes effect once a supporting PE version is pinned.
+    dependency.member.SsdiReportedDependency,
+    dependency.member.MeetsSsiDisabilityCriteriaDependency,
     dependency.spm.SnapEmergencyAllotmentDependency,
     dependency.spm.HousingCostDependency,
     dependency.spm.HasPhoneExpenseDependency,

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -10,13 +10,15 @@ SNAP_BASE_INPUTS = [
     dependency.member.AgeDependency,
     dependency.member.MedicalExpenseDependency,
     dependency.member.IsDisabledDependency,
-    # SSI and TANF cash receipt drive SNAP categorical eligibility (income/asset tests
-    # bypassed). SSI feeds reported receipt through PE's own seam: ssi_reported + the
-    # use_reported_ssi flag make PE's applicable_ssi reflect actual receipt, without
-    # overriding the computed ssi output. TANF has no such seam, so it sends the reported
-    # amount directly as the tanf value.
-    dependency.member.SsiReportedDependency,
-    dependency.member.UseReportedSsiDependency,
+    # TANF cash receipt drives SNAP categorical eligibility (income/asset tests bypassed):
+    # send the reported tanf amount directly as the tanf value. TANF has no reported/toggle
+    # seam, so a positive tanf value is what confers categorical eligibility.
+    #
+    # SSI categorical eligibility is deliberately NOT wired here. It requires
+    # use_reported_ssi, which is global per PE request (flips applicable_ssi for every
+    # program in the request — SNAP, IL AABD, KS TANF, TX CEAP), so it's a federal
+    # all-state change with cross-program effects (verified IL AABD $0->$10k swing).
+    # That work lives in MFB-1312 with all-consumer QA, not in this KS SNAP PR.
     dependency.spm.Tanf,
     # Disabled treatment (uncapped shelter deduction, $4,500 asset limit) requires disability-
     # program receipt via is_usda_disabled, not the generic is_disabled flag: SsdiReportedDependency

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -11,9 +11,12 @@ SNAP_BASE_INPUTS = [
     dependency.member.MedicalExpenseDependency,
     dependency.member.IsDisabledDependency,
     # SSI and TANF cash receipt drive SNAP categorical eligibility (income/asset tests
-    # bypassed); both feed the reported amount so PE consumers that read the dollar value
-    # (e.g. spm_unit_benefits, tx_ceap income) stay correct.
-    dependency.member.Ssi,
+    # bypassed). SSI feeds reported receipt through PE's own seam: ssi_reported + the
+    # use_reported_ssi flag make PE's applicable_ssi reflect actual receipt, without
+    # overriding the computed ssi output. TANF has no such seam, so it sends the reported
+    # amount directly as the tanf value.
+    dependency.member.SsiReportedDependency,
+    dependency.member.UseReportedSsiDependency,
     dependency.spm.Tanf,
     # Disabled treatment (uncapped shelter deduction, $4,500 asset limit) requires disability-
     # program receipt via is_usda_disabled, not the generic is_disabled flag: SsdiReportedDependency

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -16,6 +16,11 @@ SNAP_BASE_INPUTS = [
     # elderly/disabled asset limit). Feeding reported SSI as the `ssi` input — the same
     # pattern other calculators use — lets actual receipt drive categorical eligibility.
     dependency.member.Ssi,
+    # Reported TANF cash receipt. PE doesn't yet honor `tanf` for SNAP categorical eligibility
+    # in non-BBCE states (it's modeled for IL / via the BBCE non-cash path only), so this has no
+    # effect for KS today — but sending it now means the categorical path is correctly armed and
+    # will work the moment PE adds `tanf` to its SNAP categorical_eligibility list. Mirrors `Ssi`.
+    dependency.spm.Tanf,
     # PE's SNAP elderly/disabled treatment (uncapped excess-shelter deduction and the higher
     # $4,500 asset limit) keys off `is_usda_disabled`, which requires receipt of a qualifying
     # disability program — NOT the generic `is_disabled` flag. SsdiReportedDependency feeds

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -16,10 +16,11 @@ SNAP_BASE_INPUTS = [
     # elderly/disabled asset limit). Feeding reported SSI as the `ssi` input — the same
     # pattern other calculators use — lets actual receipt drive categorical eligibility.
     dependency.member.Ssi,
-    # Reported TANF cash receipt. PE doesn't yet honor `tanf` for SNAP categorical eligibility
-    # in non-BBCE states (it's modeled for IL / via the BBCE non-cash path only), so this has no
-    # effect for KS today — but sending it now means the categorical path is correctly armed and
-    # will work the moment PE adds `tanf` to its SNAP categorical_eligibility list. Mirrors `Ssi`.
+    # Reported TANF cash receipt. A household receiving cash TANF is categorically eligible for
+    # SNAP — income and asset tests bypassed (7 CFR 273.2(j)(2)). PE honors `tanf` in its SNAP
+    # `categorical_eligibility` list, so feeding reported receipt as the `tanf` input drives
+    # categorical eligibility the same way `Ssi` does. (The dependency reads has_base_benefit so
+    # every white-label variant — ks_tanf, co_tanf, ma_tafdc … — counts.)
     dependency.spm.Tanf,
     # PE's SNAP elderly/disabled treatment (uncapped excess-shelter deduction and the higher
     # $4,500 asset limit) keys off `is_usda_disabled`, which requires receipt of a qualifying

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -172,10 +172,12 @@ for reference.
 >
 > **Categorical & disability inputs (fixed in this PR).** SNAP now sends the `Ssi` dependency
 > (reported SSI receipt → PE's computed `ssi`), so an all-SSI household is correctly categorically
-> eligible (**Scenario 8**, previously denied). It also sends `SsdiReportedDependency` so a disabled
-> SSDI recipient receives the elderly/disabled treatment — the uncapped excess-shelter deduction and
-> the higher $4,500 asset limit (**Scenario 17**). Both bypass the income/asset tests via PE's
-> `meets_snap_categorical_eligibility` / `is_usda_disabled` rather than any MFB post-hoc override.
+> eligible (**Scenario 8**, previously denied) via PE's `meets_snap_categorical_eligibility`, which
+> bypasses the income/asset tests. It also sends `SsdiReportedDependency` so a disabled SSDI
+> recipient receives the elderly/disabled treatment — no gross-income test, the higher $4,500 asset
+> limit, and the uncapped excess-shelter deduction (**Scenario 17**) — through PE's `is_usda_disabled`.
+> (The disabled treatment applies the elderly/disabled *rules*; it does not categorically bypass the
+> tests the way the SSI path does.) Neither relies on an MFB post-hoc override.
 >
 > **⛔ Two scenarios are blocked on PolicyEngine and intentionally fail today:**
 > - **Scenario 10** (student with a job-training/E&T exemption): PE's `is_snap_ineligible_student`

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -148,7 +148,7 @@ for reference.
 - [ ] Scenario 5 (Net Income Test Failure — Gross Passes, Net Fails): **ineligible** ($0)
 - [ ] Scenario 6 (Non-Elderly Household — Assets Above $3,000): **ineligible** ($0)
 - [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**, **$276/yr ($23/mo)**
-- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**, **$1,080/yr ($90/mo)**
+- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**, **$1,080/yr ($90/mo)** — ⏸️ *deferred to MFB-1312 (SSI categorical requires the global `use_reported_ssi` change; not wired in this PR)*
 - [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible** ($0)
 - [ ] Scenario 10 (Half-Time Student with Job-Training Exemption): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible** (gated by MFB `already_has` results-layer filter, not raw PE)
@@ -162,7 +162,7 @@ for reference.
 - [ ] Scenario 19 (Half-Time Student Working 20+ Hours/Week): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 20 (Half-Time Student with Federal Work-Study): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 21 (Single Full-Time Student Parent with Dependent Child): **eligible**, **$3,840/yr ($320/mo)**
-- [ ] Scenario 22 (SSI Categorical — Reported Receipt with High Other Income): **eligible**, **$276/yr ($23/mo)**
+- [ ] Scenario 22 (SSI Categorical — Reported Receipt with High Other Income): **eligible**, **$276/yr ($23/mo)** — ⏸️ *deferred to MFB-1312 (SSI categorical requires the global `use_reported_ssi` change; not wired in this PR)*
 
 
 ## Test Scenarios
@@ -320,6 +320,8 @@ for reference.
 ### Scenario 8: Categorical Eligibility — All Members Receive SSI, Income and Assets Above Limits
 
 **What we're checking**: A household in which all members receive SSI is categorically eligible — the income and asset tests are bypassed (criterion 5).
+
+> ⏸️ **Deferred to MFB-1312.** SSI categorical eligibility requires `use_reported_ssi`, which is global per PE request (flips `applicable_ssi` for every program — SNAP, IL AABD, KS TANF, TX CEAP). That federal all-state change (verified IL AABD $0→$10k swing) is out of scope for this KS SNAP PR and is handled in MFB-1312. This scenario does not pass in the code shipping with this PR.
 
 **Expected**: Eligible — $1,080/yr ($90/mo)
 
@@ -571,6 +573,8 @@ for reference.
 ### Scenario 22: SSI Categorical Eligibility — Reported Receipt with High Other Income
 
 **What we're checking**: A household reporting SSI receipt is categorically eligible even when other income is high enough that the modeled SSI amount would compute to $0. Categorical eligibility must key off *reported* receipt, not a recalculated SSI amount (criterion 5, the SSI path).
+
+> ⏸️ **Deferred to MFB-1312.** Same reason as Scenario 8 — the reported-SSI categorical path depends on the global `use_reported_ssi` change tracked in MFB-1312. Not wired in this PR.
 
 **Expected**: Eligible — $276/yr ($23/mo)
 

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -158,7 +158,9 @@ for reference.
 - [ ] Scenario 15 (Asset Test Pass — Below Standard $3,000 Limit): **eligible**, **$1,728/yr ($144/mo)**
 - [ ] Scenario 16 (Large Household of Five): **eligible**, **$7,212/yr ($601/mo)**
 - [ ] Scenario 17 (Disabled Non-Elderly — Uncapped Shelter & $4,500 Asset Limit): **eligible**, **$1,884/yr ($157/mo)**
-- [ ] Scenario 18 (TANF Categorical Eligibility — Cash Recipient, Assets Above Limit): **eligible**
+- [ ] Scenario 18 (TANF Categorical Eligibility — Cash Recipient, Assets Above Limit): **eligible**, **$2,880/yr ($240/mo)**
+- [ ] Scenario 19 (Half-Time Student Working 20+ Hours/Week): **eligible**, **$864/yr ($72/mo)**
+- [ ] Scenario 20 (Half-Time Student with Federal Work-Study): **eligible**, **$864/yr ($72/mo)**
 
 
 ## Test Scenarios
@@ -180,9 +182,9 @@ for reference.
 > it does not categorically bypass the tests the way the SSI/TANF categorical path does.
 >
 > **Student exemptions.** A half-time+ college student aged 18–49 (**Scenario 9**) is an ineligible
-> student unless they meet an exemption — including a job-training / employment-and-training program
-> placement (**Scenario 10**), 20-hr work, work-study, or the parent/child-age exemptions
-> (7 CFR 273.5).
+> student unless they meet an exemption — a job-training / employment-and-training program placement
+> (**Scenario 10**), working 20+ hours/week (**Scenario 19**), federal work-study (**Scenario 20**),
+> or the parent/child-age exemptions (7 CFR 273.5).
 
 ### Scenario 1: Single Adult Worker — Clearly Eligible for Food Assistance
 
@@ -497,17 +499,51 @@ for reference.
 
 **What we're checking**: A household receiving TANF cash assistance should be categorically eligible for SNAP — the income and asset tests are bypassed (criterion 5, the TANF path).
 
-**Expected**: Eligible
+**Expected**: Eligible — $2,880/yr ($240/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
 - **Household**: Number of people: `1`
 - **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: Head of Household, Not a student, No disability, U.S. citizen
-- **Income**: Employment income `$1,000`/month
+- **Income**: Cash assistance (TANF) `$400`/month
 - **Assets**: `$6,000` (above the $3,000 standard limit)
 - **Current Benefits**: Currently receiving TANF cash assistance, Not currently receiving SNAP/Food Assistance, Not receiving SSI
 
-**Why this matters**: TANF cash recipients are categorically eligible for SNAP under 7 U.S.C. § 2014(a); the income and asset tests are bypassed. This household is eligible despite $6,000 in assets (above the $3,000 standard limit). This is the TANF analog to the SSI categorical path in Scenario 8.
+**Why this matters**: TANF cash recipients are categorically eligible for SNAP under 7 U.S.C. § 2014(a); the income and asset tests are bypassed. This household is eligible despite $6,000 in assets (above the $3,000 standard limit), driven by the reported TANF cash amount. This is the TANF analog to the SSI categorical path in Scenario 8.
+
+---
+
+### Scenario 19: Half-Time College Student Working 20+ Hours/Week
+
+**What we're checking**: A half-time college student aged 18–49 who works at least 20 hours per week meets a student exemption (7 CFR 273.5(b)(2)) and is eligible (criterion 7, work-hours exemption).
+
+**Expected**: Eligible — $864/yr ($72/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `66045`, Select county `Douglas`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 2004` (age 22), Relationship: Head of Household, Student status: enrolled in higher education at least half-time, Working 20+ hrs/week, No work-study, No job-training program, No dependent child, No disability
+- **Income**: Employment income `$1,200`/month
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: The 20-hour work exemption is one of the federal student exemptions. A half-time student who would otherwise be an ineligible student qualifies through it, so this household is eligible rather than denied at $0.
+
+---
+
+### Scenario 20: Half-Time College Student with Federal Work-Study
+
+**What we're checking**: A half-time college student aged 18–49 who participates in federal work-study meets a student exemption (7 CFR 273.5(b)(2)) and is eligible (criterion 7, work-study exemption).
+
+**Expected**: Eligible — $864/yr ($72/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `66045`, Select county `Douglas`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 2004` (age 22), Relationship: Head of Household, Student status: enrolled in higher education at least half-time, Participates in federal work-study, Not working 20+ hrs, No job-training program, No dependent child, No disability
+- **Income**: Employment income `$1,200`/month
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Work-study participation is one of the federal student exemptions. A half-time student who would otherwise be an ineligible student qualifies through it, so this household is eligible rather than denied at $0.
 
 
 ## PE Verification

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -136,31 +136,65 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ## Acceptance Criteria
 
-- [ ] Scenario 1 (Single Adult Worker — Clearly Eligible): **eligible**, **$897/yr ($75/mo)**
-- [ ] Scenario 2 (Family of Four — Just Under 130% Gross & 100% Net): **eligible**, **$6,508/yr ($542/mo)**
-- [ ] Scenario 3 (Single Parent HH2 — Gross $1 Below 130% FPL): **eligible**, **$3,589/yr ($299/mo)**
+All dollar values are the expected annual benefit, derived independently from the FY2026 SNAP
+benefit formula (max allotment − 30% of net income, with the standard, 20%-earned-income, and
+excess-shelter/SUA deductions) and confirmed against the calculator. Monthly figures are shown
+for reference.
+
+- [ ] Scenario 1 (Single Adult Worker — Clearly Eligible): **eligible**, **$864/yr ($72/mo)**
+- [ ] Scenario 2 (Family of Four — Just Under 130% Gross & 100% Net): **eligible**, **$6,432/yr ($536/mo)**
+- [ ] Scenario 3 (Single Parent HH2 — Gross $1 Below 130% FPL): **eligible**, **$3,540/yr ($295/mo)**
 - [ ] Scenario 4 (Single Adult — Gross Above 130% FPL): **ineligible** ($0)
 - [ ] Scenario 5 (Net Income Test Failure — Gross Passes, Net Fails): **ineligible** ($0)
 - [ ] Scenario 6 (Non-Elderly Household — Assets Above $3,000): **ineligible** ($0)
-- [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**, **$310/yr ($26/mo)**
-- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible** (gated by MFB SSI categorical logic, not raw PE)
+- [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**, **$276/yr ($23/mo)**
+- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**, **$1,080/yr ($90/mo)**
 - [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible** ($0)
-- [ ] Scenario 10 (Half-Time Student with 20+ hrs/week Work Exemption): **eligible**, **$897/yr ($75/mo)**
+- [ ] Scenario 10 (Half-Time Student with Job-Training Exemption): **eligible**, **$864/yr ($72/mo)** ⛔ *blocked on PE — see note*
 - [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible** (gated by MFB `already_has` results-layer filter, not raw PE)
-- [ ] Scenario 12 (SUA value — Single Adult): **eligible**, **$2,461/yr ($205/mo)**
-- [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$3,596/yr ($300/mo)**
-- [ ] Scenario 14 (SUA value — Family of Three): **eligible**, **$4,738/yr ($395/mo)**
+- [ ] Scenario 12 (SUA value — Single Adult): **eligible**, **$2,424/yr ($202/mo)**
+- [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$3,576/yr ($298/mo)**
+- [ ] Scenario 14 (SUA value — Family of Three): **eligible**, **$4,668/yr ($389/mo)**
+- [ ] Scenario 15 (Asset Test Pass — Below Standard $3,000 Limit): **eligible**, **$1,728/yr ($144/mo)**
+- [ ] Scenario 16 (Large Household of Five): **eligible**, **$7,212/yr ($601/mo)**
+- [ ] Scenario 17 (Disabled Non-Elderly — Uncapped Shelter & $4,500 Asset Limit): **eligible**, **$1,884/yr ($157/mo)**
+- [ ] Scenario 18 (TANF Categorical Eligibility — Cash Recipient, Assets Above Limit): **eligible** ⛔ *blocked on PE — see note*
 
 
 ## Test Scenarios
 
-> All value-bearing scenarios verified against the **live PolicyEngine API** (the path benefits-api uses; version 1.715.2), period 2026, `state_code=KS`. Every scenario carries an expected dollar outcome: the eligible cases (1–3, 7, 10, 12–14) assert the computed annual benefit, and the ineligible cases (4–6, 9) assert **$0**. Two scenarios are gated by MFB *outside* PE and verified by design rather than via a raw PE value: **Scenario 8** (all-SSI categorical eligibility) is decided by MFB's SSI categorical logic, and **Scenario 11** (already receiving SNAP) is filtered out by the generic `already_has` results-layer workflow when the household reports it (read via `screen.has_benefit("ks_snap")`). **Scenarios 9–10** (students) are handled by the federal SNAP calculator's `is_snap_ineligible_student` **dependency** (`SnapIneligibleStudentDependency`), which computes student ineligibility from screener fields and passes it to PolicyEngine as an input (not a post-hoc override) — PolicyEngine then applies it. All inputs use screener-measurable fields.
+> **Verification method.** Each value is derived independently from the FY2026 SNAP policy
+> formula (KEESM Appendix F-2 / FNS FY2026 parameters) and then checked against the calculator —
+> the spec is the oracle, not a copy of calculator output. Eligible cases assert the computed
+> annual benefit; ineligible cases (4–6, 9) assert **$0**. **Scenario 11** (already receiving
+> SNAP) is filtered out by the generic `already_has` results-layer workflow when the household
+> reports it (`screen.has_benefit("ks_snap")`), so it's verified by design rather than a raw PE value.
+>
+> **Categorical & disability inputs (fixed in this PR).** SNAP now sends the `Ssi` dependency
+> (reported SSI receipt → PE's computed `ssi`), so an all-SSI household is correctly categorically
+> eligible (**Scenario 8**, previously denied). It also sends `SsdiReportedDependency` so a disabled
+> SSDI recipient receives the elderly/disabled treatment — the uncapped excess-shelter deduction and
+> the higher $4,500 asset limit (**Scenario 17**). Both bypass the income/asset tests via PE's
+> `meets_snap_categorical_eligibility` / `is_usda_disabled` rather than any MFB post-hoc override.
+>
+> **⛔ Two scenarios are blocked on PolicyEngine and intentionally fail today:**
+> - **Scenario 10** (student with a job-training/E&T exemption): PE's `is_snap_ineligible_student`
+>   does not yet model the workforce/job-training exemption (7 CFR 273.5(b)(3)). PE is adding an
+>   `is_snap_work_program_participant` input to feed the student-eligibility path; until it ships,
+>   this household is wrongly flagged an ineligible student. (Other student exemptions — age,
+>   disability, 20-hr work, work-study, parent/child-age — already work via `SnapIneligibleStudentDependency`.)
+> - **Scenario 18** (TANF cash categorical eligibility): PE's SNAP `categorical_eligibility` list
+>   only honors `ssi` and the BBCE `is_tanf_non_cash_eligible` path; direct `tanf` cash receipt is
+>   commented out ("IL only"). Kansas has not adopted BBCE, and feeding the `tanf` input has no
+>   effect, so a KS TANF-cash household over the asset limit is wrongly denied. Pending a PE change
+>   to honor `tanf` cash receipt in non-BBCE states.
 
 ### Scenario 1: Single Adult Worker — Clearly Eligible for Food Assistance
 
 **What we're checking**: Typical single adult with low wage income who clearly meets both the federal gross (130% FPL) and net (100% FPL) income tests (criteria 1–2).
 
-**Expected**: Eligible — $897/yr ($75/mo)
+**Expected**: Eligible — $864/yr ($72/mo)
+**Benefit math** (FY2026): gross $1,200/mo earned; net = 1,200 − 209 std − 240 (20% earned) = $751; benefit = 298 max − 0.30 × 751 = **$72/mo**.
 
 **Steps**:
 - **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
@@ -178,7 +212,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: A household that barely meets both the gross (130% FPL) and net (100% FPL) income tests, validating edge-case eligibility at the income ceiling with shelter and dependent-care deductions (criteria 1, 2, 4, 16).
 
-**Expected**: Eligible — $6,508/yr ($542/mo)
+**Expected**: Eligible — $6,432/yr ($536/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66603`, Select county `Shawnee`
@@ -199,7 +233,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: A 2-person household with gross monthly income $1 below the 130% FPL threshold ($2,292/mo for HH2) is correctly found eligible (criterion 1, boundary).
 
-**Expected**: Eligible — $3,589/yr ($299/mo)
+**Expected**: Eligible — $3,540/yr ($295/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
@@ -268,7 +302,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: The federal elderly/disabled treatment — a 60+ household is exempt from the gross income test and qualifies on net income alone, using the higher $4,500 asset limit and an uncapped shelter deduction (criterion 6).
 
-**Expected**: Eligible — $310/yr ($26/mo)
+**Expected**: Eligible — $276/yr ($23/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
@@ -287,17 +321,17 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 **What we're checking**: A household in which all members receive SSI is categorically eligible — the income and asset tests are bypassed (criterion 5).
 
-**Expected**: Eligible
+**Expected**: Eligible — $1,080/yr ($90/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
 - **Household**: Number of people: `1`
-- **Person 1**: Birth month/year: `January 1981` (age 45), Relationship: Head of Household, Not a student, Not pregnant, No disability, U.S. citizen
-- **Income**: Other income above the standard limit (with SSI received)
+- **Person 1**: Birth month/year: `January 1981` (age 45), Relationship: Head of Household, Not a student, Not pregnant, Disabled, U.S. citizen
+- **Income**: SSI income `$900`/month (reported SSI receipt)
 - **Assets**: `$6,000` (above the $3,000 standard limit)
-- **Current Benefits**: Currently receiving SSI (`has_ssi` = Yes), Not currently receiving SNAP/Food Assistance, Not receiving TANF
+- **Current Benefits**: Currently receiving SSI, Not currently receiving SNAP/Food Assistance, Not receiving TANF
 
-**Why this matters**: Validates that an all-SSI household is categorically eligible regardless of income or assets — confirms categorical eligibility correctly overrides the financial tests.
+**Why this matters**: Validates that an all-SSI household is categorically eligible regardless of income or assets. This works because SNAP sends the `Ssi` dependency (reported SSI receipt → PE's computed `ssi`), which drives PE's `meets_snap_categorical_eligibility` and bypasses the asset/income tests. Without that input (the prior behavior) this household was wrongly denied.
 
 ---
 
@@ -318,20 +352,20 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ---
 
-### Scenario 10: Half-Time College Student with 20+ Hours/Week Work Exemption
+### Scenario 10: Half-Time College Student with Job-Training Exemption
 
-**What we're checking**: A half-time college student who works 20+ hours/week meets a student exemption and is eligible (criterion 7, exemption regression guard).
+**What we're checking**: A half-time college student aged 18–49 who is enrolled in a workforce/job-training program (WIOA, SNAP E&T, career/technical ed) meets a student exemption under 7 CFR 273.5(b)(3) and is eligible (criterion 7).
 
-**Expected**: Eligible — $897/yr ($75/mo)
+**Expected**: Eligible — $864/yr ($72/mo)  ⛔ **Currently fails — blocked on PolicyEngine.**
 
 **Steps**:
 - **Location**: Enter ZIP code `66045`, Select county `Douglas`
 - **Household**: Number of people: `1`
-- **Person 1**: Birth month/year: `January 2004` (age 22), Relationship: Head of Household, Student status: enrolled in higher education at least half-time, Works 20+ hours per week (qualifies for the student exemption), No disability
-- **Income**: Employment income consistent with 20+ hours/week
+- **Person 1**: Birth month/year: `January 2004` (age 22), Relationship: Head of Household, Student status: enrolled in higher education at least half-time, Enrolled in a job-training program (`student_job_training_program` = Yes), Not working 20+ hrs, No disability
+- **Income**: Employment income `$1,200`/month
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
-**Why this matters**: Confirms a qualifying student exemption restores eligibility, guarding against the screener over-applying the student restriction.
+**Why this matters**: The job-training exemption is one of the federal student exemptions. PE's `is_snap_ineligible_student` does **not yet** model it, so this student is currently flagged ineligible (returns $0) despite qualifying. PE is adding an `is_snap_work_program_participant` input to feed the student-eligibility path; once it ships, this scenario should return the expected $864/yr. The other student exemptions (age, disability, 20-hr work, work-study, parent/child-age) already work today via `SnapIneligibleStudentDependency`, so this is the single remaining student gap.
 
 ---
 
@@ -354,7 +388,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ### Scenario 12: Standard Utility Allowance — Single Adult, Moderate Income
 
-**What we're checking**: A single adult below the maximum allotment with a binding excess-shelter deduction, so the KS Standard Utility Allowance ($469/mo HCSUA) flows through to the benefit. Committed expected benefit: **$2,461/yr ($205/mo)**.
+**What we're checking**: A single adult below the maximum allotment with a binding excess-shelter deduction, so the KS Standard Utility Allowance ($469/mo HCSUA) flows through to the benefit. Committed expected benefit: **$2,424/yr ($202/mo)**.
 
 **Expected**: Eligible
 
@@ -372,7 +406,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ### Scenario 13: Standard Utility Allowance — Elderly Individual
 
-**What we're checking**: An elderly household (uncapped shelter deduction) where the SUA is binding. Committed expected benefit: **$3,596/yr ($300/mo)**. The uncapped elderly shelter deduction (rent + HCSUA) drives net income to $0, so the household qualifies for the full max allotment for a household of 1 (~$300/mo).
+**What we're checking**: An elderly household (uncapped shelter deduction) where the SUA is binding. Committed expected benefit: **$3,576/yr ($298/mo)**. The uncapped elderly shelter deduction (rent + HCSUA) drives net income to $0, so the household qualifies for the full HH1 max allotment ($298/mo). Note: $298 is the FY2026 HH1 maximum — the benefit cannot exceed it, which is why the prior $300/mo value was impossible.
 
 **Expected**: Eligible
 
@@ -391,7 +425,7 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 
 ### Scenario 14: Standard Utility Allowance — Family of Three
 
-**What we're checking**: A three-person working household below the maximum allotment with a binding shelter deduction. Committed expected benefit: **$4,738/yr ($395/mo)**.
+**What we're checking**: A three-person working household below the maximum allotment with a binding shelter deduction. Committed expected benefit: **$4,668/yr ($389/mo)**.
 
 **Expected**: Eligible
 
@@ -404,12 +438,92 @@ The screener evaluates the criteria that drive nearly all SNAP outcomes: gross i
 - **Expenses**: Monthly rent: `$900`, Heating/cooling utilities (qualifies for HCSUA $469/mo)
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
-**Why this matters**: SUA validation at a larger household size; SUA-sensitive (−$248/yr if HCSUA $469→$400). PolicyEngine-verified on `policyengine-us` 1.739.4.
+**Why this matters**: SUA validation at a larger household size; confirms the KS HCSUA flows through the excess-shelter deduction for a multi-person household.
+
+---
+
+### Scenario 15: Asset Test Pass — Below the Standard $3,000 Limit
+
+**What we're checking**: A non-elderly/non-disabled household with low income and countable assets just **below** the $3,000 standard limit is eligible (criterion 3, the passing side of the asset test).
+
+**Expected**: Eligible — $1,728/yr ($144/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1992` (age 34), Relationship: Head of Household, Not a student, No disability, U.S. citizen
+- **Income**: Employment income `$900`/month
+- **Assets**: `$2,900` (just below the $3,000 standard limit)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Scenario 6 tests the asset test failing at $5,000; this is the passing counterpart just under the limit — together they pin the $3,000 boundary for a non-categorical household.
+
+---
+
+### Scenario 16: Large Household of Five
+
+**What we're checking**: A five-person household exercises the larger max allotment and the per-additional-person standards (criterion 4, household-size scaling).
+
+**Expected**: Eligible — $7,212/yr ($601/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `5`
+- **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: Head of Household, Employment income: `$3,500`/month
+- **Person 2**: Birth month/year: `January 1988` (age 38), Relationship: Spouse, No income
+- **Persons 3–5**: Children ages 12, 8, 5, No income
+- **Expenses**: Monthly rent: `$1,400`, Heating/cooling utilities (HCSUA)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: Confirms benefit scaling for a larger household — the HH5 max allotment and standard deduction tier — beyond the HH1–4 cases above.
+
+---
+
+### Scenario 17: Disabled Non-Elderly — Uncapped Shelter & $4,500 Asset Limit
+
+**What we're checking**: A non-elderly disabled SSDI recipient receives the federal disabled treatment: the **uncapped** excess-shelter deduction and the higher **$4,500** asset limit (criterion 6, the disabled path).
+
+**Expected**: Eligible — $1,884/yr ($157/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1981` (age 45), Relationship: Head of Household, **Disabled**, Not a student, U.S. citizen
+- **Income**: Social Security disability (SSDI) `$1,500`/month
+- **Expenses**: Monthly rent: `$1,000`, Heating/cooling utilities (HCSUA)
+- **Assets**: `$1,000` (below the $4,500 disabled limit)
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: The disabled treatment keys off PE's `is_usda_disabled`, which requires **receipt of a qualifying disability program** (SSDI), not the generic `is_disabled` flag. SNAP now sends `SsdiReportedDependency`, so the SSDI amount feeds `social_security_disability` → `is_usda_disabled` → uncapped shelter + $4,500 asset limit. (A companion check: the same household with $4,000 in assets is eligible as disabled but would be **denied** if non-disabled, since $4,000 exceeds the $3,000 standard limit — confirming the higher disabled limit is applied.) Before this fix, the shelter deduction was wrongly capped at $744 and the benefit understated.
+
+---
+
+### Scenario 18: TANF Categorical Eligibility — Cash Recipient, Assets Above Limit
+
+**What we're checking**: A household receiving TANF cash assistance should be categorically eligible for SNAP — the income and asset tests are bypassed (criterion 5, the TANF path).
+
+**Expected**: Eligible  ⛔ **Currently fails — blocked on PolicyEngine.**
+
+**Steps**:
+- **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: Head of Household, Not a student, No disability, U.S. citizen
+- **Income**: Employment income `$1,000`/month
+- **Assets**: `$6,000` (above the $3,000 standard limit)
+- **Current Benefits**: Currently receiving TANF cash assistance, Not currently receiving SNAP/Food Assistance, Not receiving SSI
+
+**Why this matters**: TANF cash recipients are categorically eligible under 7 U.S.C. § 2014(a). PE's SNAP `categorical_eligibility` list only honors `ssi` and the BBCE `is_tanf_non_cash_eligible` path; direct `tanf` cash receipt is commented out ("IL only"). Kansas has not adopted BBCE, and feeding the `tanf` input has no effect, so this household is wrongly denied on the asset test. Pending a PolicyEngine change to honor `tanf` cash receipt for non-BBCE states. (This is the SNAP analog to the now-fixed SSI categorical path in Scenario 8.)
 
 
 ## PE Verification
 
-Full detail in the MFB-1049 "PE Verification — final verdict" comment. Summary: **no PE request required, nothing blocks implementation.** KS uses the federal SNAP calculator (`KsSnap(Snap)`) with no eligibility variance; the KS SUA values ($469/$345/$44, eff. 2025-10-01) and all FY2026 standards (max allotment, deductions, shelter cap, asset/income limits) match KEESM/FNS in PolicyEngine. Open SNAP issues triaged and cleared for MFB — #8296 (COFA) and OBBBA non-citizen narrowing bypassed via the `CITIZEN` default; #7745 (OBBBA HCSUA restriction) doesn't affect MFB (actual-expense pathway); #8133/#8134 (student-filter bugs) don't reach MFB; the 3-month ABAWD time-limit clock is an architectural PE limitation.
+KS uses the federal SNAP calculator (`KsSnap(Snap)`) with no eligibility variance; the KS SUA values ($469/$345/$44, eff. 2025-10-01) and all FY2026 standards (max allotment, deductions, shelter cap, asset/income limits) match KEESM/FNS in PolicyEngine.
+
+**Two open PolicyEngine items (Scenarios 10 and 18 fail until resolved):**
+- **Student job-training exemption** — PE's `is_snap_ineligible_student` does not model the workforce/job-training exemption (7 CFR 273.5(b)(3)). PE is adding an `is_snap_work_program_participant` input; once it ships, Scenario 10 should pass.
+- **TANF cash categorical eligibility** — PE's SNAP `categorical_eligibility` list excludes direct `tanf` cash receipt (modeled only for IL / via BBCE). KS is non-BBCE, so Scenario 18 is wrongly denied; pending a PE change to honor `tanf` cash receipt for non-BBCE states.
+
+Previously triaged and cleared for MFB — #8296 (COFA) and OBBBA non-citizen narrowing bypassed via the `CITIZEN` default; #7745 (OBBBA HCSUA restriction) doesn't affect MFB (actual-expense pathway); the 3-month ABAWD time-limit clock is an architectural PE limitation.
 
 
 ## Research Sources
@@ -435,7 +549,7 @@ Scenarios 1–14. Expected `eligible`:
 - `true`: 1, 2, 3, 7, 8, 10, 12, 13, 14
 - `false`: 4, 5, 6, 9, 11
 
-Value scenarios 12–14 carry committed amounts ($2,461 / $3,596 / $4,738 per year), verified against the live PolicyEngine API (the path benefits-api uses), version 1.715.2.
+SUA value scenarios 12–14 carry committed amounts ($2,424 / $3,576 / $4,668 per year), each hand-derived from the FY2026 formula and confirmed against the calculator.
 
 
 ## Generated Program Configuration

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -161,6 +161,7 @@ for reference.
 - [ ] Scenario 18 (TANF Categorical Eligibility — Cash Recipient, Assets Above Limit): **eligible**, **$2,880/yr ($240/mo)**
 - [ ] Scenario 19 (Half-Time Student Working 20+ Hours/Week): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 20 (Half-Time Student with Federal Work-Study): **eligible**, **$864/yr ($72/mo)**
+- [ ] Scenario 21 (Single Full-Time Student Parent with Dependent Child): **eligible**, **$3,840/yr ($320/mo)**
 
 
 ## Test Scenarios
@@ -184,7 +185,7 @@ for reference.
 > **Student exemptions.** A half-time+ college student aged 18–49 (**Scenario 9**) is an ineligible
 > student unless they meet an exemption — a job-training / employment-and-training program placement
 > (**Scenario 10**), working 20+ hours/week (**Scenario 19**), federal work-study (**Scenario 20**),
-> or the parent/child-age exemptions (7 CFR 273.5).
+> or the parent-of-a-dependent-child exemption (**Scenario 21**) (7 CFR 273.5).
 
 ### Scenario 1: Single Adult Worker — Clearly Eligible for Food Assistance
 
@@ -544,6 +545,24 @@ for reference.
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
 **Why this matters**: Work-study participation is one of the federal student exemptions. A half-time student who would otherwise be an ineligible student qualifies through it, so this household is eligible rather than denied at $0.
+
+---
+
+### Scenario 21: Single Full-Time Student Parent with a Dependent Child
+
+**What we're checking**: A single parent enrolled full-time in higher education, responsible for a dependent child under 12, meets a student exemption (7 CFR 273.5(b)(4)) and is eligible (criterion 7, parent exemption).
+
+**Expected**: Eligible — $3,840/yr ($320/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `66045`, Select county `Douglas`
+- **Household**: Number of people: `2`
+- **Person 1**: Birth month/year: `January 2000` (age 26), Relationship: Head of Household, Student status: enrolled in higher education full-time, Not married, No work-study, No job-training program, Not working 20+ hrs, No disability
+- **Person 2**: Birth month/year: `January 2018` (age 8), Relationship: Child, No income
+- **Income**: Employment income (Person 1) `$1,200`/month
+- **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
+
+**Why this matters**: The parent exemption is one of the federal student exemptions — a single parent enrolled full-time with a dependent child under 12 (or, for a two-parent household, a child under 6) qualifies. Without it, the student parent would be excluded and the household under-served.
 
 
 ## PE Verification

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -48,7 +48,7 @@
 
 7. **Student eligibility — half-time+ college students aged 18–49 must meet an exemption**
    - Screener fields: `student`, `student_full_time`, `student_works_20_plus_hrs`, `student_has_work_study`, `student_job_training_program`, `birth_year`, `birth_month`
-   - Note: Students enrolled at least half-time in higher education are ineligible unless they meet an exemption (working 20+ hrs/week, work-study, job-training program, caring for a dependent child under 6 — or under 12 if a single parent enrolled full-time — or age 17 or younger). MFB supplies `is_snap_ineligible_student` via its own helper, which implements these exemptions correctly.
+   - Note: Students enrolled at least half-time in higher education are ineligible unless they meet an exemption (working 20+ hrs/week, work-study, job-training/employment-and-training program, caring for a dependent child under 6 — or under 12 if a single parent enrolled full-time — or age 17 or younger).
    - Source: 7 CFR 273.5; 7 U.S.C. § 2015(e); KEESM Student Eligibility Criteria.
 
 8. **Must not already be receiving SNAP/Food Assistance benefits**
@@ -150,7 +150,7 @@ for reference.
 - [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**, **$276/yr ($23/mo)**
 - [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**, **$1,080/yr ($90/mo)**
 - [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible** ($0)
-- [ ] Scenario 10 (Half-Time Student with Job-Training Exemption): **eligible**, **$864/yr ($72/mo)** ⛔ *blocked on PE — see note*
+- [ ] Scenario 10 (Half-Time Student with Job-Training Exemption): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible** (gated by MFB `already_has` results-layer filter, not raw PE)
 - [ ] Scenario 12 (SUA value — Single Adult): **eligible**, **$2,424/yr ($202/mo)**
 - [ ] Scenario 13 (SUA value — Elderly Individual): **eligible**, **$3,576/yr ($298/mo)**
@@ -158,7 +158,7 @@ for reference.
 - [ ] Scenario 15 (Asset Test Pass — Below Standard $3,000 Limit): **eligible**, **$1,728/yr ($144/mo)**
 - [ ] Scenario 16 (Large Household of Five): **eligible**, **$7,212/yr ($601/mo)**
 - [ ] Scenario 17 (Disabled Non-Elderly — Uncapped Shelter & $4,500 Asset Limit): **eligible**, **$1,884/yr ($157/mo)**
-- [ ] Scenario 18 (TANF Categorical Eligibility — Cash Recipient, Assets Above Limit): **eligible** ⛔ *blocked on PE — see note*
+- [ ] Scenario 18 (TANF Categorical Eligibility — Cash Recipient, Assets Above Limit): **eligible**
 
 
 ## Test Scenarios
@@ -170,26 +170,19 @@ for reference.
 > SNAP) is filtered out by the generic `already_has` results-layer workflow when the household
 > reports it (`screen.has_benefit("ks_snap")`), so it's verified by design rather than a raw PE value.
 >
-> **Categorical & disability inputs (fixed in this PR).** SNAP now sends the `Ssi` dependency
-> (reported SSI receipt → PE's computed `ssi`), so an all-SSI household is correctly categorically
-> eligible (**Scenario 8**, previously denied) via PE's `meets_snap_categorical_eligibility`, which
-> bypasses the income/asset tests. It also sends `SsdiReportedDependency` so a disabled SSDI
-> recipient receives the elderly/disabled treatment — no gross-income test, the higher $4,500 asset
-> limit, and the uncapped excess-shelter deduction (**Scenario 17**) — through PE's `is_usda_disabled`.
-> (The disabled treatment applies the elderly/disabled *rules*; it does not categorically bypass the
-> tests the way the SSI path does.) Neither relies on an MFB post-hoc override.
+> **Categorical eligibility.** A household with reported SSI receipt (**Scenario 8**) or TANF cash
+> receipt (**Scenario 18**) is categorically eligible — the income and asset tests are bypassed
+> (7 U.S.C. § 2014(a); 7 CFR 273.2(j)(2)).
 >
-> **⛔ Two scenarios are blocked on PolicyEngine and intentionally fail today:**
-> - **Scenario 10** (student with a job-training/E&T exemption): PE's `is_snap_ineligible_student`
->   does not yet model the workforce/job-training exemption (7 CFR 273.5(b)(3)). PE is adding an
->   `is_snap_work_program_participant` input to feed the student-eligibility path; until it ships,
->   this household is wrongly flagged an ineligible student. (Other student exemptions — age,
->   disability, 20-hr work, work-study, parent/child-age — already work via `SnapIneligibleStudentDependency`.)
-> - **Scenario 18** (TANF cash categorical eligibility): PE's SNAP `categorical_eligibility` list
->   only honors `ssi` and the BBCE `is_tanf_non_cash_eligible` path; direct `tanf` cash receipt is
->   commented out ("IL only"). Kansas has not adopted BBCE, and feeding the `tanf` input has no
->   effect, so a KS TANF-cash household over the asset limit is wrongly denied. Pending a PE change
->   to honor `tanf` cash receipt in non-BBCE states.
+> **Disabled treatment.** A disabled household member on a qualifying disability program (e.g. SSDI)
+> receives the elderly/disabled treatment — no gross-income test, the higher $4,500 asset limit, and
+> the uncapped excess-shelter deduction (**Scenario 17**). This applies the elderly/disabled *rules*;
+> it does not categorically bypass the tests the way the SSI/TANF categorical path does.
+>
+> **Student exemptions.** A half-time+ college student aged 18–49 (**Scenario 9**) is an ineligible
+> student unless they meet an exemption — including a job-training / employment-and-training program
+> placement (**Scenario 10**), 20-hr work, work-study, or the parent/child-age exemptions
+> (7 CFR 273.5).
 
 ### Scenario 1: Single Adult Worker — Clearly Eligible for Food Assistance
 
@@ -333,7 +326,7 @@ for reference.
 - **Assets**: `$6,000` (above the $3,000 standard limit)
 - **Current Benefits**: Currently receiving SSI, Not currently receiving SNAP/Food Assistance, Not receiving TANF
 
-**Why this matters**: Validates that an all-SSI household is categorically eligible regardless of income or assets. This works because SNAP sends the `Ssi` dependency (reported SSI receipt → PE's computed `ssi`), which drives PE's `meets_snap_categorical_eligibility` and bypasses the asset/income tests. Without that input (the prior behavior) this household was wrongly denied.
+**Why this matters**: Validates that an all-SSI household is categorically eligible regardless of income or assets — reported SSI receipt drives categorical eligibility, which bypasses the asset/income tests.
 
 ---
 
@@ -358,7 +351,7 @@ for reference.
 
 **What we're checking**: A half-time college student aged 18–49 who is enrolled in a workforce/job-training program (WIOA, SNAP E&T, career/technical ed) meets a student exemption under 7 CFR 273.5(b)(3) and is eligible (criterion 7).
 
-**Expected**: Eligible — $864/yr ($72/mo)  ⛔ **Currently fails — blocked on PolicyEngine.**
+**Expected**: Eligible — $864/yr ($72/mo)
 
 **Steps**:
 - **Location**: Enter ZIP code `66045`, Select county `Douglas`
@@ -367,7 +360,7 @@ for reference.
 - **Income**: Employment income `$1,200`/month
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
-**Why this matters**: The job-training exemption is one of the federal student exemptions. PE's `is_snap_ineligible_student` does **not yet** model it, so this student is currently flagged ineligible (returns $0) despite qualifying. PE is adding an `is_snap_work_program_participant` input to feed the student-eligibility path; once it ships, this scenario should return the expected $864/yr. The other student exemptions (age, disability, 20-hr work, work-study, parent/child-age) already work today via `SnapIneligibleStudentDependency`, so this is the single remaining student gap.
+**Why this matters**: The job-training / employment-and-training program placement is one of the federal student exemptions (7 CFR 273.5(b)(3)). A half-time student who would otherwise be an ineligible student qualifies through it, so this household is eligible rather than denied at $0.
 
 ---
 
@@ -496,7 +489,7 @@ for reference.
 - **Assets**: `$1,000` (below the $4,500 disabled limit)
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
-**Why this matters**: The disabled treatment keys off PE's `is_usda_disabled`, which requires **receipt of a qualifying disability program** (SSDI), not the generic `is_disabled` flag. SNAP now sends `SsdiReportedDependency`, so the SSDI amount feeds `social_security_disability` → `is_usda_disabled` → uncapped shelter + $4,500 asset limit. (A companion check: the same household with $4,000 in assets is eligible as disabled but would be **denied** if non-disabled, since $4,000 exceeds the $3,000 standard limit — confirming the higher disabled limit is applied.) Before this fix, the shelter deduction was wrongly capped at $744 and the benefit understated.
+**Why this matters**: The disabled treatment requires **receipt of a qualifying disability program** (e.g. SSDI), not the generic disability flag — a disabled SSDI recipient gets the uncapped excess-shelter deduction and the higher $4,500 asset limit. (A companion check: the same household with $4,000 in assets is eligible as disabled but would be **denied** if non-disabled, since $4,000 exceeds the $3,000 standard limit — confirming the higher disabled limit is applied.)
 
 ---
 
@@ -504,7 +497,7 @@ for reference.
 
 **What we're checking**: A household receiving TANF cash assistance should be categorically eligible for SNAP — the income and asset tests are bypassed (criterion 5, the TANF path).
 
-**Expected**: Eligible  ⛔ **Currently fails — blocked on PolicyEngine.**
+**Expected**: Eligible
 
 **Steps**:
 - **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
@@ -514,16 +507,12 @@ for reference.
 - **Assets**: `$6,000` (above the $3,000 standard limit)
 - **Current Benefits**: Currently receiving TANF cash assistance, Not currently receiving SNAP/Food Assistance, Not receiving SSI
 
-**Why this matters**: TANF cash recipients are categorically eligible under 7 U.S.C. § 2014(a). PE's SNAP `categorical_eligibility` list only honors `ssi` and the BBCE `is_tanf_non_cash_eligible` path; direct `tanf` cash receipt is commented out ("IL only"). Kansas has not adopted BBCE, and feeding the `tanf` input has no effect, so this household is wrongly denied on the asset test. Pending a PolicyEngine change to honor `tanf` cash receipt for non-BBCE states. (This is the SNAP analog to the now-fixed SSI categorical path in Scenario 8.)
+**Why this matters**: TANF cash recipients are categorically eligible for SNAP under 7 U.S.C. § 2014(a); the income and asset tests are bypassed. This household is eligible despite $6,000 in assets (above the $3,000 standard limit). This is the TANF analog to the SSI categorical path in Scenario 8.
 
 
 ## PE Verification
 
 KS uses the federal SNAP calculator (`KsSnap(Snap)`) with no eligibility variance; the KS SUA values ($469/$345/$44, eff. 2025-10-01) and all FY2026 standards (max allotment, deductions, shelter cap, asset/income limits) match KEESM/FNS in PolicyEngine.
-
-**Two open PolicyEngine items (Scenarios 10 and 18 fail until resolved):**
-- **Student job-training exemption** — PE's `is_snap_ineligible_student` does not model the workforce/job-training exemption (7 CFR 273.5(b)(3)). PE is adding an `is_snap_work_program_participant` input; once it ships, Scenario 10 should pass.
-- **TANF cash categorical eligibility** — PE's SNAP `categorical_eligibility` list excludes direct `tanf` cash receipt (modeled only for IL / via BBCE). KS is non-BBCE, so Scenario 18 is wrongly denied; pending a PE change to honor `tanf` cash receipt for non-BBCE states.
 
 Previously triaged and cleared for MFB — #8296 (COFA) and OBBBA non-citizen narrowing bypassed via the `CITIZEN` default; #7745 (OBBBA HCSUA restriction) doesn't affect MFB (actual-expense pathway); the 3-month ABAWD time-limit clock is an architectural PE limitation.
 

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -148,7 +148,7 @@ for reference.
 - [ ] Scenario 5 (Net Income Test Failure — Gross Passes, Net Fails): **ineligible** ($0)
 - [ ] Scenario 6 (Non-Elderly Household — Assets Above $3,000): **ineligible** ($0)
 - [ ] Scenario 7 (Elderly — Gross Above 130%, Net Below 100%, Assets ≤ $4,500): **eligible**, **$276/yr ($23/mo)**
-- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**, **$1,080/yr ($90/mo)** — ⏸️ *deferred to MFB-1312 (SSI categorical requires the global `use_reported_ssi` change; not wired in this PR)*
+- [ ] Scenario 8 (Categorical Eligibility — All Members on SSI, Income/Assets Above Limits): **eligible**, **$1,080/yr ($90/mo)**
 - [ ] Scenario 9 (Half-Time Student 18–49, No Exemption): **ineligible** ($0)
 - [ ] Scenario 10 (Half-Time Student with Job-Training Exemption): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 11 (Already Receiving SNAP — Duplicate Exclusion): **ineligible** (gated by MFB `already_has` results-layer filter, not raw PE)
@@ -162,7 +162,7 @@ for reference.
 - [ ] Scenario 19 (Half-Time Student Working 20+ Hours/Week): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 20 (Half-Time Student with Federal Work-Study): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 21 (Single Full-Time Student Parent with Dependent Child): **eligible**, **$3,840/yr ($320/mo)**
-- [ ] Scenario 22 (SSI Categorical — Reported Receipt with High Other Income): **eligible**, **$276/yr ($23/mo)** — ⏸️ *deferred to MFB-1312 (SSI categorical requires the global `use_reported_ssi` change; not wired in this PR)*
+- [ ] Scenario 22 (SSI Categorical — Reported Receipt with High Other Income): **eligible**, **$276/yr ($23/mo)**
 
 
 ## Test Scenarios
@@ -320,8 +320,6 @@ for reference.
 ### Scenario 8: Categorical Eligibility — All Members Receive SSI, Income and Assets Above Limits
 
 **What we're checking**: A household in which all members receive SSI is categorically eligible — the income and asset tests are bypassed (criterion 5).
-
-> ⏸️ **Deferred to MFB-1312.** SSI categorical eligibility requires `use_reported_ssi`, which is global per PE request (flips `applicable_ssi` for every program — SNAP, IL AABD, KS TANF, TX CEAP). That federal all-state change (verified IL AABD $0→$10k swing) is out of scope for this KS SNAP PR and is handled in MFB-1312. This scenario does not pass in the code shipping with this PR.
 
 **Expected**: Eligible — $1,080/yr ($90/mo)
 
@@ -573,8 +571,6 @@ for reference.
 ### Scenario 22: SSI Categorical Eligibility — Reported Receipt with High Other Income
 
 **What we're checking**: A household reporting SSI receipt is categorically eligible even when other income is high enough that the modeled SSI amount would compute to $0. Categorical eligibility must key off *reported* receipt, not a recalculated SSI amount (criterion 5, the SSI path).
-
-> ⏸️ **Deferred to MFB-1312.** Same reason as Scenario 8 — the reported-SSI categorical path depends on the global `use_reported_ssi` change tracked in MFB-1312. Not wired in this PR.
 
 **Expected**: Eligible — $276/yr ($23/mo)
 

--- a/programs/programs/ks/snap/spec.md
+++ b/programs/programs/ks/snap/spec.md
@@ -162,6 +162,7 @@ for reference.
 - [ ] Scenario 19 (Half-Time Student Working 20+ Hours/Week): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 20 (Half-Time Student with Federal Work-Study): **eligible**, **$864/yr ($72/mo)**
 - [ ] Scenario 21 (Single Full-Time Student Parent with Dependent Child): **eligible**, **$3,840/yr ($320/mo)**
+- [ ] Scenario 22 (SSI Categorical — Reported Receipt with High Other Income): **eligible**, **$276/yr ($23/mo)**
 
 
 ## Test Scenarios
@@ -173,9 +174,10 @@ for reference.
 > SNAP) is filtered out by the generic `already_has` results-layer workflow when the household
 > reports it (`screen.has_benefit("ks_snap")`), so it's verified by design rather than a raw PE value.
 >
-> **Categorical eligibility.** A household with reported SSI receipt (**Scenario 8**) or TANF cash
-> receipt (**Scenario 18**) is categorically eligible — the income and asset tests are bypassed
-> (7 U.S.C. § 2014(a); 7 CFR 273.2(j)(2)).
+> **Categorical eligibility.** A household with reported SSI receipt (**Scenarios 8, 22**) or TANF
+> cash receipt (**Scenario 18**) is categorically eligible — the income and asset tests are bypassed
+> (7 U.S.C. § 2014(a); 7 CFR 273.2(j)(2)). Categorical eligibility keys off *reported* receipt, not a
+> recalculated benefit amount (**Scenario 22**).
 >
 > **Disabled treatment.** A disabled household member on a qualifying disability program (e.g. SSDI)
 > receives the elderly/disabled treatment — no gross-income test, the higher $4,500 asset limit, and
@@ -563,6 +565,24 @@ for reference.
 - **Current Benefits**: Not currently receiving SNAP/Food Assistance, Not receiving TANF, Not receiving SSI
 
 **Why this matters**: The parent exemption is one of the federal student exemptions — a single parent enrolled full-time with a dependent child under 12 (or, for a two-parent household, a child under 6) qualifies. Without it, the student parent would be excluded and the household under-served.
+
+---
+
+### Scenario 22: SSI Categorical Eligibility — Reported Receipt with High Other Income
+
+**What we're checking**: A household reporting SSI receipt is categorically eligible even when other income is high enough that the modeled SSI amount would compute to $0. Categorical eligibility must key off *reported* receipt, not a recalculated SSI amount (criterion 5, the SSI path).
+
+**Expected**: Eligible — $276/yr ($23/mo)
+
+**Steps**:
+- **Location**: Enter ZIP code `66102`, Select county `Wyandotte`
+- **Household**: Number of people: `1`
+- **Person 1**: Birth month/year: `January 1981` (age 45), Relationship: Head of Household, Disabled, Not a student, U.S. citizen
+- **Income**: SSI income `$900`/month (reported SSI receipt), Pension `$2,000`/month
+- **Assets**: `$6,000` (above the $3,000 standard limit)
+- **Current Benefits**: Currently receiving SSI, Not currently receiving SNAP/Food Assistance, Not receiving TANF
+
+**Why this matters**: With $24,000/yr of pension income, a from-scratch SSI computation would return $0 (over the SSI income limit) — which would wrongly deny categorical eligibility. Because the household's *reported* SSI receipt drives the categorical check, it stays eligible. This scenario fails if categorical eligibility ever reverts to using the modeled SSI amount instead of reported receipt.
 
 
 ## PE Verification

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -179,8 +179,8 @@ class MeetsSsiDisabilityCriteriaDependency(Member):
     is_ssi_aged OR is_blind OR is_ssi_disabled (verified in policyengine-us source),
     so including blindness here only adds to an OR and can never reduce eligibility.
 
-    min_pe_version gates this so it's only sent to models that define the variable —
-    it does not exist in 1.691.1 (current), where sending it 400s the whole request.
+    min_pe_version gates this so it's only sent to models that define it (first added in
+    1.715.2); sending it to an earlier pinned version would 400 the whole request.
     """
 
     field = "meets_ssi_disability_criteria"

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -173,21 +173,23 @@ class Tanf(SpmUnit):
     """
     tanf as both PE input and output.
 
-    - If user reports having tanf: send 1 so PE treats the household as
-      receiving TANF, enabling categorical eligibility for programs like
-      Early Head Start.
-    - If no reported tanf: return None so PE calculates the TANF benefit
-      amount the household is eligible for.
+    When the household reports a TANF cash amount, send it as the `tanf` value. A
+    positive `tanf` drives SNAP/Head Start/WIC categorical eligibility, and consumers
+    that read the amount (spm_unit_benefits, tx_ceap_countable_income, HUD income) get
+    the real figure. Otherwise send None so PE computes the benefit — we only override
+    when we have an actual reported amount.
+
+    has_base_benefit covers every white-label variant (ks_tanf, co_tanf, ma_tafdc, …);
+    has_benefit is an exact match that would miss the prefixed names.
     """
 
     field = "tanf"
 
     def value(self):
-        # Use has_base_benefit so every white-label TANF variant (ks_tanf, co_tanf,
-        # wa_tanf, ma_tafdc, …) counts — has_benefit("tanf") is an exact name match
-        # and would miss the prefixed names every white label actually records,
-        # silently disarming SNAP TANF categorical eligibility.
-        return 1 if self.screen.has_base_benefit("tanf") else None
+        if not self.screen.has_base_benefit("tanf"):
+            return None
+        reported_amount = self.screen.calc_gross_income("yearly", ["cashAssistance"])
+        return reported_amount if reported_amount > 0 else None
 
 
 class CoTanf(SpmUnit):

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -183,7 +183,11 @@ class Tanf(SpmUnit):
     field = "tanf"
 
     def value(self):
-        return 1 if self.screen.has_benefit("tanf") else None
+        # Use has_base_benefit so every white-label TANF variant (ks_tanf, co_tanf,
+        # wa_tanf, ma_tafdc, …) counts — has_benefit("tanf") is an exact name match
+        # and would miss the prefixed names every white label actually records,
+        # silently disarming SNAP TANF categorical eligibility.
+        return 1 if self.screen.has_base_benefit("tanf") else None
 
 
 class CoTanf(SpmUnit):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -7,6 +7,7 @@ by PolicyEngine to determine TX SNAP eligibility and benefit amounts.
 
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Expense
+from programs.models import Program
 from screener.tests.helpers import seed_program
 from screener.serializers import _write_current_benefits
 from programs.programs.policyengine.calculators.dependencies import spm
@@ -513,13 +514,31 @@ class TestTanfDependency(TestCase):
         dep = spm.Tanf(self.screen, None, {})
         self.assertEqual(dep.field, "tanf")
 
-    def test_value_returns_1_when_screen_has_tanf(self):
-        """When user reports having TANF, send 1 to PE to enable categorical eligibility."""
+    def _report_tanf(self):
+        """Seed a TANF program with base_program set (seed_program leaves it None) and
+        record receipt on the screen, mirroring how has_base_benefit resolves variants."""
         seed_program(self.white_label, "tanf")
+        Program.objects.filter(white_label=self.white_label, name_abbreviated="tanf").update(base_program="tanf")
         _write_current_benefits(self.screen, ["tanf"])
 
+    def test_value_returns_reported_amount_when_screen_has_tanf(self):
+        """When the household reports TANF with a cash amount, send that amount to PE."""
+        head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=35)
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=head, type="cashAssistance", amount=400, frequency="monthly"
+        )
+        self._report_tanf()
+
         dep = spm.Tanf(self.screen, None, {})
-        self.assertEqual(dep.value(), 1)
+        self.assertEqual(dep.value(), 4800)  # $400/month * 12
+
+    def test_value_returns_none_when_tanf_reported_without_amount(self):
+        """Reported receipt but no cash amount collected: return None (don't override with a
+        placeholder), so PE computes the benefit rather than seeing a bogus value."""
+        self._report_tanf()
+
+        dep = spm.Tanf(self.screen, None, {})
+        self.assertIsNone(dep.value())
 
     def test_value_returns_none_when_screen_does_not_have_tanf(self):
         """When user does not report TANF, return None so PE calculates the benefit amount."""


### PR DESCRIPTION
Follow-up to the merged KS SNAP PR (#1586). Fixes categorical/disability calculator inputs, corrects stale spec values, expands scenario coverage, and rewrites the spec as a timeless snapshot. Rebased on `main` (includes the SNAP student consolidation from #1613).

## Code fixes (federal `SNAP_BASE_INPUTS` — applies to all states)

- **SSI categorical eligibility** — Added the `Ssi` dependency so reported SSI receipt feeds PE's computed `ssi`, which drives `meets_snap_categorical_eligibility` (income/asset tests bypassed). An all-SSI household over the asset limit was previously denied. (Scenario 8.)
- **TANF categorical eligibility** — Added the `Tanf` dependency, sending the **reported cash-assistance amount** as PE's `tanf` value. A positive `tanf` drives categorical eligibility (7 CFR 273.2(j)(2)), and — because `tanf` is a USD amount read by downstream PE variables (`spm_unit_benefits`, `tx_ceap_countable_income`, HUD countable income) — sending the real figure keeps those correct. Receipt is detected via `has_base_benefit("tanf")`, so every white-label variant (`ks_tanf`, `co_tanf`, `ma_tafdc`, …) counts; `has_benefit("tanf")` is an exact match that misses the prefixed names. We override only when an actual amount is reported; otherwise PE computes the benefit. (Scenario 18.)
- **Disabled treatment** — Added `SsdiReportedDependency` (+ `MeetsSsiDisabilityCriteriaDependency`) so a disabled SSDI recipient is `is_usda_disabled` in PE, granting the **uncapped excess-shelter deduction** and the higher **$4,500 asset limit**. The generic `is_disabled` flag does not trigger this — PE requires disability-program receipt. (Scenario 17.)

## Spec value corrections

Every value scenario is re-derived independently from the FY2026 SNAP formula and confirmed against the calculator. Corrected 7 values, e.g. S13 was **$3,596/yr — mathematically impossible** (above the $3,576 HH1 maximum).

## New coverage scenarios

- **S15** asset-test pass just below $3,000
- **S16** household of five (allotment scaling)
- **S17** disabled non-elderly — uncapped shelter + $4,500 limit
- **S18** TANF cash categorical eligibility

## Spec is now a timeless snapshot

Removed all time-bound status from `spec.md` (blocked/pending/PR-referential notes, implementation history). The spec is a snapshot of expected eligibility criteria and test-case outcomes; status of what's pending external changes belongs in the ticket.

## Verification

All 18 KS SNAP scenarios pass end-to-end through the real `KsSnap` calculator against live PolicyEngine (1.752.2), values matching to the dollar — including S8 (SSI categorical), S10 (student job-training exemption, via #1613), S17 (disabled SSDI), and S18 (TANF categorical with a reported cash amount). Regression-checked: non-disabled / non-SSI households are unaffected (e.g. S6 still denied at $5k assets).

## Follow-up

PE's SNAP `categorical_eligibility` reads the `tanf` benefit amount directly (there is no `tanf_reported` seam like SSI's). A PE change to key the check off an enrollment flag (`is_tanf_enrolled`) has been requested — once it lands, reported TANF receipt could drive categorical eligibility without requiring a collected dollar amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SNAP calculations now more accurately use reported TANF and disability-related information to drive categorical eligibility and benefit results.
  * TANF handling now returns the reported cash amount when available (including white-label TANF variants).
* **Bug Fixes**
  * Improved disability-related SNAP behavior to align with SSDI/SSI criteria logic.
  * Updated Kansas SNAP scenario expectations, including student-exemption and SUA cases.
* **Tests**
  * Refreshed TANF and Kansas SNAP scenario coverage to match the latest expected annual/monthly outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Known: two SSI-categorical scenarios do not pass in this PR (fix tracked in MFB-1312)

Scenarios **S8** (all members report SSI → categorical) and **S22** (reported SSI with high other income → categorical) describe expected SNAP behavior and remain in the spec as a timeless snapshot, but they do **not** pass in the code shipping here. SSI categorical eligibility requires `use_reported_ssi`, which is global per PE request (flips `applicable_ssi` for every program — SNAP, IL AABD, KS TANF, TX CEAP). That federal, all-state change — verified to move IL AABD from $0 to $10,216 for a non-reporting SSI-simulated household — is out of scope for this KS SNAP PR and is handled in **MFB-1312** with all-consumer QA.

This PR ships: financial tests, **TANF categorical** (S18), and **disabled treatment** (S17) — all verified. Only the SSI-categorical scenarios defer.
