### PR TITLE
MFB-1146: Count reported SSI + full SS in TX CEAP/LIHEAP income

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -248,6 +248,30 @@ class SsiReportedDependency(Member):
         return self.member.calc_gross_income("yearly", ["sSI"])
 
 
+class UseReportedSsiDependency(Member):
+    """
+    Tells PolicyEngine to count the household's *reported* SSI (ssi_reported)
+    instead of PE's *calculated* ssi when a program's countable income includes
+    applicable_ssi. Programs affected today: tx_ceap (TX CEAP/LIHEAP) and ks_tanf.
+
+    Without this, tx_ceap counts PE's modeled SSI (~$0 for a household that
+    reports receiving SSI but whose modeled entitlement differs), undercounting
+    income and pushing SS/SSI households into the wrong (too-generous) benefit
+    tier. We always send True so the screener's reported SSI drives the income
+    test — matching what the user told us.
+
+    min_pe_version gates this: use_reported_ssi / applicable_ssi were added in
+    policyengine-us 1.742.0 (PR #8732, 2026-06-23). Sending it to an earlier
+    model 400s the whole request.
+    """
+
+    field = "use_reported_ssi"
+    min_pe_version = (1, 742, 0)
+
+    def value(self):
+        return True
+
+
 class SsdiReportedDependency(Member):
     # Amount in "Social Security disability benefits (SSDI)"
     field = "social_security_disability"

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -251,18 +251,16 @@ class SsiReportedDependency(Member):
 class UseReportedSsiDependency(Member):
     """
     Tells PolicyEngine to count the household's *reported* SSI (ssi_reported)
-    instead of PE's *calculated* ssi when a program's countable income includes
-    applicable_ssi. Programs affected today: tx_ceap (TX CEAP/LIHEAP) and ks_tanf.
+    instead of PE's *calculated* ssi wherever a program's countable income reads
+    applicable_ssi (the calculator opts in by including this in its pe_inputs).
+    We always send True so the screener's reported SSI drives the income test.
 
-    Without this, tx_ceap counts PE's modeled SSI (~$0 for a household that
-    reports receiving SSI but whose modeled entitlement differs), undercounting
-    income and pushing SS/SSI households into the wrong (too-generous) benefit
-    tier. We always send True so the screener's reported SSI drives the income
-    test — matching what the user told us.
+    Person-level and global within a request: it flips applicable_ssi for every
+    program in that request, so only add it to calculators where reported SSI is
+    the correct measure.
 
-    min_pe_version gates this: use_reported_ssi / applicable_ssi were added in
-    policyengine-us 1.742.0 (PR #8732, 2026-06-23). Sending it to an earlier
-    model 400s the whole request.
+    min_pe_version gates this to the first model that defines use_reported_ssi;
+    sending it to an earlier model 400s the whole request.
     """
 
     field = "use_reported_ssi"

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -91,6 +91,17 @@ def all_eligibility(method: Sim, valid_programs: dict[str, PolicyEngineCalulator
     return all_eligibility
 
 
+def _has_gated_input(programs: List[PolicyEngineCalulator]) -> bool:
+    """True if any input/output in these programs is version-gated (has a
+    min_pe_version or max_pe_version). Lets us skip resolving the PE version when
+    nothing in the request depends on it."""
+    for program in programs:
+        for Data in program.pe_inputs + program.pe_outputs:
+            if getattr(Data, "min_pe_version", ()) or getattr(Data, "max_pe_version", ()):
+                return True
+    return False
+
+
 def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: Optional[str] = None):
     """
     Generate Policy Engine API request from the list of programs.
@@ -122,6 +133,18 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
     #   comparable_version (tuple)  -> tuple representation to gate which inputs are sent
     version = pe_versions.determine_pe_version(pe_version)
     comparable_version = pe_versions.to_comparable_pe_version(version)
+
+    # No pin (and no exact override) means "ride PE's current model": we omit the
+    # version string so PE serves current, but for input gating we still need to know
+    # what current concretely is — otherwise a min_pe_version floor can never be met
+    # and gated inputs (e.g. use_reported_ssi) are withheld forever. Resolve current
+    # from PE's published /versions/us. If PE is unreachable this stays None, keeping
+    # the conservative withhold-gated behavior (safe: PE just uses modeled values).
+    #
+    # Only bother resolving when this request actually carries a version-gated input —
+    # the vast majority don't, and resolving would be a needless (cached) lookup.
+    if comparable_version is None and _has_gated_input(programs):
+        comparable_version = pe_versions.resolve_unpinned_comparable_version()
 
     members: list[HouseholdMember] = screen.household_members.all()
     relationship_map = screen.relationship_map()

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -8,6 +8,8 @@ independent of any specific calculator's dependencies.
 Calculator-specific dependency tests belong in the state's pe/tests/ directory.
 """
 
+from unittest.mock import patch
+
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, Expense, IncomeStream
 from programs.programs.policyengine.policy_engine import pe_input
@@ -311,12 +313,34 @@ class TestPeInputVersionGating(PeInputTestBase):
         result = pe_input(self.screen, [self.ssi], pe_version=version)
         return "meets_ssi_disability_criteria" in result["household"]["people"][self.head_id]
 
-    def test_omitted_when_no_version_pinned(self):
-        # No pin => current default model (1.691.1), which lacks the variable.
-        self.assertFalse(self._meets_ssi_field_present(None))
+    # When unpinned (None / "current"), gating resolves what PE's current model is via
+    # resolve_unpinned_comparable_version(); mock it so these tests are deterministic
+    # and never hit the network. meets_ssi_disability_criteria's floor is (1, 715, 2).
+    def _mock_unpinned(self, resolved):
+        return patch(
+            "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version",
+            return_value=resolved,
+        )
 
-    def test_omitted_on_current_alias(self):
-        self.assertFalse(self._meets_ssi_field_present("current"))
+    def test_omitted_when_no_pin_and_current_below_floor(self):
+        # Unpinned + PE current resolves below the floor => variable does not exist there.
+        with self._mock_unpinned((1, 691, 1)):
+            self.assertFalse(self._meets_ssi_field_present(None))
+
+    def test_sent_when_no_pin_and_current_at_or_above_floor(self):
+        # Unpinned + PE current resolves at/above the floor => send it (this is the
+        # fix: gated inputs activate on an empty pin once current supports them).
+        with self._mock_unpinned((1, 732, 0)):
+            self.assertTrue(self._meets_ssi_field_present(None))
+
+    def test_omitted_when_no_pin_and_pe_unreachable(self):
+        # /versions/us unreachable => resolve returns None => conservative withhold.
+        with self._mock_unpinned(None):
+            self.assertFalse(self._meets_ssi_field_present(None))
+
+    def test_current_alias_resolves_like_no_pin(self):
+        with self._mock_unpinned((1, 732, 0)):
+            self.assertTrue(self._meets_ssi_field_present("current"))
 
     def test_omitted_on_older_pinned_version(self):
         self.assertFalse(self._meets_ssi_field_present("1.691.1"))
@@ -328,12 +352,14 @@ class TestPeInputVersionGating(PeInputTestBase):
         self.assertTrue(self._meets_ssi_field_present("1.800.0"))
 
     def test_sent_on_frontier_alias(self):
-        # frontier is the newest released model, so gated inputs are sent.
+        # frontier is the newest released model, so gated inputs are sent without a lookup.
         self.assertTrue(self._meets_ssi_field_present("frontier"))
 
     def test_ungated_input_always_present(self):
-        # A non-gated input (is_disabled) is sent regardless of version.
-        result = pe_input(self.screen, [self.ssi], pe_version=None)
+        # A non-gated input (is_disabled) is sent regardless of version. Ssi carries a
+        # gated input too, so an unpinned request resolves current — mock it offline.
+        with self._mock_unpinned(None):
+            result = pe_input(self.screen, [self.ssi], pe_version=None)
         self.assertIn("is_disabled", result["household"]["people"][self.head_id])
 
 
@@ -379,3 +405,63 @@ class TestVersionSupports(TestCase):
 
     def test_frontier_alias_satisfies_floor(self):
         self.assertTrue(self.supports(self.v("frontier"), (1, 715, 2), ()))
+
+
+class TestResolveUnpinnedVersion(TestCase):
+    """Unit tests for resolving PE's `current` from /versions/us for input gating
+    when there is no pin. Network is always mocked; cache is cleared per test."""
+
+    def setUp(self):
+        from programs.programs.policyengine import versions as pe_versions
+        from django.core.cache import cache
+
+        self.pe_versions = pe_versions
+        cache.delete(pe_versions._PE_VERSIONS_CACHE_KEY)
+
+    def _mock_get(self, *, json_data=None, exc=None, status_ok=True):
+        mock_resp = type("R", (), {})()
+        mock_resp.json = lambda: json_data
+        mock_resp.raise_for_status = (lambda: None) if status_ok else self._raise_http
+        if exc is not None:
+            return patch(
+                "programs.programs.policyengine.versions.requests.get",
+                side_effect=exc,
+            )
+        return patch(
+            "programs.programs.policyengine.versions.requests.get",
+            return_value=mock_resp,
+        )
+
+    @staticmethod
+    def _raise_http():
+        import requests
+
+        raise requests.HTTPError("500")
+
+    def test_resolves_current_to_tuple(self):
+        with self._mock_get(json_data={"current": "1.732.0", "frontier": "1.744.0"}):
+            self.assertEqual(self.pe_versions.resolve_unpinned_comparable_version(), (1, 732, 0))
+
+    def test_network_error_returns_none(self):
+        import requests
+
+        with self._mock_get(exc=requests.ConnectionError("down")):
+            self.assertIsNone(self.pe_versions.resolve_unpinned_comparable_version())
+
+    def test_malformed_payload_returns_none(self):
+        with self._mock_get(json_data={"unexpected": "shape"}):
+            self.assertIsNone(self.pe_versions.resolve_unpinned_comparable_version())
+
+    def test_result_is_cached(self):
+        with self._mock_get(json_data={"current": "1.732.0", "frontier": "1.744.0"}) as mock_get:
+            self.pe_versions.resolve_unpinned_comparable_version()
+            self.pe_versions.resolve_unpinned_comparable_version()
+            self.assertEqual(mock_get.call_count, 1)  # second call served from cache
+
+    def test_failure_not_cached(self):
+        import requests
+
+        with self._mock_get(exc=requests.ConnectionError("down")) as mock_get:
+            self.pe_versions.resolve_unpinned_comparable_version()
+            self.pe_versions.resolve_unpinned_comparable_version()
+            self.assertEqual(mock_get.call_count, 2)  # retried, not cached

--- a/programs/programs/policyengine/versions.py
+++ b/programs/programs/policyengine/versions.py
@@ -4,7 +4,7 @@ what each form means. Imported by:
   - configuration.models.PolicyEngineConfig (validates the pinned config value)
   - screener.views (validates the ?pe_version= override)
   - programs.programs.policyengine.policy_engine (parses the resolved version for
-    input gating)
+    input gating; when unpinned, resolves PE's current via resolve_unpinned_comparable_version)
 
 Two kinds of version string:
   - an exact package version, e.g. "1.715.2" (MAJOR.MINOR.PATCH) — the only form
@@ -14,8 +14,14 @@ Two kinds of version string:
     promotes a release, so storing one would let our served version move under us).
 """
 
+import logging
 import re
 from typing import Optional
+
+import requests
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
 
 # Exact MAJOR.MINOR.PATCH. The shape (not a hardcoded list) means new PolicyEngine
 # releases need no code change.
@@ -29,6 +35,17 @@ ALIASES = (CURRENT, FRONTIER)
 # Sentinel tuple meaning "newest released model" — compares greater than any real
 # version, so it satisfies any min_pe_version floor.
 NEWEST_VERSION = (float("inf"),)
+
+# PolicyEngine publishes what its floating aliases currently resolve to here:
+#   GET https://household.api.policyengine.org/versions/us -> {"current": "1.732.0", "frontier": "1.744.0"}
+# Used to gate inputs when we have NO pin (ride current): we must know what concrete
+# version "current" is right now, or a min_pe_version floor can never be satisfied.
+PE_VERSIONS_URL = "https://household.api.policyengine.org/versions/us"
+_PE_VERSIONS_CACHE_KEY = "pe_resolved_versions_us"
+# current/frontier only move when PE promotes a release, so a short TTL is plenty and
+# keeps this off the eligibility hot path. Worst case: gating is one TTL window stale
+# right after a PE promotion.
+_PE_VERSIONS_CACHE_TTL = 3600
 
 
 def is_valid_version_number(value: str) -> bool:
@@ -92,3 +109,39 @@ def version_supports(comparable_version: Optional[tuple], min_pe_version: tuple,
         if comparable_version is not None and comparable_version > max_pe_version:
             return False
     return True
+
+
+def _fetch_pe_versions() -> Optional[dict]:
+    """Fetch {"current": "...", "frontier": "..."} from PolicyEngine, cached.
+    Returns None on any failure (network, non-200, bad JSON) — callers must treat
+    None as "unknown" and fall back to the conservative (withhold-gated) path."""
+    cached = cache.get(_PE_VERSIONS_CACHE_KEY)
+    if cached is not None:
+        return cached
+    try:
+        res = requests.get(PE_VERSIONS_URL, timeout=(3, 5))
+        res.raise_for_status()
+        data = res.json()
+        if not isinstance(data, dict) or CURRENT not in data:
+            raise ValueError(f"unexpected payload: {data!r}")
+        cache.set(_PE_VERSIONS_CACHE_KEY, data, _PE_VERSIONS_CACHE_TTL)
+        return data
+    except (requests.RequestException, ValueError) as e:
+        # Don't cache failures — retry next request. Withholding gated inputs on a
+        # miss is safe (PE just uses modeled values); over-sending would 400.
+        logger.warning("Could not resolve PolicyEngine versions from %s: %s", PE_VERSIONS_URL, e)
+        return None
+
+
+def resolve_unpinned_comparable_version() -> Optional[tuple]:
+    """Comparable version to gate inputs against when there is NO pin (ride current).
+
+    With no pin we omit the version string so PE serves `current`; but for input
+    gating we must know what `current` concretely is, or a min_pe_version floor is
+    never satisfiable and version-gated inputs are withheld forever (silently). Ask
+    PE what `current` resolves to and gate against that. Returns None if PE can't be
+    reached — caller then keeps the conservative None (withhold-gated) behavior."""
+    data = _fetch_pe_versions()
+    if not data:
+        return None
+    return to_comparable_pe_version(data.get(CURRENT))

--- a/programs/programs/tx/liheap/spec.md
+++ b/programs/programs/tx/liheap/spec.md
@@ -363,18 +363,6 @@ All eligible scenarios include **heating `$200/month`**, required for PolicyEngi
 
 ---
 
-## Pre-Handoff Notes (Dev Items)
-
-1. **PE contribution — VA pension:** Add `veteran` income stream to `tx_ceap_eligible.py` (current categorical formula: TANF | SNAP | SSI only).
-2. **Screener gap:** Add `has_tx_liheap` to the TX white-label existing-benefits step under a new "Housing & Utilities" category (no generic `has_liheap` exists; `has_il_liheap` is IL-specific).
-3. **Screener gap:** Surface `electricity_is_disconnected` / `has_past_due_energy_bills` from the Energy Calculator into the standard screener (crisis component).
-4. **Screener gap (optional):** `pays_own_energy_bills` household-level question (criterion 4 data gap).
-5. **Import pre-check:** Confirm a 2026 `FederalPoveryLimit` row exists — the importer only *warns* if `year` lookup fails, which would silently ship the program with no income test. Run with `--dry-run` first.
-6. **Verify:** `show_in_has_benefits_step: false` — check whether the SNAP Heat-and-Eat exception applies.
-7. **Optional admin update:** The reused `211_texas` navigator (shared with `tx_wap`) has a non-E.164 phone and empty email; improved contact info (phone `+18775417905`, email `211@hhs.texas.gov`, "press Option 1") must be applied via admin — the importer does not update existing navigators.
-
----
-
 ## Source Documentation
 
 - https://liheapch.acf.gov/docs/2026/state-plans/TX_Plan_2026.pdf

--- a/programs/programs/tx/liheap/spec.md
+++ b/programs/programs/tx/liheap/spec.md
@@ -95,7 +95,7 @@ The benefit is a variable annual amount based on household income as a percentag
 
 > **Important for testing:** Because PE caps the benefit at reported energy expenses, every eligible test scenario must include a heating or cooling expense of at least `tier_maximum / 12` per month — otherwise PE returns $0. All eligible scenarios below include **heating `$200/month`** ($2,400/year, ≥ all tier maximums).
 
-> ⚠️ **Known PE income-definition gap:** PE's `tx_ceap` computes income as `irs_gross_income` (IRC §61), which counts only the *taxable* portion of Social Security (≈ $0 at these income levels) and excludes SSI entirely. TDHCA's actual rules (10 TAC §6.4; State Plan §1.9) count **gross** SSA benefits and SSI. Expected values below follow the program rules; until the PE income measure is aligned, scenarios whose income is mostly Social Security or SSI (S1, S6, S8, S13) will return **$1,800** from the live calculator instead of the values below. Wage-based scenarios are unaffected (MFB maps wages → `irs_employment_income` ✓), and VA pension is unaffected (`veteran` → `taxable_pension_income`, which IS counted ✓). See Open Dev Items.
+**Income counting:** `tx_ceap` countable income follows the TDHCA state-plan income sources list — full Social Security, pension, and alimony are counted; capital gains and child support are excluded (10 TAC §6.4 / State Plan §1.9). SSI is counted using the household's reported amount. Requires PolicyEngine **≥ 1.742.0**.
 
 **Methodology — income tier maximums (2026):**
 
@@ -155,26 +155,16 @@ All eligible scenarios assume **heating expense `$200/month`** is entered in the
 - [ ] Scenario 7 (SNAP Categorical Eligibility): User should be **eligible** with **$1,200/year**
 - [ ] Scenario 8 (High-Income Household with Priority Members — Ineligible): User should be **ineligible**
 - [ ] Scenario 9 (Household of 1 with Zero Income): User should be **eligible** with **$1,800/year**
-- [ ] Scenario 10 (Elderly Couple on Social Security + SSI): User should be **eligible** with **$1,800/year** ⚠️ *PE income-definition gap: policy tier is $1,500, but the live calculator returns $1,800 until the PE income measure is aligned (see Open Dev Items)*
+- [ ] Scenario 10 (Elderly Couple on Social Security + SSI): User should be **eligible** with **$1,500/year**
+- [ ] Scenario 11 (Single Adult on Social Security Retirement only): User should be **eligible** with **$1,500/year**
 
-Expected values reflect TDHCA program rules (gross income incl. SSA benefits and SSI per 10 TAC §6.4 and State Plan §1.9). Scenario 10's **$1,800** is the *live* value (the PE income gap drops its SS/SSI income, pushing it to the 0–50% tier); its policy-correct value is $1,500.
-
-### Test-suite audit (2026-06-10)
-
-The original 14-scenario suite was trimmed to 10 to give full coverage of the **measurable** calculator behavior without redundancy:
-
-- **Removed #10** (Already Receiving LIHEAP): not testable — requires a `has_tx_liheap` existing-benefits field that does not exist in the screener (Dev Item #3). Restore once that field ships.
-- **Removed old #6, #8** (elderly age 60 / 78): the calculator does not surface elderly *priority* in its output (priority neither gates eligibility nor changes value), so these duplicated the single-adult 76–150% tier already covered by old #7 (now Scenario 5). Both also depended on the SS/SSI gap.
-- **Removed old #13** (multi-priority 5-person SS/SSI household): priority flags are not in the calculator output, and the case depended on the SS/SSI gap; added no unique measurable coverage.
-- **Kept one SS/SSI case** (old #1 → Scenario 10) for realism, since elderly-on-fixed-Social-Security is the archetypal LIHEAP household; its expected value is documented as the live $1,800.
-
-Coverage retained across the 10: income-ceiling boundary (inclusive / just-below / just-over / well-over / zero), all three benefit tiers ($1,800 / $1,500 / $1,200), SNAP and SSI categorical eligibility, and the energy-expense cap.
+Expected values reflect TDHCA program rules (gross income incl. SSA benefits and SSI per 10 TAC §6.4 and State Plan §1.9).
 
 ---
 
 ## Test Scenarios
 
-> **Suite note (2026-06-10):** Trimmed from 14 to 10 scenarios — see the *Test-suite audit* under Acceptance Criteria. Removed the untestable "already receiving LIHEAP" case (no `has_tx_liheap` field) and three redundant elderly/priority cases (priority is not in the calculator output). One elderly-on-Social-Security case is retained (Scenario 10) for realism, with its expected value documented as the live $1,800 produced by the PE SS/SSI income gap.
+All eligible scenarios include **heating `$200/month`**, required for PolicyEngine to return a non-zero benefit (the benefit is capped at reported energy expense — see Benefit Value).
 
 ### Scenario 1: Minimally Eligible Single Adult at Income Ceiling
 
@@ -215,7 +205,7 @@ Coverage retained across the 10: income-ceiling boundary (inclusive / just-below
 
 ### Scenario 3: VA Pension — 51–75% Tier
 
-**What we're checking**: Household with a veteran receiving VA pension income is eligible and lands in the 51–75% benefit tier. VA pension maps to `taxable_pension_income`, which the PE income measure counts correctly — so this tier is verifiable today (unlike SS/SSI income).
+**What we're checking**: Household with a veteran receiving VA pension income is eligible and lands in the 51–75% benefit tier.
 
 **Expected**: Eligible, **$1,500/year**
 
@@ -226,7 +216,7 @@ Coverage retained across the 10: income-ceiling boundary (inclusive / just-below
 - **Expenses**: Heating `$200/month`
 - **Current Benefits**: None
 
-**Why this matters**: Covers the 51–75% tier with income PE counts correctly. Income $800/month = $9,600/year; 60.2% of 2026 FPL for HH1 ($15,960) → 51–75% tier → $1,500/year. Screener captures this via `income_streams[].type === 'veteran'`. (Note: the spec's categorical VA-pension pathway in `tx_ceap_eligible` is a pending PE contribution — Dev Item #1 — but this household passes on income alone, so the tier and eligibility are verifiable now.)
+**Why this matters**: Covers the 51–75% tier. Income $800/month = $9,600/year; 60.2% of 2026 FPL for HH1 ($15,960) → 51–75% tier → $1,500/year. Screener captures this via `income_streams[].type === 'veteran'`.
 
 ---
 
@@ -317,7 +307,7 @@ Coverage retained across the 10: income-ceiling boundary (inclusive / just-below
 - **Person 4**: Birth `November 2022` (age 3), grandchild (select "Grandchild"), no income
 - **Current Benefits**: None (no TANF, SSI, or SNAP)
 
-**Why this matters**: Confirms that priority criteria (elderly, disabled, young child) do not bypass the income eligibility requirement. Combined income $6,600/month = $79,200/year; 240% of 2026 FPL for HH4 ($33,000) → correctly ineligible regardless of vulnerable household members. (Ineligible regardless of the SS/SSI income gap — even counting only the $5,700 wages, the household is far over the limit.)
+**Why this matters**: Confirms that priority criteria (elderly, disabled, young child) do not bypass the income eligibility requirement. Combined income $6,600/month = $79,200/year; 240% of 2026 FPL for HH4 ($33,000) → correctly ineligible regardless of vulnerable household members.
 
 ---
 
@@ -338,11 +328,11 @@ Coverage retained across the 10: income-ceiling boundary (inclusive / just-below
 
 ---
 
-### Scenario 10: Elderly Couple on Social Security + SSI (realism case)
+### Scenario 10: Elderly Couple on Social Security + SSI
 
-**What we're checking**: The archetypal LIHEAP household — an elderly couple on fixed Social Security with SSI — is eligible (via SSI categorical eligibility and on income grounds). This case documents the **PE SS/SSI income gap**: its policy-correct tier is 51–75% ($1,500), but the live calculator returns $1,800.
+**What we're checking**: An elderly couple on fixed Social Security with SSI is eligible (via SSI categorical eligibility and on income grounds) and lands in the 51–75% benefit tier. Verifies that full Social Security and reported SSI are counted in income.
 
-**Expected**: Eligible, **$1,800/year** ⚠️ *PE income-definition gap: `tx_ceap` uses `irs_gross_income`, which counts ~$0 of this household's Social Security and excludes SSI, dropping computed income to ~0% FPL → 0–50% tier → $1,800. Policy-correct value is $1,500 (66.5% FPL). Tracked as Dev Item #2.*
+**Expected**: Eligible, **$1,500/year**
 
 **Steps**:
 - **Location**: ZIP `78702`, county `Travis`
@@ -352,20 +342,36 @@ Coverage retained across the 10: income-ceiling boundary (inclusive / just-below
 - **Expenses**: Heating `$200/month`
 - **Current Benefits**: SSI → Yes
 
-**Why this matters**: Elderly-on-fixed-income is LIHEAP's core population, so the suite keeps one such case for realism even though its dollar value reflects the known PE gap. Validates SSI categorical eligibility. Policy: combined income $1,200/month = $14,400/year; 66.5% of 2026 FPL for HH2 ($21,640) → 51–75% tier → $1,500/year. Live: PE drops the SS/SSI income → 0–50% tier → $1,800/year.
+**Why this matters**: Elderly-on-fixed-income is LIHEAP's core population. Validates SSI categorical eligibility. Combined income $1,200/month = $14,400/year; 66.5% of 2026 FPL for HH2 ($21,640) → 51–75% tier → $1,500/year.
+
+---
+
+### Scenario 11: Single Adult on Social Security Retirement Only
+
+**What we're checking**: A single elderly adult whose only income is Social Security Retirement is eligible and lands in the 51–75% tier, confirming full Social Security is counted in income.
+
+**Expected**: Eligible, **$1,500/year**
+
+**Steps**:
+- **Location**: ZIP `78701`, county `Travis`
+- **Household**: 1 person
+- **Person 1**: Birth `April 1958` (age 68), head of household, Social Security Retirement `$800/month`
+- **Expenses**: Heating `$200/month`
+- **Current Benefits**: None
+
+**Why this matters**: Income $800/month = $9,600/year; 60.2% of 2026 FPL for HH1 ($15,960) → 51–75% tier → $1,500/year. Covers the 51–75% tier via a Social Security income stream.
 
 ---
 
 ## Pre-Handoff Notes (Dev Items)
 
 1. **PE contribution — VA pension:** Add `veteran` income stream to `tx_ceap_eligible.py` (current categorical formula: TANF | SNAP | SSI only).
-2. **PE contribution — income measure:** `tx_ceap`/`tx_ceap_eligible` use `irs_gross_income`, which counts only taxable Social Security and excludes SSI — contrary to 10 TAC §6.4 / State Plan §1.9 (gross income incl. SSA benefits and SSI). Until fixed, SS/SSI-income households are shown the $1,800 tier regardless of actual tier (affects Scenario 10 in the trimmed suite; originally also old Scenarios 6, 8, 13, which were removed as redundant). Raise alongside item 1.
-3. **Screener gap:** Add `has_tx_liheap` to the TX white-label existing-benefits step under a new "Housing & Utilities" category (no generic `has_liheap` exists; `has_il_liheap` is IL-specific). Unblocks Scenario 10.
-4. **Screener gap:** Surface `electricity_is_disconnected` / `has_past_due_energy_bills` from the Energy Calculator into the standard screener (crisis component).
-5. **Screener gap (optional):** `pays_own_energy_bills` household-level question (criterion 4 data gap).
-6. **Import pre-check:** Confirm a 2026 `FederalPoveryLimit` row exists — the importer only *warns* if `year` lookup fails, which would silently ship the program with no income test. Run with `--dry-run` first.
-7. **Verify:** `show_in_has_benefits_step: false` — check whether the SNAP Heat-and-Eat exception applies.
-8. **Optional admin update:** The reused `211_texas` navigator (shared with `tx_wap`) has a non-E.164 phone and empty email; improved contact info (phone `+18775417905`, email `211@hhs.texas.gov`, "press Option 1") must be applied via admin — the importer does not update existing navigators.
+2. **Screener gap:** Add `has_tx_liheap` to the TX white-label existing-benefits step under a new "Housing & Utilities" category (no generic `has_liheap` exists; `has_il_liheap` is IL-specific).
+3. **Screener gap:** Surface `electricity_is_disconnected` / `has_past_due_energy_bills` from the Energy Calculator into the standard screener (crisis component).
+4. **Screener gap (optional):** `pays_own_energy_bills` household-level question (criterion 4 data gap).
+5. **Import pre-check:** Confirm a 2026 `FederalPoveryLimit` row exists — the importer only *warns* if `year` lookup fails, which would silently ship the program with no income test. Run with `--dry-run` first.
+6. **Verify:** `show_in_has_benefits_step: false` — check whether the SNAP Heat-and-Eat exception applies.
+7. **Optional admin update:** The reused `211_texas` navigator (shared with `tx_wap`) has a non-E.164 phone and empty email; improved contact info (phone `+18775417905`, email `211@hhs.texas.gov`, "press Option 1") must be applied via admin — the importer does not update existing navigators.
 
 ---
 

--- a/programs/programs/tx/pe/spm.py
+++ b/programs/programs/tx/pe/spm.py
@@ -103,6 +103,16 @@ class TxCeap(PolicyEngineSpmCalulator):
     pe_inputs = [
         dependency.household.TxStateCodeDependency,
         *dependency.irs_gross_income,
+        # As of policyengine-us 1.728.0, tx_ceap derives countable income from the TX
+        # state-plan income sources list (full Social Security, pension, alimony; cap
+        # gains and child support excluded) rather than irs_gross_income. That list
+        # counts applicable_ssi, which resolves to the household's reported SSI only
+        # when use_reported_ssi is True (added in 1.742.0) — so we send both the
+        # reported SSI amount and the toggle. Without them, PE's modeled (calculated)
+        # SSI is counted instead, undercounting income and over-tiering SS/SSI
+        # households (the MFB-1146 gap).
+        dependency.member.SsiReportedDependency,
+        dependency.member.UseReportedSsiDependency,
         # tx_ceap caps the payment at electricity_expense + gas_expense; route the
         # screener's energy expenses into electricity_expense so the cap is non-zero.
         dependency.spm.TxCeapEnergyExpenseDependency,

--- a/programs/programs/tx/pe/spm.py
+++ b/programs/programs/tx/pe/spm.py
@@ -103,14 +103,10 @@ class TxCeap(PolicyEngineSpmCalulator):
     pe_inputs = [
         dependency.household.TxStateCodeDependency,
         *dependency.irs_gross_income,
-        # As of policyengine-us 1.728.0, tx_ceap derives countable income from the TX
-        # state-plan income sources list (full Social Security, pension, alimony; cap
-        # gains and child support excluded) rather than irs_gross_income. That list
-        # counts applicable_ssi, which resolves to the household's reported SSI only
-        # when use_reported_ssi is True (added in 1.742.0) — so we send both the
-        # reported SSI amount and the toggle. Without them, PE's modeled (calculated)
-        # SSI is counted instead, undercounting income and over-tiering SS/SSI
-        # households (the MFB-1146 gap).
+        # tx_ceap counts SSI via applicable_ssi, which uses the household's reported
+        # SSI only when use_reported_ssi is True; otherwise PE substitutes its own
+        # modeled SSI (~0 for screener inputs), undercounting income. Send both the
+        # reported amount and the toggle so the household's actual SSI drives the tier.
         dependency.member.SsiReportedDependency,
         dependency.member.UseReportedSsiDependency,
         # tx_ceap caps the payment at electricity_expense + gas_expense; route the

--- a/programs/programs/tx/pe/tests/test_spm.py
+++ b/programs/programs/tx/pe/tests/test_spm.py
@@ -337,3 +337,29 @@ class TestTxCeap(TestCase):
         """The calculator outputs the tx_ceap variable to PolicyEngine."""
         self.assertIn(spm.TxCeap, TxCeap.pe_outputs)
         self.assertEqual(spm.TxCeap.field, "tx_ceap")
+
+    def test_pe_inputs_includes_reported_ssi_inputs(self):
+        """
+        MFB-1146: tx_ceap counts applicable_ssi, which only reflects the household's
+        *reported* SSI when use_reported_ssi is sent True. Both the reported amount
+        and the toggle must be in pe_inputs, otherwise PE counts modeled SSI and
+        SS/SSI households land in the wrong (too-generous) benefit tier.
+        """
+        self.assertIn(member.SsiReportedDependency, TxCeap.pe_inputs)
+        self.assertIn(member.UseReportedSsiDependency, TxCeap.pe_inputs)
+        self.assertEqual(member.UseReportedSsiDependency.field, "use_reported_ssi")
+
+    def test_use_reported_ssi_is_version_gated(self):
+        """
+        use_reported_ssi / applicable_ssi were added in policyengine-us 1.742.0.
+        The dependency must carry that floor so it is never sent to an earlier model
+        (which would 400 the whole request). The reported-amount input (ssi_reported)
+        has existed since 2022, so it stays ungated.
+        """
+        self.assertEqual(member.UseReportedSsiDependency.min_pe_version, (1, 742, 0))
+        self.assertEqual(member.SsiReportedDependency.min_pe_version, ())
+
+    def test_use_reported_ssi_value_is_true(self):
+        """The toggle is always True so the screener's reported SSI drives the income test."""
+        dep = member.UseReportedSsiDependency(None, None, {})
+        self.assertTrue(dep.value())


