### PR TITLE
MFB-1066: fix WH spec Sc 2/10 (children's-Medicaid mutex) + rename to "Working Healthy (Medicaid)"

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_working_healthy_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_working_healthy_initial_config.json
@@ -16,7 +16,7 @@
       "gc_5plus",
       "otherWithWorkPermission"
     ],
-    "name": "Working Healthy (WH)",
+    "name": "Working Healthy (Medicaid)",
     "description": "Working Healthy is a Medicaid program for Kansans with disabilities who are working. It lets you keep full health coverage even if you earn too much for regular Medicaid.\n\nIt covers the same care as regular KanCare. You can use it for things like doctor visits, hospital stays, and prescriptions. Depending on your income, you may pay a small monthly premium to keep it.\n\nYou may still qualify even if your income or savings look too high. Some income and savings may not count. Disability-related work costs can lower the income we count. And savings like retirement accounts may not count toward the limit. This program is for people living in the community, not a long-term care facility. You may need to show proof of your disability, such as an SSI or SSDI award letter or a doctor's statement.\n\nClick 'Apply Now' to start a KanCare application online, or call 1-866-305-5147 to have one mailed to you. A regional Benefits Specialist can help you understand how working affects your coverage.",
     "description_short": "Health coverage for working Kansans with disabilities",
     "learn_more_link": "https://www.kancare.ks.gov/members/benefits-services/working-healthy",

--- a/programs/management/commands/import_program_config_data/data/ks_working_healthy_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_working_healthy_initial_config.json
@@ -3,7 +3,7 @@
     "code": "ks"
   },
   "program_category": {
-    "external_name": "ks_health_care",
+    "external_name": "ks_healthcare",
     "name": "Health Care",
     "icon": "health_care"
   },

--- a/programs/programs/ks/working_healthy/spec.md
+++ b/programs/programs/ks/working_healthy/spec.md
@@ -92,7 +92,9 @@ The income, resource, age, employment, disability, insurance, and SSI criteria a
 
 ## Test Scenarios
 
-*The 20 scenarios below cover all major eligibility branches: the golden-path eligible case, an ineligible case per each major exclusion criterion, boundary/edge values, both disability paths (long-term disability and blindness), multi-member, assistance-plan sizing (minor-with-parent under both relationship codings, and the unaccompanied-minor 1-person case), and the SSI/HCBS mutex. Eligible value = $19,051/year per eligible member (annual); $38,102/year for a 2-member eligible household. (KS residency isn't a scenario here — it's enforced by white-label routing, not the calculator.)*
+*The 22 scenarios below cover all major eligibility branches: the golden-path eligible case, an ineligible case per each major exclusion criterion, boundary/edge values, both disability paths (long-term disability and blindness), multi-member, assistance-plan sizing (minor-with-parent under both relationship codings, and the unaccompanied-minor 1-person case), and the full mutex set — the already-on-Medicaid case (Sc 9), the SSI/HCBS mutex (Sc 15), and the **children's-Medicaid mutex for a low-income minor** (Sc 2 and Sc 10). Eligible value = $19,051/year per eligible member (annual); $38,102/year for a 2-member eligible household. (KS residency isn't a scenario here — it's enforced by white-label routing, not the calculator.)*
+
+**Criterion 8 mutex depends on regular KanCare eligibility, which is evaluated live.** Working Healthy excludes anyone who qualifies for full Medicaid through another category (`household_eligible` → `medicaid_eligible()`, which reads the `ks_medicaid` result computed on the same screen). Two everyday shapes trip this: an **age-16–18 minor at low income** qualifies for children's KanCare Medicaid (older-child pathway, ≤138% FPL) and a **low-income disabled adult** qualifies for the ABD pathway (countable income ≤ the SSI FBR **and** assets ≤ $2,000). Both are excluded from Working Healthy by design — regular Medicaid is the better coverage and WH is the buy-in for those who earn too much for it. Scenarios that intend to test a WH *edge* (minimum age, the earned-income floor) must therefore put the household **above** the regular-Medicaid threshold, or they are really testing the mutex, not the edge. Sc 2/10 test the minor mutex; Sc 21/22 test the age and earned-income edges with the mutex deliberately not firing.*
 
 ### Scenario 1: Clearly eligible disabled worker
 
@@ -110,10 +112,10 @@ The income, resource, age, employment, disability, insurance, and SSI criteria a
 
 ---
 
