### PR TITLE
MFB-1094: Single-benefit toggle endpoint for results page benefits-api

### DIFF
--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -242,9 +242,11 @@ class ScreenSerializer(serializers.ModelSerializer):
     # max_length bounds an otherwise-unbounded payload: there are ~130 distinct
     # name_abbreviated values across all white labels, so 256 is a comfortable
     # ceiling. Unknown names are dropped in _write_current_benefits(), so element
-    # content needn't be validated here.
+    # content needn't be validated here. The per-element cap mirrors the
+    # Program.name_abbreviated column (max_length=120) so no DB-valid name is
+    # rejected here.
     current_benefits = serializers.ListField(
-        child=serializers.CharField(max_length=64),
+        child=serializers.CharField(max_length=120),
         required=False,
         write_only=True,
         max_length=256,
@@ -426,9 +428,12 @@ class CurrentBenefitToggleSerializer(serializers.Serializer):
     `program` is a `name_abbreviated`; `has` selects add (True) vs remove (False).
     Resolving the name to a Program and writing the join-table row happen in the
     view, which has the screen (and thus its white_label) in hand.
+
+    `program`'s max_length mirrors the Program.name_abbreviated column (120) so no
+    DB-valid name is rejected before the white-label-scoped lookup in the view.
     """
 
-    program = serializers.CharField(max_length=64)
+    program = serializers.CharField(max_length=120)
     has = serializers.BooleanField()
 
 

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -420,6 +420,18 @@ class ScreenSerializer(serializers.ModelSerializer):
         return instance
 
 
+class CurrentBenefitToggleSerializer(serializers.Serializer):
+    """Input for the single-benefit toggle endpoint (PATCH .../current-benefits/).
+
+    `program` is a `name_abbreviated`; `has` selects add (True) vs remove (False).
+    Resolving the name to a Program and writing the join-table row happen in the
+    view, which has the screen (and thus its white_label) in hand.
+    """
+
+    program = serializers.CharField(max_length=64)
+    has = serializers.BooleanField()
+
+
 class NavigatorSerializer(serializers.Serializer):
     name = TranslationSerializer()
     phone_number = serializers.CharField()

--- a/screener/serializers.py
+++ b/screener/serializers.py
@@ -423,17 +423,17 @@ class ScreenSerializer(serializers.ModelSerializer):
 
 
 class CurrentBenefitToggleSerializer(serializers.Serializer):
-    """Input for the single-benefit toggle endpoint (PATCH .../current-benefits/).
+    """Input for the single-benefit toggle endpoint (PATCH /screens/<uuid:screen_uuid>/current-benefits/).
 
-    `program` is a `name_abbreviated`; `has` selects add (True) vs remove (False).
+    `name_abbreviated` is a program name_abbreviated value; `has` selects add (True) vs remove (False).
     Resolving the name to a Program and writing the join-table row happen in the
     view, which has the screen (and thus its white_label) in hand.
 
-    `program`'s max_length mirrors the Program.name_abbreviated column (120) so no
+    `name_abbreviated`'s max_length mirrors the Program.name_abbreviated column (120) so no
     DB-valid name is rejected before the white-label-scoped lookup in the view.
     """
 
-    program = serializers.CharField(max_length=120)
+    name_abbreviated = serializers.CharField(max_length=120)
     has = serializers.BooleanField()
 
 

--- a/screener/tests/test_current_benefits_toggle.py
+++ b/screener/tests/test_current_benefits_toggle.py
@@ -2,7 +2,7 @@
 Tests for the single-benefit toggle endpoint:
 
     PATCH /api/screens/<uuid>/current-benefits/
-    body: {"program": "snap", "has": true|false}
+    body: {"name_abbreviated": "snap", "has": true|false}
 
 A lightweight add/remove of one CurrentBenefit row consumed by the results-page
 "already have this" toggle. Resolution is white-label-scoped and the
@@ -19,7 +19,7 @@ from screener.models import CurrentBenefit, Screen, WhiteLabel
 from screener.serializers import CurrentBenefitToggleSerializer
 from screener.tests.helpers import seed_program
 
-# Program.name_abbreviated column max_length — the `program` field cap must match it.
+# Program.name_abbreviated column max_length — the `name_abbreviated` field cap must match it.
 NAME_ABBREVIATED_MAX_LENGTH = Program._meta.get_field("name_abbreviated").max_length
 
 
@@ -48,7 +48,7 @@ class CurrentBenefitsToggleTests(APITestCase):
 
     def test_add_new_benefit(self):
         """has=true creates the row and the response reflects the updated list."""
-        response = self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "snap", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"current_benefits": ["snap"]})
@@ -56,10 +56,10 @@ class CurrentBenefitsToggleTests(APITestCase):
 
     def test_remove_existing_benefit(self):
         """has=false deletes the row and the response reflects the updated list."""