### PR DESCRIPTION
## Summary

Closes MFB-1146. Fixes the `tx_ceap` (TX CEAP / MFB `tx_liheap`) income-measure gap that undercounted Social Security and SSI income for SS/SSI households, dropping them into the 0–50% FPG tier and showing the `$1,800` max regardless of their true tier.

PolicyEngine fixed the underlying model in two parts:

| PE change | Version |
| --- | --- |
| `tx_ceap` income basis → TDHCA state-plan income sources (full SS/pension/alimony; cap gains & child support excluded) | 1.728.0 |
| `use_reported_ssi` toggle + `applicable_ssi` (count reported SSI instead of modeled SSI) | 1.742.0 |

The income-basis change is automatic; the SSI half is opt-in (`use_reported_ssi` defaults to `false`). This PR wires up the opt-in **and** makes the version gate actually fire in unpinned environments.

## Changes

**1. Wire reported SSI into TX CEAP**
- `member.py` — new `UseReportedSsiDependency` (`use_reported_ssi = True`), gated `min_pe_version = (1, 742, 0)` so it's never sent to a model that lacks the variable (which would 400 the whole request).
- `tx/pe/spm.py` — `TxCeap.pe_inputs` now sends `SsiReportedDependency` + `UseReportedSsiDependency` so PE's `applicable_ssi` resolves to the household's *reported* SSI.

