### PR TITLE
Updating KS spec.mds to resolve test scenario issues

### DIFF
--- a/programs/programs/ks/chip/spec.md
+++ b/programs/programs/ks/chip/spec.md
@@ -147,7 +147,7 @@ The core screening factors are fully covered: age (under 19), income (at or belo
 - [ ] Scenario 13 (Age-banded Medicaid floor — child age 3, ~145% FPL): **ineligible for CHIP** (age 1–5 child is Medicaid-eligible)
 - [ ] Scenario 14 (Oldest eligible age — child age 18, ~177% FPL): **eligible**, $1,896/yr value, $20/mo premium
 - [ ] Scenario 15 (Child with non-ESI / private coverage — `has_health_coverage_other_than_chip=True`): **ineligible/$0** — PE correctly returns ineligible (gap #8577 resolved in PE 1.752.1)
-- [ ] Scenario 16 (Two CHIP-eligible uninsured children — ~178% FPL): **eligible**, $3,793/yr value (PE raw: 2 × $1,896.49 → $3,793), $20/mo premium (per-family charge, not doubled)
+- [ ] Scenario 16 (Two CHIP-eligible uninsured children — ~178% FPL): **eligible**, $3,792/yr value (PE raw per child $1,896.4944 → 2 × = $3,792.99, which the platform **truncates** to the integer **$3,792** — not rounded to $3,793), $20/mo premium (per-family charge, not doubled)
 
 ## Test Scenarios
 
@@ -377,8 +377,8 @@ Each scenario lists PE-verified expected eligibility and premium. Birth years as
 ---
 
 ### Scenario 16: Two CHIP-eligible uninsured children — value scales, premium stays flat
-**What we're checking**: When two siblings are both CHIP-eligible and uninsured, the coverage value is per-child ($1,896/yr × 2 → $3,793/yr PE total) while the household premium remains a single flat charge ($20/mo, not doubled).
-**Expected**: Eligible · coverage value **$3,793/yr** (PE raw: 2 × $1,896.49 → $3,793; display value $1,896/yr per child is per-child rounded) · **$20/mo** premium (per-family, FPL ≈178%)
+**What we're checking**: When two siblings are both CHIP-eligible and uninsured, the coverage value is per-child ($1,896.4944/yr × 2 = $3,792.99, truncated to **$3,792/yr** total) while the household premium remains a single flat charge ($20/mo, not doubled).
+**Expected**: Eligible · coverage value **$3,792/yr** (PE raw per child $1,896.4944; 2 × = $3,792.99, which the platform **truncates** to the integer **$3,792** — the per-child display value is still $1,896) · **$20/mo** premium (per-family, FPL ≈178%)
 
 **Steps**:
 - **Location**: ZIP `67202`, county `Sedgwick`
@@ -388,7 +388,7 @@ Each scenario lists PE-verified expected eligibility and premium. Birth years as
 - **Person 3**: Child, born `January 2019` (age 7), no income, insurance: none, not on Medicaid
 - **Person 4**: Child, born `March 2016` (age 10), no income, insurance: none, not on Medicaid
 
-**Why this matters**: Verifies two implementation requirements that could independently fail: (1) the coverage value aggregates per child — PE's `chip` output returns `per_capita_chip` (~$1,896.49) for each eligible member, so both must be summed (2 × $1,896.49 → $3,793; the $1,896 display value is per-child rounded, not the aggregate); (2) `ks_chip_premium` is a TaxUnit/household-level output — it returns one flat premium regardless of how many children are enrolled. A developer could plausibly double the premium for two children, or fail to sum per-child coverage values correctly. Both children are ages 6–18 at ~178% FPL (above the 133% Medicaid floor) and uninsured — each is independently CHIP-eligible.
+**Why this matters**: Verifies two implementation requirements that could independently fail: (1) the coverage value aggregates per child — PE's `chip` output returns `per_capita_chip` (~$1,896.49) for each eligible member, so both must be summed (2 × $1,896.4944 = $3,792.99, which the platform truncates to the integer **$3,792**; the $1,896 display value is the per-child figure, not the aggregate); (2) `ks_chip_premium` is a TaxUnit/household-level output — it returns one flat premium regardless of how many children are enrolled. A developer could plausibly double the premium for two children, or fail to sum per-child coverage values correctly. Both children are ages 6–18 at ~178% FPL (above the 133% Medicaid floor) and uninsured — each is independently CHIP-eligible.
 
 ---
 

--- a/programs/programs/ks/medicaid/spec.md
+++ b/programs/programs/ks/medicaid/spec.md
@@ -232,9 +232,9 @@ Scenarios 7, 8, 16, and 17 are eligible because of the KS calculator's committed
 **Steps**:
 - **Location**: ZIP `66604`, county `Shawnee`
 - **Household**: 1 person
-- **Person 1**: Head of Household, born `July 1961` (age 64), male, US citizen, not disabled, employment income `$250`/mo, insurance: none
+- **Person 1**: Head of Household, born `December 1961` (age 64), male, US citizen, not disabled, employment income `$250`/mo, insurance: none
 
-**Why this matters**: Distinguishes "not yet 65" from the ABD age trigger — pairs with Scenario 7 (age 66, eligible).
+**Why this matters**: Distinguishes "not yet 65" from the ABD age trigger — pairs with Scenario 7 (age 66, eligible). The birth month is intentionally late in the year (December) so the applicant is unambiguously age 64 on any run date; a birth month equal to the current month would resolve to age 65 under the platform's month-only age arithmetic and wrongly qualify under the AGED pathway.
 
 ---
 


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes MFB-1054 (KS: KanCare (Medicaid)) — QA spec correction, not a calculator change.
- Related PR: https://github.com/MyFriendBen/benefits-api/pull/1616
- During staging API QA of `ks_medicaid`, Scenario 6 ("Childless adult age 64") failed: the applicant returned **Eligible (AGED, $20,508)** instead of the expected **Not eligible**. Root cause was the spec's test data, not the calculator. The scenario set the birthdate to **July 1961** and labeled it "age 64." The platform derives age from `birth_year`/`birth_month` only (no day), so a July-1961 birthdate evaluated on the run date **2026-07-07** (birth month == current month) resolves to **age 65**, correctly triggering the ABD/AGED pathway. The payload therefore encoded a 65-year-old rather than the age-64 person the scenario intended.
- Verified this is a test-data boundary artifact, not a code bug: re-running the identical scenario with an unambiguous age-64 birthdate (**December 1961**, birthday not yet reached in July 2026) returned **Not eligible** (staging UUID `471ea762-6d10-4766-9dde-dcc0316390ee`). The calculator correctly excludes a genuine under-65 childless adult in non-expansion KS.
- This matters for future testing: any run where the current month equals the scenario's birth month would re-trip the same false failure. Pinning the birth month to late in the year makes the scenario deterministic regardless of run date.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- `benefits-api/programs/programs/ks/medicaid/spec.md`, Scenario 6 ("Childless adult age 64 — ineligible"):
  - Changed Person 1's birthdate from `July 1961` to `December 1961` (still age 64) so the applicant is unambiguously under 65 on any run date.
  - Expanded the "Why this matters" note to document that the birth month is intentionally late in the year to avoid the platform's month-only age arithmetic resolving a current-month birthdate to age 65 (which would wrongly qualify the applicant under the AGED pathway).
- No calculator, config, or validation-JSON changes — this is a spec/test-data fix only.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: None.
- Configuration updates needed: None.
- Environment variables/settings to add: None.
- Manual testing steps:
  - Re-run the API QA suite against staging: `/api-qa-execution MFB-1054 staging`.
  - Expected outcome: 23/23 scenarios pass. Scenario 6 now returns **Not eligible** (previously failed as Eligible/AGED due to the July-1961 boundary).
  - Spot-check independently: POST a KS screen with a single `headOfHousehold` born `1961-12`, `$250/mo` wages, no disability, and confirm `ks_medicaid` returns `eligible=false`.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: None.
- Production config updates: None.
- Admin updates needed: None.
- Notify team/users of: Nothing required. This is a documentation/QA-artifact change with no runtime effect on the deployed screener or calculator.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: The underlying cause is the platform deriving age from year+month only (no day), so any scenario whose birth month equals the run month sits on a 1-year boundary. This fix addresses only Scenario 6; other specs that pick a birth month near the age threshold could exhibit the same run-date sensitivity.
- Future considerations:
  - When authoring age-boundary scenarios, choose a birth month late in the year (or otherwise clearly on one side of the threshold) so the intended age holds regardless of run date.
  - The `ks_medicaid.json` validation file was intentionally left unchanged for this fix (per direction); if that suite is later found to hardcode the same July-1961 birthdate, apply the equivalent correction there.

---

# MFB-1055 (KS: Kansas CHIP) — spec value correction

## Context & Motivation

- Fixes MFB-1055 (KS: Kansas Children's Health Insurance Program (CHIP)) — QA spec correction, not a calculator change.
- During staging API QA of `ks_chip`, all 16 spec scenarios were run against the screener API, then re-run at PolicyEngine **frontier** via the `?pe_version=frontier` override. **Eligibility was 100% correct (16/16) in both runs.**
- Two issues surfaced, only one of which is a spec fix:
  1. **PE-version lag (environment, not spec):** on staging's default `PolicyEngineConfig` pin, every eligible child returned a coverage value of **$2,111** instead of the spec's **$1,896**. The spec pins the value at PE **1.752.1**, where `per_capita_chip` was revised to *separate-CHIP* spending ÷ enrollment ($136.6M ÷ 72,018 = **$1,896.49/yr**); the prior PE value used *all-CHIP* spending ÷ enrollment (≈$2,112/yr). Staging's pin predates 1.752.1, so it returned the old figure uniformly. Re-running the identical screens at `frontier` returned exactly `1896.4944 → $1,896`, confirming the calculator is correct and the mismatch is purely an environment PE-pin lag that resolves once staging is bumped to PE ≥ 1.752.1. **No spec change for this — it is a staging PE-pin follow-up.**
  2. **Scenario 16 aggregate rounding (the spec fix):** the two-child scenario expected **$3,793**, but frontier returned **$3,792**. Per-member values are `[1896.4944, 1896.4944]`, so the per-child summation is correct; `2 × 1896.4944 = 3792.99`, and the platform **truncates** the aggregate to the integer `3792` rather than rounding to `3793`. The spec author had rounded up. Single-child scenarios are unaffected because `1896.4944` truncates and rounds to the same `1896`.
- This matters for future testing: since spec.md now feeds the test suite, the Scenario 16 expected value must equal what the platform actually returns (`$3,792`), or the suite will report a permanent false failure on that scenario at the correct PE version.

## Changes Made

- `benefits-api/programs/programs/ks/chip/spec.md`, Scenario 16 ("Two CHIP-eligible uninsured children"): updated the coverage-value expectation from **$3,793** to **$3,792** in all four places it appears, each with an explanation that `2 × $1,896.4944 = $3,792.99` is **truncated** (not rounded) to the integer `$3,792`:
  - Acceptance Criteria checklist item (Scenario 16).
  - Scenario 16 **What we're checking** line.
  - Scenario 16 **Expected** line.
  - Scenario 16 **Why this matters** line (the per-child summation math).
- The per-child display value ($1,896) is unchanged — truncation and rounding agree at the single-child level.
- No calculator, config, or validation-JSON changes — this is a spec/test-data fix only.

## Testing

- Migrations to run: None.
- Configuration updates needed: None (see Deployment for the separate staging PE-pin follow-up).
- Environment variables/settings to add: None.
- Manual testing steps:
  - Re-run the API QA suite against staging at frontier: the eligibility endpoint accepts `?pe_version=frontier`, e.g. `GET /api/eligibility/{uuid}?pe_version=frontier`.
  - Expected outcome at PE ≥ 1.752.1 / frontier: 16/16 scenarios pass, including Scenario 16 now expecting **$3,792**.
  - Full frontier run recorded in `qa/MFB-1055-ks_chip-api-results.md` (15/16 before this spec fix; Scenario 16 was the only miss, at −$1 rounding).

## Deployment

- Post-deployment scripts needed: None.
- Production config updates: None.
- **Staging PE-pin follow-up (separate from this spec fix):** bump staging's `PolicyEngineConfig` PolicyEngine version to ≥ **1.752.1** so the normal (non-`?pe_version=`) path returns the $1,896 per-child coverage value. Until then, default-pin coverage values will read ~$2,111 and are expected.
- Admin updates needed: None.
- Notify team/users of: Nothing required for the spec change itself (documentation/QA-artifact only).

## Notes for Reviewers

- The `ks_chip` KS-specific monthly premium (`ks_chip_premium`, $0/$20/$30/$50 per family/month) is **not surfaced in the eligibility API response** — it is a frontend display line (`ks_chip_premium ÷ 12`) and could not be validated via API. It needs browser verification; per-scenario expected premium tiers are listed in `qa/MFB-1055-ks_chip-api-results.md`.
- Known limitations: this fix addresses only the Scenario 16 aggregate. Any other multi-recipient scenario that sums a fractional per-capita value could exhibit the same truncate-vs-round $1 delta; expected aggregate values should be computed with truncation (floor of the summed raw values), matching platform behavior.
- Future considerations: when authoring multi-recipient value scenarios, compute the expected total as `int(sum(raw per-recipient values))` (truncation), not by rounding each recipient and multiplying.
