### PR TITLE
MFB-1244: KS CDCC — enable disabled & student-spouse qualifying-individual paths

### DIFF
--- a/programs/programs/ks/cdcc/spec.md
+++ b/programs/programs/ks/cdcc/spec.md
@@ -96,7 +96,7 @@ Dollar values for the eligible scenarios are PolicyEngine-verified (KS CDCC = 50
 [ ] Scenario 7 (Child turns 13 mid-year — still 12 at time of screening): User should be **eligible**, value: $570/year
 [ ] Scenario 8 (No qualifying dependent — only teenager age 16 in household): User should be **ineligible**
 [ ] Scenario 9 (Disabled adult dependent — alternative qualifying individual): User should be **eligible** per IRC § 21, value: $540/year
-[ ] Scenario 10 (Disabled spouse with no earned income — deemed-income path): User should be **eligible** per IRC § 21(d)(2), value: $525/year
+[ ] Scenario 10 (Disabled spouse with no earned income — deemed-income path): User should be **eligible** per IRC § 21(d)(2), value: $490/year
 
 ## Test Scenarios
 
@@ -243,7 +243,7 @@ Dollar values for the eligible scenarios are PolicyEngine-verified (KS CDCC = 50
 
 ### Scenario 10: Disabled Spouse with No Earned Income — Deemed-Income Path
 **What we're checking**: Married couple where one spouse is disabled (incapable of self-care) and has no earned income, with care expenses for that spouse. Under IRC § 21(d)(2), a spouse incapable of self-care is deemed to have earned income of $250/month (one qualifying individual), which both makes them a qualifying individual and satisfies the two-earner requirement — so the household should qualify.
-**Expected**: Eligible, value: $525/year. Per IRC § 21(d)(2), a disabled spouse incapable of self-care is deemed to have $250/month of earned income, which both makes them a qualifying individual and satisfies the two-earner requirement, so the household qualifies for the credit. (Value: expenses limited to the lower "earner's" deemed $3,000/year → 35% × $3,000 = $1,050 federal → 50% = $525 KS.)
+**Expected**: Eligible, value: $490/year. Per IRC § 21(d)(2), a disabled spouse incapable of self-care is deemed to have $250/month of earned income, which both makes them a qualifying individual and satisfies the two-earner requirement, so the household qualifies for the credit. (Federal CDCC computes to $980 for this household; KS credit = 50% = $490.)
 
 **Steps**:
 - **Location**: Enter ZIP code `66044`, Select county `Douglas`

--- a/programs/programs/ks/cdcc/spec.md
+++ b/programs/programs/ks/cdcc/spec.md
@@ -10,11 +10,12 @@
 
 ## Eligibility Criteria
 
-1. **Must have at least one qualifying dependent: a child under age 13, or a disabled spouse or dependent of any age who is physically or mentally incapable of self-care**
+1. **Must have at least one qualifying individual: a dependent under age 13, or a spouse or dependent of any age who is physically or mentally incapable of self-care**
    - Screener fields:
      - `birth_year + birth_month (HouseholdMember)`
      - `relationship (HouseholdMember)`
-     - `disabled (HouseholdMember)`
+     - `disabled`, `long_term_disability`, `visually_impaired (HouseholdMember)` (any of these marks a member incapable of self-care)
+   - Note: A full-time student is **not** a qualifying individual — only a child under 13 or a person incapable of self-care qualifies. (Student status matters separately, for the deemed-income exception in Criterion 9.)
    - Source: IRC § 21(b)(1); K.S.A. 79-32,111 (Kansas adopts federal definitions); Kansas K-40 Instructions - Child and Dependent Care Credit section
 
 2. **Must have earned income (wages, salaries, tips, self-employment income) during the tax year**
@@ -54,10 +55,10 @@
    - Source: IRC § 21(e)(6); K.S.A. 79-32,111
    - Impact: ImpactLevel.LOW
 
-9. **Full-time student or disabled spouse exception to the earned income requirement — if one spouse is a full-time student or is incapable of self-care, they are deemed to have earned income of $250/month (one qualifying individual) or $500/month (two or more), satisfying the earned-income requirement even with no actual earnings**
+9. **Full-time student or incapable-of-self-care spouse — deemed-income exception to the earned income requirement.** If a spouse is a full-time student or is incapable of self-care, they are deemed to have earned income of $250/month (when the household has one qualifying individual) or $500/month (two or more), which satisfies the two-earner requirement in Criterion 2 even when that spouse has no actual earnings. This does **not** make the spouse a qualifying individual (see Criterion 1) — it only supplies earned income so a real qualifying individual's care expenses become creditable.
     - Screener fields:
       - `student_full_time (HouseholdMember)`
-      - `disabled (HouseholdMember)`
+      - `disabled`, `long_term_disability`, `visually_impaired (HouseholdMember)`
     - Source: IRC § 21(d)(2); K.S.A. 79-32,111
 
 ## Benefit Value

--- a/programs/programs/ks/cdcc/spec.md
+++ b/programs/programs/ks/cdcc/spec.md
@@ -97,6 +97,8 @@ Dollar values for the eligible scenarios are PolicyEngine-verified (KS CDCC = 50
 [ ] Scenario 8 (No qualifying dependent — only teenager age 16 in household): User should be **ineligible**
 [ ] Scenario 9 (Disabled adult dependent — alternative qualifying individual): User should be **eligible** per IRC § 21, value: $540/year
 [ ] Scenario 10 (Disabled spouse with no earned income — deemed-income path): User should be **eligible** per IRC § 21(d)(2), value: $490/year
+[ ] Scenario 11 (Full-time student spouse with a qualifying child — deemed-income path): User should be **eligible** per IRC § 21(d)(2), value: $490/year
+[ ] Scenario 12 (Full-time student spouse with no qualifying individual): User should be **ineligible** (a student is not a qualifying individual under § 21(b)(1))
 
 ## Test Scenarios
 
@@ -242,8 +244,8 @@ Dollar values for the eligible scenarios are PolicyEngine-verified (KS CDCC = 50
 ---
 
 ### Scenario 10: Disabled Spouse with No Earned Income — Deemed-Income Path
-**What we're checking**: Married couple where one spouse is disabled (incapable of self-care) and has no earned income, with care expenses for that spouse. Under IRC § 21(d)(2), a spouse incapable of self-care is deemed to have earned income of $250/month (one qualifying individual), which both makes them a qualifying individual and satisfies the two-earner requirement — so the household should qualify.
-**Expected**: Eligible, value: $490/year. Per IRC § 21(d)(2), a disabled spouse incapable of self-care is deemed to have $250/month of earned income, which both makes them a qualifying individual and satisfies the two-earner requirement, so the household qualifies for the credit. (Federal CDCC computes to $980 for this household; KS credit = 50% = $490.)
+**What we're checking**: Married couple where one spouse is disabled (incapable of self-care) and has no earned income, with care expenses for that spouse. Under IRC § 21(b)(1)(C) the disabled spouse is a qualifying individual; under § 21(d)(2) they are deemed to have $250/month of earned income, satisfying the two-earner requirement so the care expenses become creditable — so the household should qualify.
+**Expected**: Eligible, value: $490/year. The disabled spouse is a qualifying individual (§ 21(b)(1)(C)), and the § 21(d)(2) deemed $250/month of earned income satisfies the two-earner requirement, so their care expenses are creditable. (Federal CDCC computes to $980 for this household; KS credit = 50% = $490.)
 
 **Steps**:
 - **Location**: Enter ZIP code `66044`, Select county `Douglas`
@@ -253,6 +255,37 @@ Dollar values for the eligible scenarios are PolicyEngine-verified (KS CDCC = 50
 - **Expenses**: Care expenses: Yes, Monthly care cost for disabled spouse: `$500` (i.e. $6,000/year)
 
 **Why this matters**: This is the deemed-income path of IRC § 21(d)(2), distinct from Scenario 9's disabled-dependent path. A married household with one disabled non-earning spouse and care expenses for that spouse still qualifies — a real population that would otherwise be missed if the deemed $250/month were not applied.
+
+---
+
+### Scenario 11: Full-Time Student Spouse with a Qualifying Child — Deemed-Income Path
+**What we're checking**: Married couple filing jointly with one qualifying child under 13 and childcare expenses, where the non-working spouse is a full-time student. Under IRC § 21(d)(2), a full-time-student spouse is deemed to have $250/month of earned income, which satisfies the two-earner requirement so the child's childcare expenses become creditable. (Distinct from the disabled cases: a student is **not** itself a qualifying individual under § 21(b)(1) — the child is the qualifying individual here.)
+**Expected**: Eligible, value: $490/year. The child under 13 is the qualifying individual; the § 21(d)(2) deemed earned income for the full-time-student spouse satisfies the two-earner test, so the child's childcare is creditable. (Federal CDCC computes to $980 for this household; KS credit = 50% = $490.)
+
+**Steps**:
+- **Location**: Enter ZIP code `66044`, Select county `Douglas`
+- **Household**: Number of people: `3`
+- **Person 1**: Relationship: `Head of Household`, Birth month/year: `March 1985` (age 41), Has earned income: Yes, Employment income: `$3,500/month`, Filing status: Married Filing Jointly, Last tax filing year: `2025`
+- **Person 2**: Relationship: `Spouse`, Birth month/year: `May 1990` (age 36), Full-time student: Yes, Has earned income: No, Income: `$0`
+- **Person 3**: Relationship: `Child`, Birth month/year: `January 2023` (age 3), No income
+- **Expenses**: Child care expenses: Yes, Monthly childcare cost: `$900` (i.e. $10,800/year)
+
+**Why this matters**: Without the § 21(d)(2) deeming, a married household with one full-time-student spouse who has no earnings would fail the two-earner test and get $0 despite a qualifying child in paid care — a real population (student-parent households) that would otherwise be under-screened. Requires the screener's `student_full_time` flag to reach the calculator.
+
+---
+
+### Scenario 12: Full-Time Student Spouse with No Qualifying Individual — Ineligible
+**What we're checking**: Married couple filing jointly where the non-working spouse is a full-time student, but there is **no** qualifying individual — no child under 13 and no one incapable of self-care. Tests that a full-time student is not itself a qualifying individual.
+**Expected**: Not eligible. A full-time student is not a qualifying individual under IRC § 21(b)(1); the § 21(d)(2) deeming only supplies earned income and does not create a qualifying individual. With no child under 13 and no one incapable of self-care, there are no creditable care expenses.
+
+**Steps**:
+- **Location**: Enter ZIP code `66044`, Select county `Douglas`
+- **Household**: Number of people: `2`
+- **Person 1**: Relationship: `Head of Household`, Birth month/year: `March 1985` (age 41), Has earned income: Yes, Employment income: `$3,500/month`, Filing status: Married Filing Jointly, Last tax filing year: `2025`
+- **Person 2**: Relationship: `Spouse`, Birth month/year: `May 1990` (age 36), Full-time student: Yes, Has earned income: No, Income: `$0`
+- **Expenses**: Care expenses: Yes, Monthly care cost: `$900`
+
+**Why this matters**: Confirms the boundary of § 21: the student-spouse deeming does not, by itself, make anyone a qualifying individual. A household with a full-time-student spouse but no child under 13 and no disabled member correctly gets $0 — distinguishing the "deemed income" mechanic from "qualifying individual" status.
 
 ## Source Documentation
 

--- a/programs/programs/ks/pe/tax.py
+++ b/programs/programs/ks/pe/tax.py
@@ -21,6 +21,7 @@ class KsCdcc(PolicyEngineTaxUnitCalulator):
         dependency.member.TaxUnitDependentDependency,
         dependency.member.IsDisabledDependency,
         dependency.member.IsIncapableOfSelfCareDependency,
+        dependency.member.FullTimeCollegeStudentDependency,
         dependency.spm.ChildCareDependency,
         dependency.member.CareExpensesDependency,
         dependency.household.KsStateCodeDependency,

--- a/programs/programs/ks/pe/tax.py
+++ b/programs/programs/ks/pe/tax.py
@@ -20,7 +20,9 @@ class KsCdcc(PolicyEngineTaxUnitCalulator):
         dependency.member.TaxUnitSpouseDependency,
         dependency.member.TaxUnitDependentDependency,
         dependency.member.IsDisabledDependency,
+        dependency.member.IsIncapableOfSelfCareDependency,
         dependency.spm.ChildCareDependency,
+        dependency.member.CareExpensesDependency,
         dependency.household.KsStateCodeDependency,
         *dependency.irs_gross_income,
     ]

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -168,6 +168,43 @@ class IsDisabledDependency(Member):
         return self.member.disabled or self.member.long_term_disability or self.member.visually_impaired
 
 
+class IsIncapableOfSelfCareDependency(Member):
+    field = "is_incapable_of_self_care"
+
+    def value(self):
+        # PolicyEngine's CDCC treats a spouse/dependent who is incapable of self-care as a
+        # qualifying individual at any age. We infer this from the same self-reported disability
+        # signals as is_disabled (the screener has no dedicated incapable-of-self-care field).
+        return self.member.disabled or self.member.long_term_disability or self.member.visually_impaired
+
+
+class CareExpensesDependency(Member):
+    field = "care_expenses"
+
+    def value(self):
+        # PolicyEngine's federal CDCC reads care costs for a disabled adult/spouse from the
+        # person-level `care_expenses` variable (distinct from spm-level `childcare_expenses`,
+        # which only distributes to under-13 children). The screener collects a single
+        # household-level "Dependent Care" (dependentCare) expense with no per-member
+        # attribution, so we split it evenly across the members who are incapable of self-care
+        # and assign this member their share. An even split is safe for the credit: the federal
+        # CDCC caps relevant expenses at $3,000 (one qualifying individual) / $6,000 (two or more),
+        # so the split lands on the cap in the cases that matter.
+        if not (self.member.disabled or self.member.long_term_disability or self.member.visually_impaired):
+            return 0
+
+        incapable_members = [
+            m
+            for m in self.screen.household_members.all()
+            if (m.disabled or m.long_term_disability or m.visually_impaired)
+        ]
+        if not incapable_members:
+            return 0
+
+        dependent_care_total = self.screen.calc_expenses("yearly", ["dependentCare"])
+        return dependent_care_total / len(incapable_members)
+
+
 class MeetsSsiDisabilityCriteriaDependency(Member):
     """
     PolicyEngine frontier (policyengine-us 1.715.2) requires this person input to

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -185,9 +185,10 @@ class IsIncapableOfSelfCareDependency(Member):
 class CareExpensesDependency(Member):
     """
     PolicyEngine's `care_expenses` person input — the cost of caring for a member who
-    is incapable of self-care. Distinct from the spm-level `childcare_expenses`, which
-    PE distributes only across under-13 children. It feeds the federal CDCC and any
-    state credit derived from it.
+    is incapable of self-care. Distinct from the spm-unit-level `childcare_expenses`,
+    which PE aggregates into `tax_unit_childcare_expenses` by distributing only across
+    under-13 children (so an adult qualifying individual gets $0 from that path). It
+    feeds the federal CDCC and any state credit derived from it.
 
     Our screener captures a single household-level "Dependent Care" (dependentCare)
     expense with no per-member attribution, so we split it evenly across the members

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -169,27 +169,37 @@ class IsDisabledDependency(Member):
 
 
 class IsIncapableOfSelfCareDependency(Member):
+    """
+    PolicyEngine's `is_incapable_of_self_care` person input — used across care-related
+    calculations (e.g. the federal CDCC, where such a person is a qualifying individual
+    at any age). We infer it from the same self-reported disability signals as
+    is_disabled, since the screener has no dedicated incapable-of-self-care field.
+    """
+
     field = "is_incapable_of_self_care"
 
     def value(self):
-        # PolicyEngine's CDCC treats a spouse/dependent who is incapable of self-care as a
-        # qualifying individual at any age. We infer this from the same self-reported disability
-        # signals as is_disabled (the screener has no dedicated incapable-of-self-care field).
         return self.member.disabled or self.member.long_term_disability or self.member.visually_impaired
 
 
 class CareExpensesDependency(Member):
+    """
+    PolicyEngine's `care_expenses` person input — the cost of caring for a member who
+    is incapable of self-care. Distinct from the spm-level `childcare_expenses`, which
+    PE distributes only across under-13 children. It feeds the federal CDCC and any
+    state credit derived from it.
+
+    Our screener captures a single household-level "Dependent Care" (dependentCare)
+    expense with no per-member attribution, so we split it evenly across the members
+    who are incapable of self-care and assign this member their share (others get 0).
+    The even split is safe for the CDCC, which caps relevant expenses at $3,000 (one
+    qualifying individual) / $6,000 (two or more) — the split lands on the cap in the
+    cases that matter.
+    """
+
     field = "care_expenses"
 
     def value(self):
-        # PolicyEngine's federal CDCC reads care costs for a disabled adult/spouse from the
-        # person-level `care_expenses` variable (distinct from spm-level `childcare_expenses`,
-        # which only distributes to under-13 children). The screener collects a single
-        # household-level "Dependent Care" (dependentCare) expense with no per-member
-        # attribution, so we split it evenly across the members who are incapable of self-care
-        # and assign this member their share. An even split is safe for the credit: the federal
-        # CDCC caps relevant expenses at $3,000 (one qualifying individual) / $6,000 (two or more),
-        # so the split lands on the cap in the cases that matter.
         if not (self.member.disabled or self.member.long_term_disability or self.member.visually_impaired):
             return 0
 


### PR DESCRIPTION
## Context

Follow-up to [MFB-1244](https://linear.app/myfriendben/issue/MFB-1244). Builds on the KS CDCC program (`ks_cdcc`) merged in #1590, which shipped the child-under-13 paths (spec Scenarios 1–8). This PR enables the **disabled and student-spouse qualifying-individual paths** (spec Scenarios 9–12), which previously returned $0 because the calculator never sent PolicyEngine's person-level `care_expenses` / `is_incapable_of_self_care` / student inputs.

## Changes

- **`member.py`** — two new dependencies:
  - `IsIncapableOfSelfCareDependency` (`is_incapable_of_self_care`), from `disabled` / `long_term_disability` / `visually_impaired`.
  - `CareExpensesDependency` (person-level `care_expenses`): sources the household's **Dependent Care** (`dependentCare`) expense, split evenly across members incapable of self-care (safe under the federal $3k/$6k expense cap).
- **`tax.py`** — wire `IsIncapableOfSelfCareDependency`, `FullTimeCollegeStudentDependency` (existing; `is_full_time_college_student`), and `CareExpensesDependency` into `KsCdcc.pe_inputs`. Existing `childCare → childcare_expenses` unchanged.
- **`spec.md`** — corrected Scenario 10 value to $490 (PE-verified deemed-income result); added Scenario 11 (student spouse + child → eligible $490) and Scenario 12 (student spouse, no qualifying individual → ineligible, proving a student alone is not a QI).

## IRC § 21 basis

- **§ 21(b)(1)** — qualifying individual: child <13, or a spouse/dependent incapable of self-care. A full-time student is **not** a qualifying individual.
- **§ 21(d)(2)** — deems $250/mo ($500 for 2+) of earned income to a student or incapable-of-self-care spouse, satisfying the two-earner test so a real qualifying individual's care expenses become creditable.

## Verification

All 12 spec scenarios verified against the real calculator @ household.api **frontier (1.768.1)**:

| # | Expected | Result |
|---|----------|--------|
| 1 | $540 | ✅ |
| 2–5 | ineligible | ✅ $0 |
| 6 | $1,050 | ✅ |
| 7 | $570 | ✅ |
| 8 | ineligible | ✅ $0 |
| 9 disabled dependent | $540 | ✅ |
| 10 disabled spouse | $490 | ✅ |
| 11 student spouse + child | $490 | ✅ |
| 12 student spouse, no QI | ineligible | ✅ $0 |

105 member-dependency unit tests pass.

## ⚠️ Deployment dependency

Verified at **frontier = 1.768.1**. Production is unpinned → serves **current = 1.755.0**, where these paths do **not** compute (they return $0). **This does not take effect in staging/prod until the served PolicyEngine version is pinned to ≥1.768.1** — see [MFB-1246](https://linear.app/myfriendben/issue/MFB-1246). (1.744.0 is now retired → 422.) The child path (1–8) is unaffected and works on all current versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dependent care credit eligibility calculations for households with disabled spouses or full-time student spouses.
  - Care expenses are now appropriately recognized and allocated for qualifying individuals.
  - Added support for scenarios involving qualifying children and clarified when student status alone does not establish eligibility.

- **Documentation**
  - Updated Kansas CDCC acceptance criteria and test scenarios.
  - Corrected the expected annual credit from $525 to $490 where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->