**2. Resolve PE's `current` version for input gating when unpinned**
- Without a pin, the resolved version was `None`, which fails every `min_pe_version` floor — so version-gated inputs were withheld **forever** in any environment that rides PE's `current` model, with no signal. The gate in (1) would have been dead code there.
- `versions.py` — new `resolve_unpinned_comparable_version()` calls PE's `GET /versions/us`, reads `current`, returns it as a comparable tuple. Cached (1h TTL); failures aren't cached and fall back to `None` (conservative withhold — safe, since over-sending 400s the request).
- `policy_engine.py` — when there's no pin (and no exact override), gate against the resolved `current` while still **omitting** the version string so PE keeps serving current. Only resolves when the request actually carries a gated input.
- Net effect: gated inputs auto-activate once PE's `current` reaches their floor, with no config change. This also fixed a pre-existing latent bug — `meets_ssi_disability_criteria` (floor 1.715.2) was being silently withheld on unpinned environments and now sends correctly.

**3. spec.md → final artifact + version-agnostic comments**
- `tx/liheap/spec.md` — Scenario 10 expected `$1,800` → `$1,500`; added Scenario 11 (SS-only) to isolate the income-basis change from the SSI path. Removed the test-suite audit / change-history narrative and the "Pre-Handoff Notes (Dev Items)" section (tracked in Linear instead).
- Code comments rewritten to explain the durable *why* (reported vs. modeled SSI, the global-per-request gate behavior) without citing release numbers, PR numbers, dates, or ticket IDs that go stale.

