### PR TITLE
MFB-1197: Improve latency on screener results view

### DIFF
--- a/screener/views.py
+++ b/screener/views.py
@@ -165,15 +165,19 @@ class EligibilityTranslationView(views.APIView):
         EligibilitySnapshot — that ordering is locked by
         screener/tests/test_pe_version_override.py.
         """
-        screen = Screen.objects.select_related("white_label").prefetch_related(
-            "household_members",
-            "household_members__income_streams",
-            "household_members__insurance",
-            "household_members__energy_calculator",
-            "expenses",
-            "energy_calculator",
-            "current_benefits__program",
-        ).get(uuid=id)
+        screen = (
+            Screen.objects.select_related("white_label")
+            .prefetch_related(
+                "household_members",
+                "household_members__income_streams",
+                "household_members__insurance",
+                "household_members__energy_calculator",
+                "expenses",
+                "energy_calculator",
+                "current_benefits__program",
+            )
+            .get(uuid=id)
+        )
 
         is_admin = request.query_params.get("admin")
 

--- a/screener/views.py
+++ b/screener/views.py
@@ -77,9 +77,19 @@ class ScreenViewSet(
     API endpoint that allows screens to be viewed or edited.
     """
 
-    # Prefetch current_benefits__program so ScreenSerializer.to_representation can
-    # build the current_benefits list without a per-screen query.
-    queryset = Screen.objects.all().prefetch_related("current_benefits__program").order_by("-submission_date")
+    queryset = (
+        Screen.objects.all()
+        .select_related("user", "white_label")
+        .prefetch_related(
+            "current_benefits__program",
+            "household_members__income_streams",
+            "household_members__insurance",
+            "household_members__energy_calculator",
+            "expenses",
+            "energy_calculator",
+        )
+        .order_by("-submission_date")
+    )
     serializer_class = ScreenSerializer
     permission_classes = [permissions.DjangoModelPermissions]
     filterset_fields = ["agree_to_tos", "is_test"]
@@ -155,7 +165,7 @@ class EligibilityTranslationView(views.APIView):
         EligibilitySnapshot — that ordering is locked by
         screener/tests/test_pe_version_override.py.
         """
-        screen = Screen.objects.prefetch_related(
+        screen = Screen.objects.select_related("white_label").prefetch_related(
             "household_members",
             "household_members__income_streams",
             "household_members__insurance",
@@ -344,12 +354,10 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
 
     missing_dependencies = screen.missing_fields()
 
+    program_by_abbr = {p.name_abbreviated: p for p in all_programs}
     pe_calculators = {}
     for calculator_name, Calculator in all_calculators.items():
-        program: Optional[Program] = None
-        for p in all_programs:
-            if calculator_name == p.name_abbreviated:
-                program = p
+        program = program_by_abbr.get(calculator_name)
 
         if program is not None:
             pe_calculators[calculator_name] = Calculator(screen, program, missing_dependencies)


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Identified N+1 query patterns and algorithmic inefficiencies in the `GET /api/screens/<uuid>/` and `GET /eligibility/<id>` endpoints causing unnecessary DB overhead on every request.
- Benchmarked `GET /api/screens/<uuid>/` locally: ~24.8ms warm average before changes. Improvements are expected to be more pronounced in production where each additional DB roundtrip carries real network latency to Heroku Postgres.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- **`ScreenViewSet.queryset`** (`screener/views.py`): Added `select_related("user", "white_label")` and `prefetch_related` for `household_members__income_streams`, `household_members__insurance`, `household_members__energy_calculator`, `expenses`, and `energy_calculator`. Previously only `current_benefits__program` was prefetched, causing N+1 queries — one per household member per relation — on every `GET /api/screens/<uuid>/` request.

- **`EligibilityTranslationView` screen fetch** (`screener/views.py`): Added `select_related("white_label")` to the screen query. `screen.white_label` is accessed at least twice inside `eligibility_results` (once for the `Program` filter and once for the `Referrer` lookup) without being prefetched, causing 2+ extra DB queries per eligibility request.

- **`eligibility_results` PE calculator lookup** (`screener/views.py`): Replaced an O(n×m) nested loop — which scanned all programs for every PE calculator — with an O(n+m) dict lookup using a `program_by_abbr` dict built once from `all_programs`. With ~130 programs and a meaningful number of PE calculators, the old approach performed thousands of string comparisons per request.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None
- Configuration updates needed: None
- Environment variables/settings to add: None
- Manual testing steps:
  1. Start the local dev server
  2. Run the timing benchmark against a known screen UUID:
     ```bash
     for i in {1..5}; do
       curl -s -o /dev/null \
         -w "Run $i — Total: %{time_total}s\n" \
         -H "Authorization: Token <token>" \
         "http://localhost:8000/api/screens/<uuid>/"
     done
     ```
  3. Verify the eligibility endpoint still returns correct results for a test screen
  4. Confirm no regression in existing screener tests: `python manage.py test screener`

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: Re-run the timing benchmark against staging before and after deploy to capture the production-level improvement for stakeholder reporting

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: Local benchmarks showed ~24ms warm response times before and after — the improvement is not visible locally because the local DB has near-zero network latency. The gains are expected to surface in staging/production where each saved DB roundtrip carries Heroku Postgres network overhead.
- Future considerations:
  - The webhook call in `EligibilityTranslationView` (`hook.send(screen, results)`) runs synchronously before `return Response`, meaning any partner webhook latency is directly added to the user's response time. Moving this to a Celery task is the highest-impact remaining improvement.
  - `screen.completed = True; screen.save()` similarly blocks the response and could be deferred.
  - `screen.validations.all()` is not prefetched in `EligibilityTranslationView`, causing one extra DB query per eligibility request.
  - `EligibilitySnapshot.objects.prefetch_related("program_snapshots")` loads full snapshot objects just to compute a boolean `new` flag; a `.values("name_abbreviated", "eligible")` query would reduce data transfer.
  - PolicyEngine results are not cached — repeat requests for the same screen re-run the full PE API call. Caching by `(screen_id, data_hash, pe_version)` would eliminate the dominant cost for repeat requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading speed for screening and eligibility pages by reducing unnecessary data lookups.
  * Optimized eligibility result calculations for faster matching of programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->