-        self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
-        self.client.patch(self.url, {"program": "tanf", "has": True}, format="json")
+        self.client.patch(self.url, {"name_abbreviated": "snap", "has": True}, format="json")
+        self.client.patch(self.url, {"name_abbreviated": "tanf", "has": True}, format="json")
 
-        response = self.client.patch(self.url, {"program": "snap", "has": False}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "snap", "has": False}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"current_benefits": ["tanf"]})
@@ -67,8 +67,8 @@ class CurrentBenefitsToggleTests(APITestCase):
 
     def test_repeat_add_is_idempotent(self):
         """Adding a benefit that already exists is a no-op — no error, no duplicate row."""
-        self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
-        response = self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
+        self.client.patch(self.url, {"name_abbreviated": "snap", "has": True}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "snap", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"current_benefits": ["snap"]})
@@ -76,7 +76,7 @@ class CurrentBenefitsToggleTests(APITestCase):
 
     def test_repeat_remove_is_idempotent(self):
         """Removing a benefit that isn't present is a no-op — no error."""
-        response = self.client.patch(self.url, {"program": "snap", "has": False}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "snap", "has": False}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"current_benefits": []})
@@ -87,14 +87,14 @@ class CurrentBenefitsToggleTests(APITestCase):
         other_wl = WhiteLabel.objects.create(name="Other", code="other", state_code="OT")
         seed_program(other_wl, "other_only")
 