## Behavior after this PR

| Served PE `current` | Result |
| --- | --- |
| < 1.742.0 (e.g. today's 1.732.0) | `use_reported_ssi` correctly withheld (variable doesn't exist yet); SS counted, SSI modeled |
| ≥ 1.742.0 | reported SSI counted → SS/SSI households land in their policy-correct tier, automatically, with no pin needed |

An explicit pin still works and overrides resolution. The fix no longer *requires* a manual pin to activate — it follows PE's `current`.

## Verification

- Unit tests: `programs/programs/tx/` + `programs/programs/policyengine/` → **575 passed**. Verified (via a network-block harness) that no test makes an unmocked call to `/versions/us`.
- Live check against the real PE API: `current` resolves to `1.732.0`; `use_reported_ssi` correctly withheld today, `meets_ssi_disability_criteria` correctly sent.
- Local API QA (`?pe_version=frontier`): Scenario 10 → **$1,500**, Scenario 11 → **$1,500**, Scenarios 1/3/9 unchanged. Counterfactual on the un-overridden model confirms the change does the work.
- [ ] Staging/prod QA once running a `current` ≥ 1.742.0 (or pinned there): re-run `/api-qa-execution MFB-1120` and update MFB-1120.

## Related

- MFB-1195 — PolicyEngine catch-up / pin to 1.744.0 (the version bump that brings `current` to ≥ 1.742.0).
- MFB-1234 — version-resolution design (implemented here).
- MFB-1224 — follow-up: map screener energy expenses to PE utility fields by meaning (separate, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)