### PR TITLE
MFB-1195: PolicyEngine catch-up - validate value changes and pin to frontier

### DIFF
--- a/programs/programs/policyengine/calculators/dependencies/base.py
+++ b/programs/programs/policyengine/calculators/dependencies/base.py
@@ -22,6 +22,11 @@ class PolicyEngineScreenInput:
     #   removed variable (dropped after X): max_pe_version = (last version that had it)
     #   windowed variable (existed A..B):  min_pe_version = A; max_pe_version = B
     #
+    # Sourcing: validate these bounds against the versions PolicyEngine actually serves
+    # (GET https://household.api.policyengine.org/versions/us -> current/frontier), not
+    # the changelog in isolation. A min_pe_version floor is the first *served* version
+    # that defines the variable, confirmed against /versions/us. (MFB-1234)
+    #
     # Scope: this gates whether a variable is SENT (add/remove across versions). It does
     # NOT handle a variable whose accepted value/format changes per version (e.g.
     # county_str -> county_fips); value() has no access to the resolved version today.

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ markers =
     integration: marks tests as integration tests (require external API access)
 env =
     ENABLE_GOOGLE_INTEGRATIONS=false
+    FRONTEND_DOMAIN=http://localhost:3000

--- a/validations/management/commands/tests/test_validate.py
+++ b/validations/management/commands/tests/test_validate.py
@@ -1,0 +1,77 @@
+from decimal import Decimal
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from programs.models import Program
+from screener.models import WhiteLabel
+from screener.serializers import ScreenSerializer
+from validations.models import Validation
+
+
+class ValidateCommandPeVersionTest(TestCase):
+    """Tests for the validate command's --pe-version override."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Colorado", code="co", state_code="CO")
+        cls.program = Program.objects.new_program(white_label="co", name_abbreviated="snap")
+
+    def setUp(self):
+        self.out = StringIO()
+
+        # Create a test screen the same way import_validations does.
+        screen_data = {
+            "white_label": "co",
+            "is_test": True,
+            "agree_to_tos": True,
+            "is_13_or_older": True,
+            "zipcode": "80202",
+            "household_size": 1,
+            "household_members": [
+                {
+                    "relationship": "headOfHousehold",
+                    "age": 30,
+                    "has_income": False,
+                    "income_streams": [],
+                    "insurance": {"none": True},
+                }
+            ],
+            "expenses": [],
+        }
+        serializer = ScreenSerializer(data=screen_data)
+        serializer.is_valid(raise_exception=True)
+        self.screen = serializer.save()
+
+        self.validation = Validation.objects.create(
+            screen=self.screen,
+            program_name="snap",
+            eligible=True,
+            value=Decimal("250.00"),
+        )
+
+    def test_invalid_pe_version_raises(self):
+        """A --pe-version that is neither an exact version nor a valid alias errors out."""
+        with self.assertRaises(CommandError):
+            call_command("validate", "--pe-version", "bogus", stdout=self.out)
+
+    @patch("validations.management.commands.validate.eligibility_results")
+    def test_pe_version_alias_is_threaded_through(self, mock_eligibility_results):
+        """A valid alias is forwarded to eligibility_results without changing the pin."""
+        mock_eligibility_results.return_value = ([], None)
+
+        call_command("validate", "--pe-version", "frontier", stdout=self.out)
+
+        mock_eligibility_results.assert_called_with(self.screen, batch=True, pe_version="frontier")
+
+    @patch("validations.management.commands.validate.eligibility_results")
+    def test_default_runs_against_configured_pin(self, mock_eligibility_results):
+        """With no --pe-version, eligibility_results is called with pe_version=None (configured pin)."""
+        mock_eligibility_results.return_value = ([], None)
+
+        call_command("validate", stdout=self.out)
+
+        mock_eligibility_results.assert_called_with(self.screen, batch=True, pe_version=None)

--- a/validations/management/commands/validate.py
+++ b/validations/management/commands/validate.py
@@ -2,11 +2,12 @@ from datetime import datetime
 from enum import Enum
 from random import randint
 from typing import Optional
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 from googleapiclient.errors import HttpError
 from integrations.services.sheets.formatting import color_cell, title_cell, wrap_row
 from screener.views import eligibility_results
+from programs.programs.policyengine import versions as pe_versions
 from validations.models import Validation
 from decouple import config
 from google_auth_httplib2 import AuthorizedHttp
@@ -155,8 +156,23 @@ class Command(BaseCommand):
         )
         parser.add_argument("-s", "--sheet-id", help="The Google sheet id to display results in")
         parser.add_argument("-w", "--white-label", help="What white label to run validations for")
+        parser.add_argument(
+            "--pe-version",
+            help=(
+                "PolicyEngine version to validate against for THIS RUN ONLY. Overrides the "
+                "DB PolicyEngineConfig pin without changing it. Accepts an exact version "
+                "('1.744.0') or an alias ('current'/'frontier'). Use to pre-validate a "
+                "target version before the pin is flipped."
+            ),
+        )
 
     def handle(self, *args, **options):
+        pe_version = options["pe_version"]
+        if pe_version is not None and not pe_versions.is_valid_override(pe_version):
+            raise CommandError("Invalid --pe-version: use an exact version like '1.744.0' or 'current'/'frontier'.")
+        if pe_version is not None:
+            self.stdout.write(f"Overriding PolicyEngine version for this run: {pe_version} (pin unchanged)")
+
         queryset = Validation.objects.all()
 
         if options["white_label"] is not None:
@@ -179,7 +195,7 @@ class Command(BaseCommand):
         for group in grouped_validations.values():
             screen = group[0].screen
             white_label = screen.white_label.code
-            results = eligibility_results(screen, batch=True)[0]
+            results = eligibility_results(screen, batch=True, pe_version=pe_version)[0]
 
             for validation in group:
                 program = self._find_program(validation, results)


### PR DESCRIPTION
## Context & Motivation

We periodically bump the pinned `policyengine-us` version, and MFB-1195 is the catch-up to validate the value changes introduced since our last bump and then flip the `PolicyEngineConfig` pin to **1.744.0** (the current PolicyEngine `frontier`). Before flipping, we need to run the regression/validation suite *at the target version* — but `validate` could only ever run against whatever `PolicyEngineConfig` pin was already set, so there was no way to validate a candidate version without first flipping the pin (the exact thing we want to de-risk).

This PR adds a per-run `--pe-version` override to the `validate` command so we can validate at 1.744.0 ahead of the pin flip. It's the foundation for the rest of MFB-1195 (expected-value reconciliation) and for re-establishing the weekly version-bump cadence.

- Linear: MFB-1195
- Related (merged): MyFriendBen/benefits-api#1609 (MFB-1146) — wired the TX CEAP `use_reported_ssi` input, version-gated to ≥ 1.742, inert until the pin reaches that floor. #1609 also shipped the MFB-1234 unpinned-gating fix (`resolve_unpinned_comparable_version`).

## Changes Made

- Add a `--pe-version` option to the `validate` management command:
  - Overrides the DB `PolicyEngineConfig` pin **for the current run only** — it does **not** change the stored pin.
  - Accepts an exact version (e.g. `1.744.0`) or the `current`/`frontier` aliases, validated via `pe_versions.is_valid_override`; invalid values raise `CommandError`.
  - Prints a one-line notice when an override is active so it's obvious in the run output that the pin was not changed.
- Thread the resolved version into `eligibility_results(screen, batch=True, pe_version=...)` (the function already accepted `pe_version`; the command simply never passed it).
- New `test_validate.py` covering: invalid version → `CommandError`; alias forwarded to `eligibility_results`; default (no flag) → `pe_version=None` (configured pin).
- Document the `min_pe_version` sourcing convention in `base.py` (validate bounds against PE's served `/versions/us`, not the changelog). This closes the only outstanding **MFB-1234** acceptance item — the unpinned-gating implementation itself already shipped with #1609.

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - `python -m pytest validations/management/commands/tests/test_validate.py` → 3 passing
  - `python -m pytest programs/programs/policyengine/tests/test_pe_input.py` → 32 passing
  - `python manage.py validate --help` → shows `--pe-version`
  - `python manage.py validate --pe-version frontier --program tx_head_start` → runs that program's validations against 1.744.0 without changing the pin
  - `python manage.py validate --pe-version bogus` → exits with a clear error

## Deployment

> This PR itself only adds tooling/docs — **merging it changes no runtime behavior and does not touch the pin.** The steps below are the MFB-1195 pin-flip runbook.

- Post-deployment scripts needed: none (the pin flip is a DB/admin change, not a code deploy)
- Migrations to run: none

### Pin-flip runbook — set `PolicyEngineConfig` → `1.744.0`

⚠️ **Do NOT flip the production pin before Thursday's scheduled release.** Roll out in order: **local (dev) → staging → production.**

The pin is the `PolicyEngineConfig` DB singleton (field `policyengine_version`). Only an **exact** `MAJOR.MINOR.PATCH` is accepted — the `frontier`/`current` aliases are rejected here, so use the literal `1.744.0`.

**Option A — Django admin (preferred):**
1. Log in as a **superuser** to the env's admin and open the singleton "PolicyEngine Version" row:
   - Staging: `https://cobenefits-api-staging.herokuapp.com/admin/configuration/policyengineconfig/`
   - Production: `https://cobenefits-api.herokuapp.com/admin/configuration/policyengineconfig/`
   - Local: `http://localhost:8000/admin/configuration/policyengineconfig/`
2. Set **PolicyEngine version** to `1.744.0` and Save.
3. Confirm the readonly **Current version** line now reads `1.744.0`.

**Option B — Django shell (Heroku):**
```bash
# staging: --app cobenefits-api-staging   |   production: --app cobenefits-api
heroku run --app cobenefits-api-staging python manage.py shell
```
```python
from configuration.models import PolicyEngineConfig
c = PolicyEngineConfig.objects.first() or PolicyEngineConfig()
c.policyengine_version = "1.744.0"
c.save()                              # forces the singleton row + validates the version
PolicyEngineConfig.current_version()  # -> '1.744.0'
```

**Verify after each env:** re-run TX CEAP QA (Scenario 10 → **$1,500**) and confirm a disabled, non-aged, $0-income household now returns non-zero SSI (gated inputs active).

**Rollback (immediate, no deploy):** set the field back to `1.732.0` (or clear it to ride PE `current`) and Save.

- Admin updates needed: the pin flip itself (superuser admin, per above)
- Notify team/users of: deferred pin-flip timing (Thursday); TX CEAP SSI-income households move from the $1,800 tier to the policy-correct $1,500 tier, and disabled SSI applicants begin receiving correct amounts

## Notes for Reviewers

- Known limitations: this PR adds the version override + a doc note; it does not change reporting (stdout / optional `--sheet-id` Google Sheet) and does not modify any expected values.
- MFB-1234 status: its functional fix (resolve PE `current` from `/versions/us` for input gating when unpinned) is **already on `main`** via #1609's squash merge — verified by reading the commit object (`resolve_unpinned_comparable_version`, `_has_gated_input`, tests; 41 passing). The only outstanding acceptance item was the `base.py` documentation note, included here.
- Validation outcome (see MFB-1195 comment): the 1.732→1.744 flip is effectively a **no-op** for screened programs — all flagged value changes (Head Start FY2024, NC/IL income tax) are already live in `current`; the only real change is the TX CEAP `use_reported_ssi` fix (validated in #1609).
- Follow-ups surfaced (not blockers): stale DB validation expected values (refresh via `update_validations`/re-pull), and a WA Head Start anomaly (`wa_head_start` active + wired + valid FPL but not surfacing in results).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing a PolicyEngine version when running validation commands.
  * Invalid version values now return a clear error instead of running with an unsupported setting.

* **Bug Fixes**
  * Validation now respects the selected version consistently during eligibility checks.

* **Tests**
  * Added coverage for valid, invalid, and default version handling in command runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->