-### Scenario 2: Minimally eligible — barely meets all thresholds
+### Scenario 2: Low-income minor covered by children's Medicaid — ineligible (mutex)
 
-**What we're checking**: Applicant who just clears every floor: exactly age 16, minimal employment income, confirmed disability.
-**Expected**: Eligible, value $19,051/year
+**What we're checking**: A disabled, working, age-16 applicant at low income who *independently qualifies for children's KanCare Medicaid*. Working Healthy's Criterion-8 mutex must exclude them — regular Medicaid is the better coverage, and WH is the buy-in for those who earn too much for it.
+**Expected**: Not eligible (routes to children's KanCare Medicaid instead)
 
 **Steps**:
 
@@ -122,7 +124,7 @@ The income, resource, age, employment, disability, insurance, and SSI criteria a
 * **Person 1**: Birth month/year: `June 2010` (age 16), Relationship: `Head of Household`, Disability: `Yes`, Currently employed: `Yes`, Monthly wages: `$200`, Citizenship: `US Citizen`, Insurance: `None`
 * **Assets**: `$500`
 
-**Why this matters**: Tests minimum age and minimal employment together. Any earned income above the $65/mo disregard satisfies §2664.3; countable income is negligible, so the member is eligible at the edge.
+**Why this matters**: A 16-year-old at $200/mo is far under the children's-Medicaid older-child ceiling (6–18, ≤138% FPL), so `ks_medicaid` returns eligible and the WH `medicaid_eligible()` mutex fires (KEESM §2664 intro — "not otherwise covered by full Medicaid"). This is the everyday case a naive "minimally eligible minor" reading misses: a low-income working disabled minor belongs on children's Medicaid, not the buy-in. The age-16 *floor* itself is tested — without the mutex — in Scenario 21. (Discovery gap corrected: MFB-1066 staging QA flagged that the original spec expected Eligible here and in Sc 10, but the calculator correctly returns Not eligible.)
 
 ---
 
@@ -238,10 +240,10 @@ The income, resource, age, employment, disability, insurance, and SSI criteria a
 
 ---
 
-### Scenario 10: Age exactly 16 — minimum age threshold
+### Scenario 10: Low-income minor covered by children's Medicaid — ineligible (mutex, higher income)
 
-**What we're checking**: Whether a person who is exactly 16 (the minimum age) qualifies.
-**Expected**: Eligible, value $19,051/year
+**What we're checking**: The same children's-Medicaid mutex as Scenario 2, at a higher (but still Medicaid-eligible) earned income, to confirm the exclusion isn't an artifact of the near-zero income in Sc 2.
+**Expected**: Not eligible (routes to children's KanCare Medicaid instead)
 
 **Steps**:
 
@@ -250,7 +252,7 @@ The income, resource, age, employment, disability, insurance, and SSI criteria a
 * **Person 1**: Birth month/year: `March 2010` (age 16), Relationship: `Head of Household`, Disability: `Yes`, Currently employed: `Yes`, Monthly wages: `$800`, Citizenship: `US Citizen`, Insurance: `None`
 * **Assets**: `$1,000`
 
-**Why this matters**: §2664.2 sets the minimum age at 16, inclusive. Confirms the age floor does not reject a 16-year-old who otherwise qualifies.
+**Why this matters**: At $800/mo a single 16-year-old is still well under the children's-Medicaid older-child ceiling (138% FPL HH1 ≈ $1,769/mo of MAGI income), so `ks_medicaid` is eligible and the WH mutex fires. Confirms the exclusion holds across the low-income band, not just at the Sc 2 floor. The age-16 *eligibility* edge (a 16-year-old who is **not** Medicaid-eligible) is Scenario 21. (Discovery gap corrected per MFB-1066 staging QA — the original spec wrongly expected Eligible.)
 
 ---
 
@@ -413,6 +415,39 @@ The income, resource, age, employment, disability, insurance, and SSI criteria a
 * **Assets**: `$2,000`
 
 **Why this matters**: Same $8,300/mo income as Sc 18–19, but with no parent present the plan is 1-person, so countable $49,767 exceeds the 1-person ceiling ($47,880) → ineligible. Confirms the sizing bites in both directions and that "minor living with a parent" is a real condition, not a blanket 2-person rule for all minors.
+
+---
+
+### Scenario 21: Age exactly 16, above children's-Medicaid income — eligible (age floor, mutex not firing)
+
+**What we're checking**: The age-16 minimum-age floor from the *eligible* side, isolated from the children's-Medicaid mutex. A 16-year-old whose household income is **above** the children's-Medicaid older-child ceiling (so `ks_medicaid` is not eligible and Criterion 8 does not fire) but still within Working Healthy's 300% FPL limit. This is the eligible-edge test that Scenario 10 used to (incorrectly) claim.
+**Expected**: Eligible, value $19,051/year (minor only)
+
+**Steps**:
+
+* **Location**: Enter ZIP code `66502`, Select county `Riley`
+* **Household**: Number of people: `2`
+* **Person 1** (parent): Birth month/year: `March 1980` (age 46), Relationship: `Head of Household`, no earned income, Insurance: `None`
+* **Person 2** (minor applicant): Birth month/year: `March 2010` (age 16), Relationship: `Child`, Disability: `Yes`, Currently employed: `Yes`, Monthly wages: `$8,300`, Citizenship: `US Citizen`, Insurance: `None`
+* **Assets**: `$2,000`
+
+**Why this matters**: §2664.2 sets the minimum age at 16, inclusive — a qualifying 16-year-old must be eligible. At $8,300/mo the minor is far over the children's-Medicaid older-child ceiling (138% FPL), so the mutex does **not** fire; the minor-with-parent 2-person sizing (Sc 18) puts countable income ($49,767) under the 2-person 300%-FPL ceiling ($64,920), so Working Healthy admits them. This is the honest age-16 floor test: unlike the original Sc 10 (which tripped the mutex), the only thing keeping a *younger* applicant out here would be the age gate. Pairs with Sc 11 (age 15 → ineligible).
+
+---
+
+### Scenario 22: Minimum earned income above the $65 floor, not Medicaid-eligible — eligible (earned floor, mutex not firing)
+
+**What we're checking**: The $65/month earned-income floor from the *eligible* side — an applicant just above the floor who does **not** qualify for regular Medicaid, so the mutex doesn't mask the result. A disabled adult with minimal earned income but countable resources over the ABD Medicaid limit ($2,000) and under the Working Healthy limit ($15,000).
+**Expected**: Eligible, value $19,051/year
+
+**Steps**:
+
+* **Location**: Enter ZIP code `67202`, Select county `Sedgwick`
+* **Household**: Number of people: `1`
+* **Person 1**: Birth month/year: `March 1986` (age 40), Relationship: `Head of Household`, Disability: `Yes`, Currently employed: `Yes`, Monthly wages: `$100`, Citizenship: `US Citizen`, Insurance: `None`
+* **Assets**: `$5,000`
+
+**Why this matters**: $100/mo gross earned is just over the $65 floor (§2664.3), so the employment gate passes and countable income is negligible — WH-eligible on income and age. The $5,000 in assets *fails* the ABD Medicaid asset test ($2,000 individual limit) so `ks_medicaid` is **not** eligible and the mutex doesn't fire, but is well under the $15,000 Working Healthy resource limit. This isolates the earned-floor's eligible side, complementing Sc 16 (earnings **below** the floor → ineligible). Without the asset spread, a low-income disabled adult would qualify for ABD Medicaid and be excluded by the mutex — exactly the trap that Sc 2/10 fell into.
 
 ---
 

--- a/programs/programs/ks/working_healthy/tests/test_working_healthy.py
+++ b/programs/programs/ks/working_healthy/tests/test_working_healthy.py
@@ -8,6 +8,10 @@ Working Healthy eligibility (KEESM §2664):
 - Countable income <= 300% FPL (assistance-plan size), awd_medicaid disregards
 - Countable resources <= $15,000 (flat)
 - Insurance none/employer/private; not an SSI recipient
+- Criterion-8 mutex: excluded if the household is eligible for regular KanCare Medicaid
+  (medicaid_eligible() reads the calculated `ks_medicaid` result). A low-income minor
+  (children's Medicaid) or low-income disabled adult (ABD Medicaid) is excluded — see
+  Sc 2/10 and the spec's mutex note.
 - KS residency handled by white-label routing (Scenario 17 not a calculator test)
 
 Benefit value: $19,051/year per eligible member (KS MAR FY2025 Working Healthy
@@ -78,11 +82,14 @@ def make_calculator(members=None, household_assets=5_000, fpl_limit=FPL_1, medic
     mock_screen.household_assets = household_assets
     mock_screen.household_members.all = Mock(return_value=members)
 
+    # The Criterion-8 mutex reads the calculated regular-Medicaid result via
+    # medicaid_eligible(), which looks up the STATE_MEDICAID_OPTIONS keys — for KS
+    # that is "ks_medicaid" (NOT "medicaid"; keying it wrong makes the mutex a no-op).
     data = {}
     if medicaid_eligible_data:
         med = Mock()
         med.eligible = True
-        data["medicaid"] = med
+        data["ks_medicaid"] = med
 
     mock_missing_deps = Mock()
     mock_missing_deps.has.return_value = False
@@ -120,11 +127,16 @@ class TestSpecScenarios(TestCase):
         self.assertTrue(eligible)
         self.assertEqual(value, VALUE_PER_MEMBER)
 
-    def test_scenario_2_minimally_eligible(self):
-        calc = make_calculator([make_member(age=16, monthly_earned=200)], household_assets=500)
-        eligible, value = run(calc)
-        self.assertTrue(eligible)
-        self.assertEqual(value, VALUE_PER_MEMBER)
+    def test_scenario_2_low_income_minor_medicaid_mutex_ineligible(self):
+        # A low-income working disabled 16-year-old independently qualifies for
+        # children's KanCare Medicaid (older-child pathway), so the Criterion-8
+        # mutex excludes them from Working Healthy. medicaid_eligible_data models
+        # ks_medicaid returning eligible for this household.
+        calc = make_calculator(
+            [make_member(age=16, monthly_earned=200)], household_assets=500, medicaid_eligible_data=True
+        )
+        eligible, _ = run(calc)
+        self.assertFalse(eligible)
 
     def test_scenario_3_not_working_ineligible(self):
         # SSDI (unearned) only, no earned income -> fails employment requirement
@@ -169,11 +181,14 @@ class TestSpecScenarios(TestCase):
         eligible, _ = run(calc)
         self.assertFalse(eligible)
 
-    def test_scenario_10_age_16_eligible(self):
-        calc = make_calculator([make_member(age=16, monthly_earned=800)], household_assets=1_000)
-        eligible, value = run(calc)
-        self.assertTrue(eligible)
-        self.assertEqual(value, VALUE_PER_MEMBER)
+    def test_scenario_10_low_income_minor_medicaid_mutex_ineligible(self):
+        # Same children's-Medicaid mutex as Sc 2, at a higher (still Medicaid-eligible)
+        # earned income — confirms the exclusion isn't an artifact of Sc 2's near-zero income.
+        calc = make_calculator(
+            [make_member(age=16, monthly_earned=800)], household_assets=1_000, medicaid_eligible_data=True
+        )
+        eligible, _ = run(calc)
+        self.assertFalse(eligible)
 
     def test_scenario_11_age_15_ineligible(self):
         calc = make_calculator([make_member(age=15, monthly_earned=800)], household_assets=1_000)
@@ -260,6 +275,42 @@ class TestSpecScenarios(TestCase):
         calc = self._size_aware_calc([minor], minor)
         eligible, _ = run(calc)
         self.assertFalse(eligible)
+
+    def test_scenario_21_age_16_above_medicaid_eligible(self):
+        # Age-16 floor from the ELIGIBLE side, mutex not firing: a 16-year-old whose
+        # income is above the children's-Medicaid ceiling (medicaid_eligible_data=False)
+        # but within WH's 300% FPL limit under 2-person (minor-with-parent) sizing.
+        # $8,300/mo -> countable $49,767: over 1-person ($47,880), under 2-person ($64,920).
+        parent = make_member(age=46, monthly_earned=0, relationship="headOfHousehold")
+        minor = make_member(age=16, monthly_earned=8_300, relationship="child")
+        calc = self._size_aware_calc([parent, minor], minor)  # medicaid mutex off by default
+        eligible, value = run(calc)
+        self.assertTrue(eligible)
+        self.assertEqual(value, VALUE_PER_MEMBER)  # minor only; parent has no earned income
+
+    def test_scenario_22_min_earned_income_not_medicaid_eligible(self):
+        # Earned-income floor from the ELIGIBLE side, mutex not firing: a disabled adult
+        # just over the $65/mo floor whose $5,000 assets fail the ABD Medicaid test
+        # (>$2,000) but pass the WH limit (<$15,000). medicaid_eligible_data=False models
+        # ks_medicaid returning ineligible (over-asset), so the mutex does not fire.
+        calc = make_calculator([make_member(age=40, monthly_earned=100)], household_assets=5_000)
+        eligible, value = run(calc)
+        self.assertTrue(eligible)
+        self.assertEqual(value, VALUE_PER_MEMBER)
+
+    def test_medicaid_mutex_reads_ks_medicaid_key(self):
+        # Structural coverage for the Criterion-8 mutex (household_eligible ->
+        # medicaid_eligible()). Take an otherwise fully-eligible adult and toggle only
+        # the regular-Medicaid result. This is the branch the QA gap exposed: the mutex
+        # keys off "ks_medicaid" (a STATE_MEDICAID_OPTIONS entry), so a household that
+        # qualifies for regular Medicaid is excluded from Working Healthy.
+        base = dict(age=40, monthly_earned=1_800)
+
+        eligible_no_medicaid, _ = run(make_calculator([make_member(**base)], medicaid_eligible_data=False))
+        self.assertTrue(eligible_no_medicaid)
+
+        eligible_with_medicaid, _ = run(make_calculator([make_member(**base)], medicaid_eligible_data=True))
+        self.assertFalse(eligible_with_medicaid)
 
     def test_assistance_plan_size_all_branches(self):
         # Directly exercise every _assistance_plan_size branch.


### PR DESCRIPTION
Follow-up to #1623 (already merged). Addresses the two staging-QA findings on **MFB-1066** and the display-name question.

## Why

Staging QA for KS Working Healthy passed **18/20** API scenarios. The two failures (Sc 2 & 10) were traced to **incorrect spec expectations, not a calculator defect**:

- Both are single-person **age-16** households at low income.
- A low-income working disabled 16-year-old **independently qualifies for children's KanCare Medicaid** (older-child pathway, ≤138% FPL).
- So `ks_medicaid` returns eligible, and Working Healthy's **Criterion-8 mutex** (`household_eligible` → `medicaid_eligible()`, which reads the calculated `ks_medicaid` result) correctly excludes them from the buy-in. Regular Medicaid is the better coverage; WH is for those who earn too much for it.

The spec scenarios conflated the age-16 / minimum-earned-income **edges** with a household shape that *also* trips that mutex. Contrast case Sc 18 (age 17 but $8,300/mo → over the children's-Medicaid ceiling → no mutex → WH eligible ✓) confirmed the mutex behaves as designed.

Per the decision on the ticket: the mutex is correct, no calculator change. Fix the spec + tests so the mutex is **fully** covered *and* the age / earned-income edges keep **dedicated** coverage.

## Changes

**Spec** (`programs/programs/ks/working_healthy/spec.md`)
- **Sc 2 & 10** → expected **Not eligible**, rewritten as the children's-Medicaid minor-mutex cases. Added a mutex-vs-edge note up front explaining that any edge scenario must sit *above* the regular-Medicaid threshold or it's really testing the mutex.
- **New Sc 21** — age-16 floor from the *eligible* side: a 16-year-old with income above the children's-Medicaid ceiling (mutex off) but within WH's 300% FPL under 2-person minor-with-parent sizing → **Eligible**. This is the honest age-16 test Sc 10 used to claim.
- **New Sc 22** — earned-income floor from the *eligible* side: a disabled adult just over the $65/mo floor whose $5,000 assets fail the ABD Medicaid test (>$2,000, mutex off) but pass the $15,000 WH limit → **Eligible**. Complements Sc 16 (below the floor → ineligible).

**Tests** (`tests/test_working_healthy.py`)
- **Fixed a dead mutex fixture**: `medicaid_eligible()` reads `"ks_medicaid"`, not `"medicaid"` — the old key made the mutex a **no-op**, which is why the buggy Sc 2/10 expectations passed as "eligible." Now keyed correctly.
- Flipped Sc 2/10 to assert **ineligible**; added Sc 21, Sc 22, and a **structural test** exercising the real mutex both ways (a branch that had **zero** coverage before).
- **27 tests pass** (`pytest programs/programs/ks/working_healthy`).

**Config** (`ks_working_healthy_initial_config.json`)
- Display name **`Working Healthy (WH)` → `Working Healthy (Medicaid)`** so the results list signals it's Medicaid coverage, matching the precedent of WA `Apple Health (Medicaid)` and KS's own `KanCare (Medicaid)`. (Program ships inactive; re-import/refresh config on staging to pick up the new name.)

## Test plan
- [x] `pytest programs/programs/ks/working_healthy` → 27 passed
- [x] `black` clean; config JSON valid
- [ ] Re-run staging API QA for Sc 2, 10, 21, 22 → 20/20
- [ ] Confirm the renamed program label renders as "Working Healthy (Medicaid)" on the staging results page

Refs: MFB-1066 · follow-up to #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)