### PR TITLE
Add KS Child Tax Credit (ks)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_ctc_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_ctc_initial_config.json
@@ -10,6 +10,7 @@
   },
   "program": {
     "name_abbreviated": "ks_ctc",
+    "year": "2026",
     "legal_status_required": [
       "citizen",
       "non_citizen",

--- a/programs/management/commands/import_program_config_data/data/ks_ctc_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_ctc_initial_config.json
@@ -1,0 +1,76 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "program_category": {
+    "external_name": "ks_tax_credit",
+    "name": "Tax Credits",
+    "icon": "tax_credit",
+    "tax_category": true
+  },
+  "program": {
+    "name_abbreviated": "ks_ctc",
+    "legal_status_required": [
+      "citizen",
+      "non_citizen",
+      "refugee",
+      "gc_5plus",
+      "gc_5less",
+      "otherWithWorkPermission"
+    ],
+    "name": "Federal Child Tax Credit (CTC)",
+    "description_short": "Federal tax credit for families with children or other dependents",
+    "description": "The Child Tax Credit lowers the amount you owe on your federal taxes. You can claim one credit for each qualifying child in your household.\n\nYou claim the credit when you file your federal tax return. If it is larger than what you owe, you get the difference back as a refund by direct deposit or check.\n\nEach qualifying child must be a U.S. citizen or resident and have a Social Security number. Higher incomes may reduce your credit amount. A free tax preparer can help confirm what you qualify for.\n\nTo claim this credit, click \"File for free\" to file your federal tax return at no cost.",
+    "learn_more_link": "https://www.irs.gov/credits-deductions/individuals/child-tax-credit",
+    "apply_button_link": "https://www.getyourrefund.org/en",
+    "apply_button_description": "File for free",
+    "estimated_application_time": "45 minutes",
+    "estimated_delivery_time": "21 days after e-filing",
+    "estimated_value": "",
+    "value_format": "estimated_annual",
+    "value_type": "tax_credit",
+    "website_description": "Federal tax credit for families with children or other dependents",
+    "base_program": "ctc",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "documents": [
+    {
+      "external_name": "ks_ctc_ssn",
+      "text": "Social Security card for each qualifying child",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_id_proof",
+      "text": "Proof of identity (e.g. driver's license, state ID, passport)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_ctc_w2",
+      "text": "Form W-2 for all household members in tax unit",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_ctc_1099",
+      "text": "1099 for all household members in tax unit",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_ctc_schedule_8812",
+      "text": "Schedule 8812 (Credits for Qualifying Children and Other Dependents)",
+      "link_url": "https://www.irs.gov/forms-pubs/about-schedule-8812-form-1040",
+      "link_text": "View Schedule 8812 on IRS.gov"
+    },
+    {
+      "external_name": "ks_ctc_form_1040",
+      "text": "Form 1040 (U.S. Individual Income Tax Return)",
+      "link_url": "https://www.irs.gov/forms-pubs/about-form-1040",
+      "link_text": "View Form 1040 on IRS.gov"
+    }
+  ]
+}

--- a/programs/programs/ks/pe/__init__.py
+++ b/programs/programs/ks/pe/__init__.py
@@ -1,6 +1,7 @@
 import programs.programs.ks.pe.spm as spm
 import programs.programs.ks.pe.tax as tax
 import programs.programs.ks.pe.member as member
+from programs.programs.federal.pe.tax import Ctc
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
 
 ks_member_calculators = {
@@ -11,6 +12,8 @@ ks_member_calculators = {
 ks_tax_unit_calculators = {
     "ks_eitc": tax.Kseitc,
     "ks_cdcc": tax.KsCdcc,
+    # Federal Child Tax Credit, used as-is (no KS variance). Mirrors wa_ctc.
+    "ks_ctc": Ctc,
 }
 
 ks_spm_calculators = {

--- a/programs/programs/ks/pe/__init__.py
+++ b/programs/programs/ks/pe/__init__.py
@@ -12,7 +12,6 @@ ks_member_calculators = {
 ks_tax_unit_calculators = {
     "ks_eitc": tax.Kseitc,
     "ks_cdcc": tax.KsCdcc,
-    # Federal Child Tax Credit, used as-is (no KS variance). Mirrors wa_ctc.
     "ks_ctc": Ctc,
 }
 


### PR DESCRIPTION
## Context & Motivation

Implements the federal Child Tax Credit (CTC) for Kansas as part of the KS launch.

- Linear: [MFB-1047](https://linear.app/myfriendben/issue/MFB-1047/ks-child-tax-credit-ctc-federal)
- Calculator tier: **PE Federal / Fed (as-is)** — config-only, no spec required (confirmed in discovery: CTC lives at `policyengine_us/variables/gov/irs/credits/ctc/`, no KS-specific variance).
- Mirrors the `wa_ctc` precedent (PR #1522) and the TX/IL federal CTC implementations.

## Changes Made

- Added `ks_ctc_initial_config.json` (program config, category `ks_tax_credit`, documents).
- Registered `ks_ctc` in `programs/programs/ks/pe/__init__.py`, mapping directly to the federal `Ctc` PolicyEngine calculator (`base_program: ctc`), consistent with `wa_ctc`.

## Testing

- Migrations to run: none.
- Configuration updates needed: run `manage.py import_program_config .../data/ks_ctc_initial_config.json` per environment (imports inactive).
- Manual testing steps:
  - `import_program_config --dry-run` succeeds; program `ks_ctc` resolves `base_program: ctc`.
  - `ks_ctc` registered in `all_calculators` (verified via Django shell).
  - KS PE test suite green (54 passed). Correctness for a Fed-as-is program is covered by the shared federal `Ctc` calculator, already exercised by WA/TX/IL.
  - `black --check` clean.

## Deployment

- Post-deployment scripts needed: run `import_program_config` for `ks_ctc` on staging then prod.
- Production config updates: activate the program when ready to launch KS.
- `show_in_has_benefits_step: false` (tax credit; no other program keys off CTC receipt).

## Notes for Reviewers

- Known limitations: value/eligibility follow federal PE rules as-is; no KS overrides by design.
- `ks_ctc` uses the federal `Ctc` class directly rather than a KS subclass, matching the established `wa_ctc` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new white-labeled Kansas tax credit program configuration (2026) with category, display, and eligibility details.
  * Enabled the program’s calculator by registering the credit under the Kansas tax unit calculators.
  * Included an associated document checklist with required identity and tax documentation (including key IRS-linked forms/text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->