### PR TITLE
Use PolicyEngine school_meal_net_subsidy for NSLP value (MFB-1045)

### DIFF
--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -44,21 +44,22 @@ class Snap(PolicyEngineSpmCalulator):
 
 
 class SchoolLunch(PolicyEngineSpmCalulator):
-    pe_name = "school_meal_daily_subsidy"
-    pe_inputs = [dependency.spm.SchoolMealCountableIncomeDependency]
-    pe_outputs = [dependency.spm.SchoolMealDailySubsidy, dependency.spm.SchoolMealTier]
+    """
+    National School Lunch Program (NSLP) — free/reduced-price school meals.
 
-    amount = 120
+    The value is PolicyEngine's ``school_meal_net_subsidy``: the annual value of
+    free/reduced meals above the full-price baseline, computed from USDA per-meal
+    rates × school days × the household's K-12 children (ages 5–17, imputed by PE
+    from ``age``). PAID-tier households net to $0, so eligibility is value > 0.
+    ``AgeDependency`` is sent so PE can derive ``is_in_k12_school``.
+    """
 
-    def household_value(self):
-        value = 0
-        num_children = self.screen.num_children(3, 18)
-
-        if self.get_variable() > 0 and num_children > 0:
-            if self.get_dependency_value(dependency.spm.SchoolMealTier) != "PAID":
-                value = SchoolLunch.amount * num_children
-
-        return value
+    pe_name = "school_meal_net_subsidy"
+    pe_inputs = [
+        dependency.spm.SchoolMealCountableIncomeDependency,
+        dependency.member.AgeDependency,
+    ]
+    pe_outputs = [dependency.spm.SchoolMealNetSubsidy, dependency.spm.SchoolMealTier]
 
 
 class Tanf(PolicyEngineSpmCalulator):

--- a/programs/programs/il/pe/spm.py
+++ b/programs/programs/il/pe/spm.py
@@ -16,28 +16,6 @@ class IlNslp(SchoolLunch):
         dependency.household.IlStateCodeDependency,
     ]
 
-    tier_1_fpl = 1.30
-    tier_2_fpl = 1.85
-
-    tier_1_amount = 935
-    tier_2_amount = 805
-
-    def household_value(self):
-        value = 0
-        num_children = self.screen.num_children(3, 18)
-        if self.get_variable() > 0 and num_children > 0:
-            if self.get_dependency_value(dependency.spm.SchoolMealTier) != "PAID":
-                countable_income = self.get_dependency_value(dependency.spm.SchoolMealCountableIncomeDependency)
-                fpl_limit = self.program.year.get_limit(self.screen.household_size)
-
-                if countable_income <= int(self.tier_1_fpl * fpl_limit):
-                    value = self.tier_1_amount * num_children
-
-                elif countable_income <= int(self.tier_2_fpl * fpl_limit):
-                    value = self.tier_2_amount * num_children
-
-        return value
-
 
 class IlTanf(Tanf):
     pe_name = "il_tanf"

--- a/programs/programs/il/pe/tests/test_spm.py
+++ b/programs/programs/il/pe/tests/test_spm.py
@@ -73,21 +73,12 @@ class TestIlNslp(TestCase):
         for parent_input in SchoolLunch.pe_inputs:
             self.assertIn(parent_input, IlNslp.pe_inputs)
 
-    def test_tier_1_fpl_is_130_percent(self):
-        """Test that tier 1 FPL threshold is 130%."""
-        self.assertEqual(IlNslp.tier_1_fpl, 1.30)
-
-    def test_tier_2_fpl_is_185_percent(self):
-        """Test that tier 2 FPL threshold is 185%."""
-        self.assertEqual(IlNslp.tier_2_fpl, 1.85)
-
-    def test_tier_1_amount_is_935(self):
-        """Test that tier 1 benefit amount is $935."""
-        self.assertEqual(IlNslp.tier_1_amount, 935)
-
-    def test_tier_2_amount_is_805(self):
-        """Test that tier 2 benefit amount is $805."""
-        self.assertEqual(IlNslp.tier_2_amount, 805)
+    def test_uses_pe_net_subsidy_value(self):
+        """IlNslp inherits the federal SchoolLunch value (PolicyEngine's
+        school_meal_net_subsidy) rather than the removed hardcoded tier amounts."""
+        self.assertEqual(IlNslp.pe_name, "school_meal_net_subsidy")
+        self.assertFalse(hasattr(IlNslp, "tier_1_amount"))
+        self.assertFalse(hasattr(IlNslp, "tier_2_amount"))
 
 
 class TestIlTanf(TestCase):

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -161,6 +161,14 @@ class SchoolMealDailySubsidy(SpmUnit):
     field = "school_meal_daily_subsidy"
 
 