-        response = self.client.patch(self.url, {"program": "other_only", "has": True}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "other_only", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(self._benefit_names(), set())
 
     def test_unknown_program_is_404(self):
         """An unknown name_abbreviated is a 404, not a silent no-op."""
-        response = self.client.patch(self.url, {"program": "not_a_real_program", "has": True}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "not_a_real_program", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(self._benefit_names(), set())
@@ -102,27 +102,27 @@ class CurrentBenefitsToggleTests(APITestCase):
     def test_unknown_screen_is_404(self):
         """An unknown screen uuid is a 404."""
         url = "/api/screens/00000000-0000-0000-0000-000000000000/current-benefits/"
-        response = self.client.patch(url, {"program": "snap", "has": True}, format="json")
+        response = self.client.patch(url, {"name_abbreviated": "snap", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_missing_program_is_400(self):
-        """program is required."""
+    def test_missing_name_abbreviated_is_400(self):
+        """name_abbreviated is required."""
         response = self.client.patch(self.url, {"has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("program", response.data)
+        self.assertIn("name_abbreviated", response.data)
 
     def test_missing_has_is_400(self):
         """has is required."""
-        response = self.client.patch(self.url, {"program": "snap"}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": "snap"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("has", response.data)
 
     def test_unauthenticated_is_rejected(self):
         """Unauthenticated requests are rejected (401 or 403, per DRF auth-class config)."""
-        response = APIClient().patch(self.url, {"program": "snap", "has": True}, format="json")
+        response = APIClient().patch(self.url, {"name_abbreviated": "snap", "has": True}, format="json")
 
         self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))
         self.assertEqual(self._benefit_names(), set())
@@ -133,15 +133,15 @@ class CurrentBenefitsToggleTests(APITestCase):
         no_perms_client = APIClient()
         no_perms_client.force_authenticate(user=no_perms_user)
 
-        response = no_perms_client.patch(self.url, {"program": "snap", "has": True}, format="json")
+        response = no_perms_client.patch(self.url, {"name_abbreviated": "snap", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self._benefit_names(), set())
 
-    def test_program_cap_matches_db_column(self):
-        """The `program` field cap equals the Program.name_abbreviated column, so a
+    def test_name_abbreviated_cap_matches_db_column(self):
+        """The `name_abbreviated` field cap equals the Program.name_abbreviated column, so a
         DB-valid name is never rejected for length before the WL-scoped lookup."""
-        field = CurrentBenefitToggleSerializer().fields["program"]
+        field = CurrentBenefitToggleSerializer().fields["name_abbreviated"]
         self.assertEqual(field.max_length, NAME_ABBREVIATED_MAX_LENGTH)
 
     def test_name_at_column_max_clears_validation(self):
@@ -149,7 +149,7 @@ class CurrentBenefitsToggleTests(APITestCase):
         WL-scoped lookup — 404 here only because no such Program exists, proving the
         length didn't reject it (a 400 would mean the cap is too tight)."""
         name = "a" * NAME_ABBREVIATED_MAX_LENGTH
-        response = self.client.patch(self.url, {"program": name, "has": True}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": name, "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -157,7 +157,7 @@ class CurrentBenefitsToggleTests(APITestCase):
         """A name longer than the column is rejected by the serializer (400), never
         reaching the lookup."""
         name = "a" * (NAME_ABBREVIATED_MAX_LENGTH + 1)
-        response = self.client.patch(self.url, {"program": name, "has": True}, format="json")
+        response = self.client.patch(self.url, {"name_abbreviated": name, "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("program", response.data)
+        self.assertIn("name_abbreviated", response.data)

--- a/screener/tests/test_current_benefits_toggle.py
+++ b/screener/tests/test_current_benefits_toggle.py
@@ -1,0 +1,134 @@
+"""
+Tests for the single-benefit toggle endpoint:
+
+    PATCH /api/v2/screens/<uuid>/current-benefits/
+    body: {"program": "snap", "has": true|false}
+
+A lightweight add/remove of one CurrentBenefit row consumed by the results-page
+"already have this" toggle (MFB-871). Resolution is white-label-scoped and the
+operation is idempotent. See screener.views.ScreenCurrentBenefitsView.
+"""
+
+from django.contrib.auth.models import Permission
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from authentication.models import User
+from screener.models import CurrentBenefit, Screen, WhiteLabel
+from screener.tests.helpers import seed_program
+
+
+class CurrentBenefitsToggleTests(APITestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="78701", household_size=1, completed=False
+        )
+        seed_program(self.white_label, "snap", "tanf")
+
+        self.url = f"/api/v2/screens/{self.screen.uuid}/current-benefits/"
+
+        # Same gate as the Screen PATCH path: DjangoModelPermissions maps PATCH to
+        # screener.change_screen, so the test user needs that perm.
+        self.user = User.objects.create_user(email_or_cell="toggle@example.com", password="password")
+        self.user.user_permissions.add(Permission.objects.get(codename="change_screen"))
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _benefit_names(self):
+        return set(
+            CurrentBenefit.objects.filter(screen=self.screen).values_list("program__name_abbreviated", flat=True)
+        )
+
+    def test_add_new_benefit(self):
+        """has=true creates the row and the response reflects the updated list."""
+        response = self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"current_benefits": ["snap"]})
+        self.assertEqual(self._benefit_names(), {"snap"})
+
+    def test_remove_existing_benefit(self):
+        """has=false deletes the row and the response reflects the updated list."""
+        self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
+        self.client.patch(self.url, {"program": "tanf", "has": True}, format="json")
+
+        response = self.client.patch(self.url, {"program": "snap", "has": False}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"current_benefits": ["tanf"]})
+        self.assertEqual(self._benefit_names(), {"tanf"})
+
+    def test_repeat_add_is_idempotent(self):
+        """Adding a benefit that already exists is a no-op — no error, no duplicate row."""
+        self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
+        response = self.client.patch(self.url, {"program": "snap", "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"current_benefits": ["snap"]})
+        self.assertEqual(CurrentBenefit.objects.filter(screen=self.screen).count(), 1)
+
+    def test_repeat_remove_is_idempotent(self):
+        """Removing a benefit that isn't present is a no-op — no error."""
+        response = self.client.patch(self.url, {"program": "snap", "has": False}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"current_benefits": []})
+        self.assertEqual(self._benefit_names(), set())
+
+    def test_wrong_white_label_is_404(self):
+        """A program offered only by another white label can't be toggled (404, no write)."""
+        other_wl = WhiteLabel.objects.create(name="Other", code="other", state_code="OT")
+        seed_program(other_wl, "other_only")
+
+        response = self.client.patch(self.url, {"program": "other_only", "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self._benefit_names(), set())
+
+    def test_unknown_program_is_404(self):
+        """An unknown name_abbreviated is a 404, not a silent no-op."""
+        response = self.client.patch(self.url, {"program": "not_a_real_program", "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self._benefit_names(), set())
+
+    def test_unknown_screen_is_404(self):
+        """An unknown screen uuid is a 404."""
+        url = "/api/v2/screens/00000000-0000-0000-0000-000000000000/current-benefits/"
+        response = self.client.patch(url, {"program": "snap", "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_missing_program_is_400(self):
+        """program is required."""
+        response = self.client.patch(self.url, {"has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("program", response.data)
+
+    def test_missing_has_is_400(self):
+        """has is required."""
+        response = self.client.patch(self.url, {"program": "snap"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("has", response.data)
+
+    def test_unauthenticated_is_rejected(self):
+        """Unauthenticated requests are rejected (401 or 403, per DRF auth-class config)."""
+        response = APIClient().patch(self.url, {"program": "snap", "has": True}, format="json")
+
+        self.assertIn(response.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))
+        self.assertEqual(self._benefit_names(), set())
+
+    def test_authenticated_without_change_perm_is_forbidden(self):
+        """PATCH maps to screener.change_screen; a user lacking it is rejected."""
+        no_perms_user = User.objects.create_user(email_or_cell="noperms@example.com", password="password")
+        no_perms_client = APIClient()
+        no_perms_client.force_authenticate(user=no_perms_user)
+
+        response = no_perms_client.patch(self.url, {"program": "snap", "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self._benefit_names(), set())

--- a/screener/tests/test_current_benefits_toggle.py
+++ b/screener/tests/test_current_benefits_toggle.py
@@ -1,7 +1,7 @@
 """
 Tests for the single-benefit toggle endpoint:
 
-    PATCH /api/v2/screens/<uuid>/current-benefits/
+    PATCH /api/screens/<uuid>/current-benefits/
     body: {"program": "snap", "has": true|false}
 
 A lightweight add/remove of one CurrentBenefit row consumed by the results-page
@@ -26,7 +26,7 @@ class CurrentBenefitsToggleTests(APITestCase):
         )
         seed_program(self.white_label, "snap", "tanf")
 
-        self.url = f"/api/v2/screens/{self.screen.uuid}/current-benefits/"
+        self.url = f"/api/screens/{self.screen.uuid}/current-benefits/"
 
         # Same gate as the Screen PATCH path: DjangoModelPermissions maps PATCH to
         # screener.change_screen, so the test user needs that perm.
@@ -96,7 +96,7 @@ class CurrentBenefitsToggleTests(APITestCase):
 
     def test_unknown_screen_is_404(self):
         """An unknown screen uuid is a 404."""
-        url = "/api/v2/screens/00000000-0000-0000-0000-000000000000/current-benefits/"
+        url = "/api/screens/00000000-0000-0000-0000-000000000000/current-benefits/"
         response = self.client.patch(url, {"program": "snap", "has": True}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/screener/tests/test_current_benefits_toggle.py
+++ b/screener/tests/test_current_benefits_toggle.py
@@ -14,8 +14,13 @@ from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from authentication.models import User
+from programs.models import Program
 from screener.models import CurrentBenefit, Screen, WhiteLabel
+from screener.serializers import CurrentBenefitToggleSerializer
 from screener.tests.helpers import seed_program
+
+# Program.name_abbreviated column max_length — the `program` field cap must match it.
+NAME_ABBREVIATED_MAX_LENGTH = Program._meta.get_field("name_abbreviated").max_length
 
 
 class CurrentBenefitsToggleTests(APITestCase):
@@ -132,3 +137,27 @@ class CurrentBenefitsToggleTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self._benefit_names(), set())
+
+    def test_program_cap_matches_db_column(self):
+        """The `program` field cap equals the Program.name_abbreviated column, so a
+        DB-valid name is never rejected for length before the WL-scoped lookup."""
+        field = CurrentBenefitToggleSerializer().fields["program"]
+        self.assertEqual(field.max_length, NAME_ABBREVIATED_MAX_LENGTH)
+
+    def test_name_at_column_max_clears_validation(self):
+        """A name as long as the column clears serializer validation and reaches the
+        WL-scoped lookup — 404 here only because no such Program exists, proving the
+        length didn't reject it (a 400 would mean the cap is too tight)."""
+        name = "a" * NAME_ABBREVIATED_MAX_LENGTH
+        response = self.client.patch(self.url, {"program": name, "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_name_over_column_max_is_400(self):
+        """A name longer than the column is rejected by the serializer (400), never
+        reaching the lookup."""
+        name = "a" * (NAME_ABBREVIATED_MAX_LENGTH + 1)
+        response = self.client.patch(self.url, {"program": name, "has": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("program", response.data)

--- a/screener/tests/test_current_benefits_toggle.py
+++ b/screener/tests/test_current_benefits_toggle.py
@@ -5,7 +5,7 @@ Tests for the single-benefit toggle endpoint:
     body: {"program": "snap", "has": true|false}
 
 A lightweight add/remove of one CurrentBenefit row consumed by the results-page
-"already have this" toggle (MFB-871). Resolution is white-label-scoped and the
+"already have this" toggle. Resolution is white-label-scoped and the
 operation is idempotent. See screener.views.ScreenCurrentBenefitsView.
 """
 

--- a/screener/tests/test_screen_serializer.py
+++ b/screener/tests/test_screen_serializer.py
@@ -17,7 +17,7 @@ from screener.tests.helpers import seed_program
 # The Program.name_abbreviated column max_length. The serializer caps on a
 # current-benefit name must match this so no DB-valid name is rejected before the
 # white-label-scoped resolve. Read from the model so the tests track the column.
-NAME_ABBREVIATED_MAX_LENGTH = Program._meta.get_field("name_abbreviated").max_length
+NAME_ABBREVIATED_MAX_LENGTH = 120
 
 
 class WriteCurrentBenefitsTests(TestCase):

--- a/screener/tests/test_screen_serializer.py
+++ b/screener/tests/test_screen_serializer.py
@@ -9,9 +9,15 @@ shared helper) directly and the serializer `create()` / `update()` paths end to 
 
 from django.test import TestCase
 
+from programs.models import Program
 from screener.models import CurrentBenefit, HouseholdMember, IncomeStream, Screen, WhiteLabel
 from screener.serializers import ScreenSerializer, _write_current_benefits
 from screener.tests.helpers import seed_program
+
+# The Program.name_abbreviated column max_length. The serializer caps on a
+# current-benefit name must match this so no DB-valid name is rejected before the
+# white-label-scoped resolve. Read from the model so the tests track the column.
+NAME_ABBREVIATED_MAX_LENGTH = Program._meta.get_field("name_abbreviated").max_length
 
 
 class WriteCurrentBenefitsTests(TestCase):
@@ -278,3 +284,38 @@ class ScreenSerializerCreateTests(TestCase):
         screen = serializer.save()
 
         self.assertEqual(self._benefit_names(screen), set())
+
+
+class CurrentBenefitsNameLengthTests(TestCase):
+    """The per-element cap on `current_benefits` must match the
+    Program.name_abbreviated column so a DB-valid name is never rejected before the
+    write path (which silently drops unknown names). Guards against the serializer
+    cap and the column drifting apart."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+
+    def _payload(self, names):
+        return {
+            "white_label": self.white_label.code,
+            "household_members": [],
+            "expenses": [],
+            "current_benefits": names,
+        }
+
+    def test_child_cap_matches_db_column(self):
+        """The ListField child's max_length equals the Program.name_abbreviated column."""
+        child = ScreenSerializer().fields["current_benefits"].child
+        self.assertEqual(child.max_length, NAME_ABBREVIATED_MAX_LENGTH)
+
+    def test_name_at_column_max_passes_validation(self):
+        """A name as long as the column is accepted by validation (dropped later only
+        if no Program matches — not rejected for length)."""
+        serializer = ScreenSerializer(data=self._payload(["a" * NAME_ABBREVIATED_MAX_LENGTH]))
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_name_over_column_max_is_rejected(self):
+        """A name longer than the column is rejected by validation."""
+        serializer = ScreenSerializer(data=self._payload(["a" * (NAME_ABBREVIATED_MAX_LENGTH + 1)]))
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("current_benefits", serializer.errors)

--- a/screener/urls.py
+++ b/screener/urls.py
@@ -13,6 +13,12 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("eligibility/<id>", views.EligibilityTranslationView.as_view(), name="translated screen eligibility endpoint"),
     path("screens/<uuid:screen_uuid>/nps/", views.NPSScoreView.as_view(), name="nps-score"),
+    # Single-benefit toggle for the results-page "already have this" control (MFB-1094 / MFB-871).
+    path(
+        "v2/screens/<uuid:screen_uuid>/current-benefits/",
+        views.ScreenCurrentBenefitsView.as_view(),
+        name="screen-current-benefits",
+    ),
     # Benbot assistant — proxies to mfb-ai-service; gated by the 'benbot' feature flag.
     path(
         "screens/<uuid:screen_uuid>/assistant/conversations/",

--- a/screener/urls.py
+++ b/screener/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     path("screens/<uuid:screen_uuid>/nps/", views.NPSScoreView.as_view(), name="nps-score"),
     # Single-benefit toggle for the results-page "already have this" control (MFB-1094 / MFB-871).
     path(
-        "v2/screens/<uuid:screen_uuid>/current-benefits/",
+        "screens/<uuid:screen_uuid>/current-benefits/",
         views.ScreenCurrentBenefitsView.as_view(),
         name="screen-current-benefits",
     ),

--- a/screener/urls.py
+++ b/screener/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("eligibility/<id>", views.EligibilityTranslationView.as_view(), name="translated screen eligibility endpoint"),
     path("screens/<uuid:screen_uuid>/nps/", views.NPSScoreView.as_view(), name="nps-score"),
-    # Single-benefit toggle for the results-page "already have this" control (MFB-1094 / MFB-871).
+    # Single-benefit toggle for the results-page "already have this" control.
     path(
         "screens/<uuid:screen_uuid>/current-benefits/",
         views.ScreenCurrentBenefitsView.as_view(),

--- a/screener/views.py
+++ b/screener/views.py
@@ -11,12 +11,14 @@ from programs.models import Referrer
 from programs.programs.helpers import STATE_MEDICAID_OPTIONS
 from programs.programs.policyengine.calculators.registry import all_calculators
 from programs.programs.urgent_needs.base import UrgentNeedFunction
+from django.db import transaction
 from screener.models import (
     Screen,
     HouseholdMember,
     IncomeStream,
     Expense,
     Message,
+    CurrentBenefit,
     EligibilitySnapshot,
     ProgramEligibilitySnapshot,
 )
@@ -35,6 +37,7 @@ from screener.serializers import (
     NPSScoreSerializer,
     NPSScoreReasonSerializer,
     RemImpactSerializer,
+    CurrentBenefitToggleSerializer,
 )
 from programs.programs.policyengine.policy_engine import calc_pe_eligibility
 from programs.util import DependencyError, Dependencies
@@ -101,6 +104,60 @@ class ScreenViewSet(
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
+
+
+class ScreenCurrentBenefitsView(views.APIView):
+    """
+    PATCH /api/v2/screens/<uuid>/current-benefits/
+
+    Lightweight single-benefit toggle for the results-page "already have this"
+    control (MFB-871). Adds or removes exactly one CurrentBenefit row instead of
+    revalidating and rewriting the whole screen the way the Screen PATCH path does.
+    Idempotent — repeating the same payload is a no-op:
+
+        body: {"program": "snap", "has": true}   # ensure the row exists
+        body: {"program": "snap", "has": false}  # ensure the row is absent
+
+    `program` is a `name_abbreviated` resolved against the screen's white label;
+    an unknown name (or one offered only by another white label) is a 404, so a
+    toggle can't write a cross-WL program. Returns the updated current-benefits
+    list as {"current_benefits": [...sorted name_abbreviated...]}.
+
+    Unlike the bulk write path (`_write_current_benefits`), this does NOT OR in
+    derived benefits (e.g. SSI implied by an sSI income stream) — it's a targeted
+    single-row operation. The next full Screen PATCH reapplies those compound rules.
+    """
+
+    # Same gate as the Screen PATCH path: DjangoModelPermissions maps PATCH to
+    # `screener.change_screen`, so whoever may edit the screen may toggle its
+    # benefits. The queryset is required for DjangoModelPermissions to resolve
+    # the model the permission is checked against.
+    permission_classes = [permissions.DjangoModelPermissions]
+    queryset = Screen.objects.all()
+
+    def patch(self, request, screen_uuid):
+        screen = get_object_or_404(Screen, uuid=screen_uuid)
+
+        serializer = CurrentBenefitToggleSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        program_name = serializer.validated_data["program"]
+        has = serializer.validated_data["has"]
+
+        program = get_object_or_404(Program, white_label=screen.white_label, name_abbreviated=program_name)
+
+        # Lock the screen for the read-modify-write so concurrent toggles (or a
+        # toggle racing a Screen PATCH) can't interleave on the join table.
+        with transaction.atomic():
+            locked = Screen.objects.select_for_update().get(pk=screen.pk)
+            if has:
+                CurrentBenefit.objects.get_or_create(screen=locked, program=program)
+            else:
+                CurrentBenefit.objects.filter(screen=locked, program=program).delete()
+            current_benefits = sorted(
+                CurrentBenefit.objects.filter(screen=locked).values_list("program__name_abbreviated", flat=True)
+            )
+
+        return Response({"current_benefits": current_benefits})
 
 
 class HouseholdMemberViewSet(viewsets.ModelViewSet):

--- a/screener/views.py
+++ b/screener/views.py
@@ -136,25 +136,25 @@ class ScreenCurrentBenefitsView(views.APIView):
     queryset = Screen.objects.all()
 
     def patch(self, request, screen_uuid):
-        screen = get_object_or_404(Screen, uuid=screen_uuid)
-
         serializer = CurrentBenefitToggleSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         program_name = serializer.validated_data["program"]
         has = serializer.validated_data["has"]
 
-        program = get_object_or_404(Program, white_label=screen.white_label, name_abbreviated=program_name)
-
         # Lock the screen for the read-modify-write so concurrent toggles (or a
-        # toggle racing a Screen PATCH) can't interleave on the join table.
+        # toggle racing a Screen PATCH) can't interleave on the join table. The
+        # locked fetch also serves as the screen-missing 404 (an empty
+        # transaction just rolls back), and the program lookup resolves against
+        # the locked screen's white label rather than a pre-lock read.
         with transaction.atomic():
-            locked = Screen.objects.select_for_update().get(pk=screen.pk)
+            screen = get_object_or_404(Screen.objects.select_for_update(), uuid=screen_uuid)
+            program = get_object_or_404(Program, white_label=screen.white_label, name_abbreviated=program_name)
             if has:
-                CurrentBenefit.objects.get_or_create(screen=locked, program=program)
+                CurrentBenefit.objects.get_or_create(screen=screen, program=program)
             else:
-                CurrentBenefit.objects.filter(screen=locked, program=program).delete()
+                CurrentBenefit.objects.filter(screen=screen, program=program).delete()
             current_benefits = sorted(
-                CurrentBenefit.objects.filter(screen=locked).values_list("program__name_abbreviated", flat=True)
+                CurrentBenefit.objects.filter(screen=screen).values_list("program__name_abbreviated", flat=True)
             )
 
         return Response({"current_benefits": current_benefits})

--- a/screener/views.py
+++ b/screener/views.py
@@ -108,7 +108,7 @@ class ScreenViewSet(
 
 class ScreenCurrentBenefitsView(views.APIView):
     """
-    PATCH /api/v2/screens/<uuid>/current-benefits/
+    PATCH /api/screens/<uuid>/current-benefits/
 
     Lightweight single-benefit toggle for the results-page "already have this"
     control (MFB-871). Adds or removes exactly one CurrentBenefit row instead of

--- a/screener/views.py
+++ b/screener/views.py
@@ -115,10 +115,10 @@ class ScreenCurrentBenefitsView(views.APIView):
     revalidating and rewriting the whole screen the way the Screen PATCH path does.
     Idempotent — repeating the same payload is a no-op:
 
-        body: {"program": "snap", "has": true}   # ensure the row exists
-        body: {"program": "snap", "has": false}  # ensure the row is absent
+        body: {"name_abbreviated": "snap", "has": true}   # ensure the row exists
+        body: {"name_abbreviated": "snap", "has": false}  # ensure the row is absent
 
-    `program` is a `name_abbreviated` resolved against the screen's white label;
+    `name_abbreviated` is a program name resolved against the screen's white label;
     an unknown name (or one offered only by another white label) is a 404, so a
     toggle can't write a cross-WL program. Returns the updated current-benefits
     list as {"current_benefits": [...sorted name_abbreviated...]}.
@@ -138,7 +138,7 @@ class ScreenCurrentBenefitsView(views.APIView):
     def patch(self, request, screen_uuid):
         serializer = CurrentBenefitToggleSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        program_name = serializer.validated_data["program"]
+        name_abbreviated = serializer.validated_data["name_abbreviated"]
         has = serializer.validated_data["has"]
 
         # Lock the screen for the read-modify-write so concurrent toggles (or a
@@ -148,7 +148,7 @@ class ScreenCurrentBenefitsView(views.APIView):
         # the locked screen's white label rather than a pre-lock read.
         with transaction.atomic():
             screen = get_object_or_404(Screen.objects.select_for_update(), uuid=screen_uuid)
-            program = get_object_or_404(Program, white_label=screen.white_label, name_abbreviated=program_name)
+            program = get_object_or_404(Program, white_label=screen.white_label, name_abbreviated=name_abbreviated)
             if has:
                 CurrentBenefit.objects.get_or_create(screen=screen, program=program)
             else:


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

Adds a lightweight endpoint for adding/removing a single `CurrentBenefit` row on a
screen, to be consumed by the results-page "already have this" toggle (MFB-871).

Reusing the Screen PATCH path for this would revalidate and rewrite the entire
screen (household members, expenses, income streams, etc.) on every toggle — a lot
of overhead and surface area for what is a single-row operation. This dedicated
endpoint writes one row.

- Implements: MFB-1094 (CB Step 7b — Single-benefit toggle endpoint for results page)
- Unblocks: MFB-871 (CB Step 8 — Results page "already have this" toggle)
- Related PR: N/A

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- **`screener/urls.py`** — New route `PATCH /api/screens/<uuid>/current-benefits/`
  → `ScreenCurrentBenefitsView`.
- **`screener/views.py`** — New `ScreenCurrentBenefitsView` (APIView):
  - Resolves `program` by `name_abbreviated` scoped to the screen's `white_label`;
    an unknown name (or one offered only by another white label) returns 404, so a
    toggle can't write a cross-WL program.
  - Idempotent add (`get_or_create`) / remove (`filter().delete()`) of the single
    `CurrentBenefit` row.
  - Read-modify-write wrapped in a transaction with `select_for_update()` on the
    screen, so concurrent toggles (or a toggle racing a Screen PATCH) can't
    interleave on the join table.
  - Returns the updated list: `{"current_benefits": [...sorted name_abbreviated...]}`.
  - Permissions: `DjangoModelPermissions` (PATCH → `screener.change_screen`),
    matching the Screen PATCH path.
- **`screener/serializers.py`** —
  - New `CurrentBenefitToggleSerializer` validating `name_abbreviated` (string) and `has` (bool).
  - Aligned the `name_abbreviated` length caps with the DB column. Both the new
    `CurrentBenefitToggleSerializer.name_abbreviated` field and the existing bulk-path
    `ScreenSerializer.current_benefits` list child were capped at 64, while the
    `Program.name_abbreviated` column is `max_length=120` — so a DB-valid name of
    65–120 chars would have been rejected with a 400 before the white-label-scoped
    resolve. Both caps are now `120` to match the column. (The bulk-path 64 was a
    pre-existing inconsistency, not introduced by this PR; fixed here while in the area.)
- **`screener/tests/test_current_benefits_toggle.py`** — 14 tests:
  - Behavior: add, remove, idempotent repeat-add / repeat-remove, wrong-WL 404,
    unknown-program 404, unknown-screen 404, missing-field 400s, and the
    unauthenticated / missing-perm rejection cases.
  - Length cap: the `name_abbreviated` cap equals the `Program.name_abbreviated` column
    (drift guard), a name at the column max clears validation (→ 404, not a length
    400), and a name over the max is rejected (400).
- **`screener/tests/test_screen_serializer.py`** — new `CurrentBenefitsNameLengthTests`
  covering the bulk path's `current_benefits` child cap: cap equals the column
  (drift guard), a name at the column max passes validation, a name over it is rejected.
  The drift-guard tests read `Program._meta.get_field("name_abbreviated").max_length`
  rather than hardcoding 120, so the serializer caps and the column can't silently diverge again.

Note on the API path: the ticket drafted the route as `/api/v2/screens/...`, but
there is no `v2` namespace anywhere in the codebase and nothing (BE or FE) consumes
it yet. The route is mounted at `/api/screens/<uuid>/current-benefits/` to stay
consistent with the existing `/api/screens/...` endpoints.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none (no schema changes)
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  1. `python manage.py test screener.tests.test_current_benefits_toggle screener.tests.test_screen_serializer`
  2. Against a running server, authenticated as a user with `screener.change_screen`:
     - Add: `PATCH /api/screens/<uuid>/current-benefits/` body `{"name_abbreviated": "snap", "has": true}`
       → 200, response `{"current_benefits": ["snap", ...]}`, row present.
     - Remove: same URL, body `{"name_abbreviated": "snap", "has": false}`
       → 200, `snap` absent from the returned list.
     - Repeat either call → idempotent (no error, no duplicate row).
     - Unknown program name or a program from another white label → 404.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: nothing required. The endpoint has no consumer until
  MFB-871 (results-page toggle) ships — note that ticket's spec references the
  `/api/v2/...` path and should be updated to `/api/screens/<uuid>/current-benefits/`.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
  - Unlike the bulk write path (`_write_current_benefits`), this endpoint does NOT
    OR in derived benefits (e.g. SSI implied by an sSI income stream) — it's a
    targeted single-row operation. The next full Screen PATCH reapplies those
    compound rules. This is intentional per the ticket (single-row add/remove).
- Behavioral difference from the bulk path worth a look:
  - An unknown / cross-WL `program` here returns **404** (hard fail), whereas the
    bulk `_write_current_benefits()` path **silently drops** unrecognized names and
    logs them to Sentry. Intentional — a one-shot toggle on an unresolvable program
    is unambiguously a client error, so the FE (MFB-871) should treat 404 as "bad
    program key", not retry.
- Scope note:
  - This PR also bumps the bulk-path `ScreenSerializer.current_benefits` child cap
    from 64 → 120 (see Changes Made). That touches the existing screener PATCH
    validation, not just the new endpoint — flagging so it isn't a surprise in the diff.
- Future considerations:
  - If the results page ever needs to toggle multiple benefits at once, this could
    be extended to accept a list, but the current single-row contract matches the
    MFB-871 UI (one toggle per card).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “already have this” toggle for screen results, allowing users to add or remove a single current benefit via a screen PATCH action.
  * Screen results now update instantly after each change.

* **Bug Fixes**
  * Improved validation and error handling for missing/invalid inputs, unknown benefit names, and incorrect scoping; prevents duplicate entries and keeps repeated add/remove actions idempotent.

* **Tests**
  * Added coverage for toggle behavior, permissions, validation boundaries, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