+class SchoolMealNetSubsidy(SpmUnit):
+    # Annual free/reduced-price school meal value: PolicyEngine multiplies the
+    # per-child-per-day net subsidy (daily subsidy minus the full-price baseline)
+    # by the number of K-12 children and the number of school days in the year.
+    # PAID-tier households net to $0.
+    field = "school_meal_net_subsidy"
+
+
 class SchoolMealTier(SpmUnit):
     field = "school_meal_tier"
 

--- a/programs/programs/tx/pe/tests/test_spm.py
+++ b/programs/programs/tx/pe/tests/test_spm.py
@@ -145,7 +145,7 @@ class TestTxNslp(TestCase):
         self.assertTrue(issubclass(TxNslp, SchoolLunch))
 
         # Verify it has the expected properties from parent
-        self.assertEqual(TxNslp.pe_name, "school_meal_daily_subsidy")
+        self.assertEqual(TxNslp.pe_name, "school_meal_net_subsidy")
         self.assertIsNotNone(TxNslp.pe_inputs)
         self.assertGreater(len(TxNslp.pe_inputs), 0)
 


### PR DESCRIPTION
## Problem

KS NSLP surfaced **$10/month** in staging QA (MFB-1045). Root cause: the federal `SchoolLunch` calculator — inherited by **KS, TX, and IL** NSLP — computed its value as a **hardcoded constant**:

```python
amount = 120
value = SchoolLunch.amount * num_children(3, 18)   # ~$120/child/yr = $10/mo
```

This `$120` is undocumented, doesn't track USDA reimbursement rates, and is ~8x too low. The real value of a school year of free/reduced meals is **~$900–1,035/child/yr**. The calculator ignored PolicyEngine's own computed subsidy entirely — using PE only for the eligibility gate and tier label.

There were effectively two implementations: the federal flat-`$120` path (KS + TX) and IL's separate hardcoded tiered override (`$935` free / `$805` reduced) — the latter realistic but also hardcoded and drift-prone.

## Fix

Return PolicyEngine's **`school_meal_net_subsidy`** — the annual dollar value of free/reduced meals net of the full-price baseline. PE computes it from USDA per-meal rates × `school_days` (180) × the household's **K-12 children (ages 5–17, imputed by PE from `age`)**. PAID-tier households net to `$0`, so eligibility still falls out of `value > 0`.

- **`federal/pe/spm.py` `SchoolLunch`**: `pe_name` → `school_meal_net_subsidy`; add `AgeDependency` to inputs (so `is_in_k12_school` resolves without depending on another program to send `age`); drop the `amount`/`num_children` override — the base `household_value()` returns PE's value directly.
- **IL**: drop the hardcoded `$935`/`$805` tiered `household_value()`; inherit the corrected base.
- **TX / KS**: unchanged shape (inherit federal) — now get the correct value automatically.
- Add `SchoolMealNetSubsidy` spm dependency.
- Update IL/TX unit tests (`pe_name`, removed tier-amount asserts).

### Value change (one free-tier child)
| | Before | After |
|---|---|---|
| KS / TX | $120/yr ($10/mo) | ~$1,035/yr (PE 2024 fixture) |
| IL | $935/yr (hardcoded) | live PE value |

## Age band note
PE's `is_in_k12_school` counts **ages 5–17**; the old code hand-counted `num_children(3, 18)`. This aligns us with PE's model (more accurate for school meals) and removes MFB's hand-count.

## Out of scope
WA NSLP (`wa/nslp/calculator.py`) is a separate custom calculator with its own income-guideline logic — unaffected.

## Testing
- IL + TX PE spm tests, KS PE tests, MA csfp: **all pass** (176 tests).
- Value magnitude confirmed by PolicyEngine's committed test fixture (`school_meal_net_subsidy: 1_035` for one free-tier child, contiguous US, 2024).
- Full staging verification to follow on deploy (staging currently runs the pre-fix code).

Relates to MFB-1045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calculating National School Lunch Program net subsidies using household income, household member ages, eligibility tiers, and applicable USDA rates.
  * Federal, Illinois, and Texas school lunch calculations now use a consistent net annual benefit value.
* **Bug Fixes**
  * Replaced outdated estimated benefit amounts and state-specific thresholds with policy-driven calculations.
* **Tests**
  * Updated coverage to verify the new net subsidy calculation and naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->