### PR TITLE
MFB-1307: Improve benefit value for WA HCV program

### DIFF
--- a/programs/programs/tx/hcv/calculator.py
+++ b/programs/programs/tx/hcv/calculator.py
@@ -132,7 +132,10 @@ class TxHcv(ProgramCalculator):
 
     def household_eligible(self, e: Eligibility):
         # Criterion 2: not already receiving Section 8 / HCV assistance.
-        e.condition(not self.screen.has_benefit("section_8"), messages.must_not_have_benefit("Section 8"))
+        # "Section 8" is the HCV program itself (base_program "section_8"): tx_hcv,
+        # wa_hcv, co_section_8, etc. Use has_base_benefit so it matches every
+        # white-label variant
+        e.condition(not self.screen.has_base_benefit("section_8"), messages.must_not_have_benefit("Section 8"))
 
         # Criterion 9: HOTMA net-asset limit — only a gate when reported over $100k.
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0

--- a/programs/programs/tx/hcv/calculator.py
+++ b/programs/programs/tx/hcv/calculator.py
@@ -131,11 +131,12 @@ class TxHcv(ProgramCalculator):
         return head.age >= self.min_head_age
 
     def household_eligible(self, e: Eligibility):
-        # Criterion 2: not already receiving Section 8 / HCV assistance.
-        # "Section 8" is the HCV program itself (base_program "section_8"): tx_hcv,
-        # wa_hcv, co_section_8, etc. Use has_base_benefit so it matches every
-        # white-label variant
-        e.condition(not self.screen.has_base_benefit("section_8"), messages.must_not_have_benefit("Section 8"))
+        # Criterion 2 (not already receiving Section 8 / HCV) is intentionally not
+        # checked here: tx_hcv *is* the "section_8" program, so "already has Section
+        # 8" == "already has tx_hcv". That duplicate-subsidy case is handled
+        # generically by the results-layer `already_has` filter
+        # (screen.has_benefit(program.name_abbreviated)), not the calculator —
+        # calculators only check *other* programs to inform eligibility.
 
         # Criterion 9: HOTMA net-asset limit — only a gate when reported over $100k.
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0

--- a/programs/programs/tx/hcv/calculator.py
+++ b/programs/programs/tx/hcv/calculator.py
@@ -131,13 +131,6 @@ class TxHcv(ProgramCalculator):
         return head.age >= self.min_head_age
 
     def household_eligible(self, e: Eligibility):
-        # Criterion 2 (not already receiving Section 8 / HCV) is intentionally not
-        # checked here: tx_hcv *is* the "section_8" program, so "already has Section
-        # 8" == "already has tx_hcv". That duplicate-subsidy case is handled
-        # generically by the results-layer `already_has` filter
-        # (screen.has_benefit(program.name_abbreviated)), not the calculator —
-        # calculators only check *other* programs to inform eligibility.
-
         # Criterion 9: HOTMA net-asset limit — only a gate when reported over $100k.
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0
         e.condition(assets <= self.asset_limit, messages.assets(self.asset_limit))

--- a/programs/programs/tx/hcv/spec.md
+++ b/programs/programs/tx/hcv/spec.md
@@ -20,9 +20,9 @@
 
 2. **Applicant must not currently be receiving HCV/Section 8 assistance.**
 
-   - **Screener fields:** `tx_hcv` current benefit — "Section 8" is the HCV program itself (base_program `section_8`), checked via `has_base_benefit("section_8")` so it matches every white-label variant (`tx_hcv`, `wa_hcv`, `co_section_8`, …).
+   - **Screener fields:** `tx_hcv` current benefit — "Section 8" *is* this program (base_program `section_8`), so "already receiving Section 8" means "already has `tx_hcv`".
    - **Source:** 24 CFR 982.551(n)
-   - **Implementation:** `has_base_benefit("section_8") == true` → ineligible, as a hard override. A household already receiving Section 8/HCV assistance cannot receive a second voucher.
+   - **Implementation:** Not a calculator check. The generic results-layer `already_has` workflow filters `tx_hcv` out of results when the household reports it (via `screen.has_benefit("tx_hcv")`). The calculator does not self-exclude — it only checks *other* programs to inform eligibility.
 
 3. **Head of household, spouse, or co-head must have the legal capacity to enter a lease under Texas law** — in practice, age 18, unless the applicant is an emancipated minor. ⚠️ *data gap — handled conservatively, not by inclusivity default*
 
@@ -413,9 +413,9 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ### Scenario 10: Single Adult Already Receiving Section 8/HCV Assistance in Harris County
 
-**What we're checking**: The duplicate-benefit exclusion (Criterion 2) for a household already receiving Section 8.
+**What we're checking**: The duplicate-benefit exclusion (Criterion 2) for a household already receiving Section 8. `tx_hcv` *is* the Section 8 program, so this is not a calculator check — the generic results-layer `already_has` filter removes `tx_hcv` from results when the household reports it. The calculator itself still returns eligible (income permitting).
 
-**Expected**: Not eligible
+**Expected**: Eligible from the calculator; filtered out of results by `already_has` (not shown to the user).
 
 **Steps**:
 - **Location**: Enter ZIP code `77001`, Select county `Harris`
@@ -423,15 +423,15 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 - **Person 1**: Birth month/year: `March 1986` (age 40), Relationship: Head of Household, Has income: No
 - **Current Benefits**: Indicate household is **already receiving Section 8 / Housing Choice Voucher assistance** — select the `tx_hcv` current benefit
 
-**Why this matters**: 24 CFR 982.551(n) prohibits duplicate HCV assistance. The JSON test case must include `tx_hcv` in the household's `current_benefits` list to trigger this exclusion — the check is `has_base_benefit("section_8")` (see Criterion 2).
+**Why this matters**: 24 CFR 982.551(n) prohibits duplicate HCV assistance, but because `tx_hcv` is itself the Section 8 program the duplicate case is handled generically by the `already_has` results-layer filter (`screen.has_benefit("tx_hcv")`), not a calculator self-check (see Criterion 2).
 
 ---
 
 ### Scenario 11: Currently Receiving HCV/Section 8 Assistance - Duplicate Benefit Exclusion in Dallas County
 
-**What we're checking**: The same duplicate-benefit exclusion for a multi-person household.
+**What we're checking**: The same duplicate-benefit exclusion for a multi-person household — handled by the `already_has` results-layer filter, not a calculator self-check.
 
-**Expected**: Not eligible
+**Expected**: Eligible from the calculator; filtered out of results by `already_has` (not shown to the user).
 
 **Steps**:
 - **Location**: Enter ZIP code `75201`, Select county `Dallas`

--- a/programs/programs/tx/hcv/spec.md
+++ b/programs/programs/tx/hcv/spec.md
@@ -15,14 +15,14 @@
 
    - **Screener fields:** `household_size`, `county`, `calc_gross_income("yearly", ["all"])`
    - **Source:** TDHCA HCV Administrative Plan (Sept. 2022 update), Ch. 3 Part II; 24 CFR 982.201(b); 42 U.S.C. § 1437n(b)(1)
-   - **Implementation:** Compare household income against the 50% AMI limit for the household's county and size, looked up from HUD's published FY2026 Section 8 Income Limits dataset (see Research Sources) — re-fetch annually when HUD updates it. TDHCA extends eligibility to 80% AMI ("Low Income") only for five narrow categories — continuously-assisted families, HOPE 1/2 homeownership residents, mortgage-prepayment-displaced families, Disaster preference, and Project Access (see Priority Criteria) — none of which apply to an ordinary applicant, so the 50% ceiling governs by default. Scenario 17 is the regression test confirming a household between the two ceilings is correctly rejected. **The same income-exclusion rules used for Benefit Value (see "Income exclusions modeled") apply here too** — a naive `calc_gross_income("yearly", ["all"])` call with no filtering could wrongly count a minor's wages or a foster child's income toward this ceiling and push an otherwise-eligible household over it, which is an eligibility miss, not just a value error.
+   - **Implementation:** Compare household income against the 50% AMI limit for the household's county and size, looked up from HUD's published FY2026 Section 8 Income Limits dataset (see Research Sources) — re-fetch annually when HUD updates it. TDHCA extends eligibility to 80% AMI ("Low Income") only for five narrow categories — continuously-assisted families, HOPE 1/2 homeownership residents, mortgage-prepayment-displaced families, Disaster preference, and Project Access (see Priority Criteria) — none of which apply to an ordinary applicant, so the 50% ceiling governs by default. Scenario 15 is the regression test confirming a household between the two ceilings is correctly rejected. **The same income-exclusion rules used for Benefit Value (see "Income exclusions modeled") apply here too** — a naive `calc_gross_income("yearly", ["all"])` call with no filtering could wrongly count a minor's wages or a foster child's income toward this ceiling and push an otherwise-eligible household over it, which is an eligibility miss, not just a value error.
    - **Known limitation:** the calculator can't detect Disaster preference or Project Access status from screener data, so a household in one of those two categories, between the 50% and 80% ceilings, would be incorrectly shown as ineligible. Handled conservatively, not by inclusivity default — same reasoning as Criterion 3's emancipated-minor exception. Documented, not a bug to fix in this ticket. **Surfaced in the description** ("if your community was recently declared a disaster area, or you're moving out of an institution due to a disability, you may still qualify...") since, unlike Criterion 3, this affects a more recognizable, actionable population.
 
 2. **Applicant must not currently be receiving HCV/Section 8 assistance.**
 
    - **Screener fields:** `tx_hcv` current benefit — "Section 8" *is* this program (base_program `section_8`), so "already receiving Section 8" means "already has `tx_hcv`".
    - **Source:** 24 CFR 982.551(n)
-   - **Implementation:** Not a calculator check. The generic results-layer `already_has` workflow filters `tx_hcv` out of results when the household reports it (via `screen.has_benefit("tx_hcv")`). The calculator does not self-exclude — it only checks *other* programs to inform eligibility.
+   - **Implementation:** Not a calculator check. Because `tx_hcv` *is* the Section 8 program, checking "already receiving Section 8" would be a self-check, which calculators don't do.
 
 3. **Head of household, spouse, or co-head must have the legal capacity to enter a lease under Texas law** — in practice, age 18, unless the applicant is an emancipated minor. ⚠️ *data gap — handled conservatively, not by inclusivity default*
 
@@ -135,9 +135,9 @@ These do not determine eligibility but affect waitlist position or access to spe
 > Monthly HAP = min(Payment Standard, Gross Rent) − Total Tenant Payment (TTP), floored at $0
 > Annual value = Monthly HAP × 12
 
-MFB does collect a household's rent, via the `rent`/`mortgage` expense fields (`screen.calc_expenses("monthly", ["rent", "mortgage"])`) — but it's optional and not reliably captured (the same limitation noted for the rent-burden priority factor). Where reported, use `min(Payment Standard, reported rent)` per the formula above; where not reported, fall back to Payment Standard alone as a reasonable upper-bound estimate. Scenario 19 tests the reported-rent branch; Scenarios 1–18 test the no-rent-reported fallback. The $0 floor is a real, tested outcome (see Scenario 4), not an error condition — a household can be eligible for the voucher program with zero net subsidy if TTP exceeds the payment standard (or reported rent).
+MFB does collect a household's rent, via the `rent`/`mortgage` expense fields (`screen.calc_expenses("monthly", ["rent", "mortgage"])`) — but it's optional and not reliably captured (the same limitation noted for the rent-burden priority factor). Where reported, use `min(Payment Standard, reported rent)` per the formula above; where not reported, fall back to Payment Standard alone as a reasonable upper-bound estimate. Scenario 17 tests the reported-rent branch; Scenarios 1–16 test the no-rent-reported fallback. The $0 floor is a real, tested outcome (see Scenario 4), not an error condition — a household can be eligible for the voucher program with zero net subsidy if TTP exceeds the payment standard (or reported rent).
 
-**Documented simplification — no utility allowance.** TDHCA defines Gross Rent as rent-to-owner *plus* a PHA-published utility allowance for tenant-paid utilities (24 CFR 982.517; TDHCA Admin Plan, Ch. 6 Part III, p.93–94), not bare contract rent. This calculator uses the household's reported rent alone as Gross Rent (Scenario 19), with no utility allowance added — MFB's screener doesn't collect utility costs, and TDHCA's allowance schedule (which varies by unit size and is revised at least annually) isn't captured anywhere in MFB's data. This understates Gross Rent, and therefore HAP, for the subset of households responsible for paying their own utilities. A known, deliberate simplification, matching the medical/childcare deduction deferrals above, not an oversight.
+**Documented simplification — no utility allowance.** TDHCA defines Gross Rent as rent-to-owner *plus* a PHA-published utility allowance for tenant-paid utilities (24 CFR 982.517; TDHCA Admin Plan, Ch. 6 Part III, p.93–94), not bare contract rent. This calculator uses the household's reported rent alone as Gross Rent (Scenario 17), with no utility allowance added — MFB's screener doesn't collect utility costs, and TDHCA's allowance schedule (which varies by unit size and is revised at least annually) isn't captured anywhere in MFB's data. This understates Gross Rent, and therefore HAP, for the subset of households responsible for paying their own utilities. A known, deliberate simplification, matching the medical/childcare deduction deferrals above, not an oversight.
 
 **Total Tenant Payment (TTP)** is the highest of (24 CFR 5.628):
 1. 30% of monthly adjusted income
@@ -145,9 +145,9 @@ MFB does collect a household's rent, via the `rent`/`mortgage` expense fields (`
 3. Welfare rent — N/A for this program (TDHCA's plan: "Welfare rent does not apply")
 4. Minimum rent, **$25/month** — 24 CFR 5.630(a)(2) actually gives TDHCA *discretion* to set HCV's minimum rent anywhere from $0 to $50 (HCV is grouped with public housing and moderate rehab in the discretionary range, not the flat-$25 "other section 8" bucket in (a)(3)); TDHCA elected $25 within that range (Admin Plan, p.90: *"The minimum rent for all Department localities is $25.00 per month"*). Waivable for documented financial hardship (temporary hardship: 90-day suspension; permanent hardship: ongoing exemption) — not evaluable from screener data
 
-**Calculator implementation:** Adjusted annual income = gross annual income (`calc_gross_income("yearly", ["all"])`) minus the two deductions below; adjusted monthly income = adjusted annual income ÷ 12. Implement all three TTP components (30%-of-adjusted, 10%-of-gross, $25 floor) and take the highest — don't skip item 2 as an optimization, even though no scenario in this spec exercises it as the binding term. That's a real property of the math, not an oversight: for a very-low-income household with dependents, 30%-of-adjusted can drop below 10%-of-gross, but at that point both are already close to the $25 floor, so the floor — not the 10% term — ends up deciding TTP. The zero-income case (Scenario 14) is where the $25 floor binds. Round TTP to the nearest dollar (24 CFR 5.628).
+**Calculator implementation:** Adjusted annual income = gross annual income (`calc_gross_income("yearly", ["all"])`) minus the two deductions below; adjusted monthly income = adjusted annual income ÷ 12. Implement all three TTP components (30%-of-adjusted, 10%-of-gross, $25 floor) and take the highest — don't skip item 2 as an optimization, even though no scenario in this spec exercises it as the binding term. That's a real property of the math, not an oversight: for a very-low-income household with dependents, 30%-of-adjusted can drop below 10%-of-gross, but at that point both are already close to the $25 floor, so the floor — not the 10% term — ends up deciding TTP. The zero-income case (Scenario 12) is where the $25 floor binds. Round TTP to the nearest dollar (24 CFR 5.628).
 
-**Income exclusions modeled** (24 CFR 5.609(b)) — apply before computing gross income, for both this eligibility test and the benefit value calculation below: (1) earned income (wages/self-employment) of a household member under 18 is excluded entirely — their *unearned* income (Social Security, child support, etc.) still counts; (2) all income of a `fosterChild`-relationship member is excluded entirely, earned or unearned. MFB's `calc_gross_income("yearly", ["all"])` sums every member's income with no such filtering — implement this by filtering `income_streams` by member age/type and by `relationship == "fosterChild"` before summing, not by using that call as-is. Scenario 23 tests the under-18-earned-income exclusion; Scenario 24 tests the foster-child exclusion (which is broader than the under-18 exclusion — it also covers a foster child's *unearned* income, which would otherwise still count for an ordinary minor).
+**Income exclusions modeled** (24 CFR 5.609(b)) — apply before computing gross income, for both this eligibility test and the benefit value calculation below: (1) earned income (wages/self-employment) of a household member under 18 is excluded entirely — their *unearned* income (Social Security, child support, etc.) still counts; (2) all income of a `fosterChild`-relationship member is excluded entirely, earned or unearned. MFB's `calc_gross_income("yearly", ["all"])` sums every member's income with no such filtering — implement this by filtering `income_streams` by member age/type and by `relationship == "fosterChild"` before summing, not by using that call as-is. Scenario 21 tests the under-18-earned-income exclusion; Scenario 22 tests the foster-child exclusion (which is broader than the under-18 exclusion — it also covers a foster child's *unearned* income, which would otherwise still count for an ordinary minor).
 
 **Other income exclusions — data gap, not modeled.** 24 CFR 5.609(b) also excludes foster-care/kinship-guardianship care payments, student financial assistance (scholarships/grants), insurance settlements, medical-expense reimbursements, disability-related civil-action settlements, PASS-plan set-asides, resident service stipends (≤$200/month), employment-training program earnings, and 529/Coverdell/baby-bond income, among others. None of these have a distinct `income_streams` type in MFB's screener (confirmed against the model) — a household receiving any of them has no way to report it as anything other than generic `other` income, so the calculator can't detect and exclude them specifically. Not evaluable, and no scenario is possible for these: there's no way to construct a household input that isolates them from ordinary `other` income. A genuine screener-driven data gap, not a modeling gap — flagged here rather than left silent.
 
@@ -249,21 +249,19 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 [ ] Scenario 7 (17-Year-Old Head of Household in El Paso County - Below Minimum Age): User should be **ineligible**
 [ ] Scenario 8 (45-Year-Old Head of Household Well Above Minimum Age in Lubbock County): User should be **eligible** with $5,496/year
 [ ] Scenario 9 (Eligible Single Adult in Midland County - West Texas Service Area): User should be **eligible** with $12,768/year
-[ ] Scenario 10 (Single Adult Already Receiving Section 8/HCV Assistance in Harris County): User should be **ineligible**
-[ ] Scenario 11 (Currently Receiving HCV/Section 8 Assistance - Duplicate Benefit Exclusion in Dallas County): User should be **ineligible**
-[ ] Scenario 12 (Mixed Household - Adult Head with Elderly Parent and Minor Child in Hidalgo County): User should be **eligible** with $5,124/year
-[ ] Scenario 13 (Multiple Eligible Adults in Same Household - Two Working Adults with Two Children in Collin County): User should be **eligible** with $21,888/year
-[ ] Scenario 14 (Household of One with Exactly Zero Income in Cameron County): User should be **eligible** with $8,976/year
-[ ] Scenario 15 (Full-Time Student with Low Income in Lubbock County): User should be **eligible** with $6,936/year
-[ ] Scenario 16 (Household of Five in McLennan County — Waco): User should be **eligible** with $12,420/year
-[ ] Scenario 17 (Single Adult Between 50% and 80% AMI in Travis County — Ineligible Despite Clearing the Generic Federal Ceiling): User should be **ineligible**
-[ ] Scenario 18 (Large Family of Seven in McLennan County — Waco, Tests 4BR Payment Standard Tier): User should be **eligible** with $12,168/year
-[ ] Scenario 19 (Reported Rent Below Payment Standard in El Paso County): User should be **eligible** with $1,800/year
-[ ] Scenario 20 (Household Exceeding the HOTMA Net-Asset Limit in Harris County): User should be **ineligible**
-[ ] Scenario 21 (Elderly Head of Household with an 18+ Disabled Dependent in Bexar County): User should be **eligible** with $5,700/year
-[ ] Scenario 22 (Foster Child Correctly Excluded from the Dependent Deduction in Harris County): User should be **eligible** with $11,556/year
-[ ] Scenario 23 (Working Teenager's Wages Correctly Excluded from Countable Income in El Paso County): User should be **eligible** with $8,700/year
-[ ] Scenario 24 (Foster Child's Unearned Income Correctly Excluded in Harris County): User should be **eligible** with $11,556/year
+[ ] Scenario 10 (Mixed Household - Adult Head with Elderly Parent and Minor Child in Hidalgo County): User should be **eligible** with $5,124/year
+[ ] Scenario 11 (Multiple Eligible Adults in Same Household - Two Working Adults with Two Children in Collin County): User should be **eligible** with $21,888/year
+[ ] Scenario 12 (Household of One with Exactly Zero Income in Cameron County): User should be **eligible** with $8,976/year
+[ ] Scenario 13 (Full-Time Student with Low Income in Lubbock County): User should be **eligible** with $6,936/year
+[ ] Scenario 14 (Household of Five in McLennan County — Waco): User should be **eligible** with $12,420/year
+[ ] Scenario 15 (Single Adult Between 50% and 80% AMI in Travis County — Ineligible Despite Clearing the Generic Federal Ceiling): User should be **ineligible**
+[ ] Scenario 16 (Large Family of Seven in McLennan County — Waco, Tests 4BR Payment Standard Tier): User should be **eligible** with $12,168/year
+[ ] Scenario 17 (Reported Rent Below Payment Standard in El Paso County): User should be **eligible** with $1,800/year
+[ ] Scenario 18 (Household Exceeding the HOTMA Net-Asset Limit in Harris County): User should be **ineligible**
+[ ] Scenario 19 (Elderly Head of Household with an 18+ Disabled Dependent in Bexar County): User should be **eligible** with $5,700/year
+[ ] Scenario 20 (Foster Child Correctly Excluded from the Dependent Deduction in Harris County): User should be **eligible** with $11,556/year
+[ ] Scenario 21 (Working Teenager's Wages Correctly Excluded from Countable Income in El Paso County): User should be **eligible** with $8,700/year
+[ ] Scenario 22 (Foster Child's Unearned Income Correctly Excluded in Harris County): User should be **eligible** with $11,556/year
 
 ## Test Scenarios
 
@@ -347,7 +345,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 - **Household**: Number of people: `1`
 - **Person 1**: Birth month/year: `March 1991` (age 35), Relationship: Head of Household, Has income: Yes, Employment income: `$6,250` per month, No current benefits
 
-**Why this matters**: Travis County's 1-person VLI is **$47,050/year (FY2026)**; at $75,000/year, income exceeds it by a wide margin — an unambiguous ineligible case (also above the generic federal 80% AMI ceiling of **$74,800 (FY2026)**, so it stays ineligible under either standard). Contrast with Scenario 17, which sits between the two ceilings and depends on using the correct one.
+**Why this matters**: Travis County's 1-person VLI is **$47,050/year (FY2026)**; at $75,000/year, income exceeds it by a wide margin — an unambiguous ineligible case (also above the generic federal 80% AMI ceiling of **$74,800 (FY2026)**, so it stays ineligible under either standard). Contrast with Scenario 15, which sits between the two ceilings and depends on using the correct one.
 
 ---
 
@@ -411,41 +409,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 10: Single Adult Already Receiving Section 8/HCV Assistance in Harris County
-
-**What we're checking**: The duplicate-benefit exclusion (Criterion 2) for a household already receiving Section 8. `tx_hcv` *is* the Section 8 program, so this is not a calculator check — the generic results-layer `already_has` filter removes `tx_hcv` from results when the household reports it. The calculator itself still returns eligible (income permitting).
-
-**Expected**: Eligible from the calculator; filtered out of results by `already_has` (not shown to the user).
-
-**Steps**:
-- **Location**: Enter ZIP code `77001`, Select county `Harris`
-- **Household**: Number of people: `1`
-- **Person 1**: Birth month/year: `March 1986` (age 40), Relationship: Head of Household, Has income: No
-- **Current Benefits**: Indicate household is **already receiving Section 8 / Housing Choice Voucher assistance** — select the `tx_hcv` current benefit
-
-**Why this matters**: 24 CFR 982.551(n) prohibits duplicate HCV assistance, but because `tx_hcv` is itself the Section 8 program the duplicate case is handled generically by the `already_has` results-layer filter (`screen.has_benefit("tx_hcv")`), not a calculator self-check (see Criterion 2).
-
----
-
-### Scenario 11: Currently Receiving HCV/Section 8 Assistance - Duplicate Benefit Exclusion in Dallas County
-
-**What we're checking**: The same duplicate-benefit exclusion for a multi-person household — handled by the `already_has` results-layer filter, not a calculator self-check.
-
-**Expected**: Eligible from the calculator; filtered out of results by `already_has` (not shown to the user).
-
-**Steps**:
-- **Location**: Enter ZIP code `75201`, Select county `Dallas`
-- **Household**: Number of people: `3`
-- **Person 1**: Birth month/year: `March 1988` (age 38), Relationship: Head of Household, Has income: Yes, Employment income: `$1,800` per month
-- **Person 2**: Birth month/year: `September 2014` (age 11), Relationship: Child, Has income: No
-- **Person 3**: Birth month/year: `January 2018` (age 8), Relationship: Child, Has income: No
-- **Current Benefits**: Indicate household is currently receiving Section 8 / Housing Choice Voucher assistance — select the `tx_hcv` current benefit
-
-**Why this matters**: Confirms the exclusion holds for larger households too, not just single-person ones.
-
----
-
-### Scenario 12: Mixed Household - Adult Head with Elderly Parent and Minor Child in Hidalgo County
+### Scenario 10: Mixed Household - Adult Head with Elderly Parent and Minor Child in Hidalgo County
 
 **What we're checking**: Income aggregation across a mixed-generation household with multiple income sources.
 
@@ -463,7 +427,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 13: Multiple Eligible Adults in Same Household - Two Working Adults with Two Children in Collin County
+### Scenario 11: Multiple Eligible Adults in Same Household - Two Working Adults with Two Children in Collin County
 
 **What we're checking**: Multiple income-earning adults are aggregated into one household total.
 
@@ -482,7 +446,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 14: Household of One with Exactly Zero Income in Cameron County
+### Scenario 12: Household of One with Exactly Zero Income in Cameron County
 
 **What we're checking**: Zero income is handled gracefully, and — the key thing this scenario tests — TDHCA's $25/month minimum-rent floor is applied to TTP rather than letting it collapse to literal $0.
 
@@ -497,7 +461,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 15: Full-Time Student with Low Income in Lubbock County
+### Scenario 13: Full-Time Student with Low Income in Lubbock County
 
 **What we're checking**: The student-restrictions inclusivity assumption (Criterion 8) — a full-time student with no disqualifying flags still shows as eligible.
 
@@ -512,7 +476,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 16: Household of Five in McLennan County (Waco) — Tests 3BR Payment Standard Tier
+### Scenario 14: Household of Five in McLennan County (Waco) — Tests 3BR Payment Standard Tier
 
 **What we're checking**: A 5-person household correctly maps to the 3BR voucher bedroom size, and the county-level FMR payment standard is applied correctly.
 
@@ -532,7 +496,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 17: Single Adult Between 50% and 80% AMI in Travis County (Austin) — Ineligible Despite Clearing the Generic Federal Ceiling
+### Scenario 15: Single Adult Between 50% and 80% AMI in Travis County (Austin) — Ineligible Despite Clearing the Generic Federal Ceiling
 
 **What we're checking**: The key regression test for Criterion 1 — confirms the calculator uses TDHCA's real, tighter 50% AMI ceiling for ordinary applicants, not the generic 80% AMI figure sometimes cited for Section 8 nationally.
 
@@ -547,9 +511,9 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 18: Large Family of Seven in McLennan County (Waco) — Tests 4BR Payment Standard Tier
+### Scenario 16: Large Family of Seven in McLennan County (Waco) — Tests 4BR Payment Standard Tier
 
-**What we're checking**: A 7-person household correctly maps to the largest voucher bedroom size (4BR) — the one bedroom-size tier no other scenario exercises (Scenarios 1, 3, 4, and 16 cover 2BR, 2BR, 1BR, and 3BR respectively; nothing previously tested 4BR).
+**What we're checking**: A 7-person household correctly maps to the largest voucher bedroom size (4BR) — the one bedroom-size tier no other scenario exercises (Scenarios 1, 3, 4, and 14 cover 2BR, 2BR, 1BR, and 3BR respectively; nothing previously tested 4BR).
 
 **Expected**: Eligible, $12,168/year
 
@@ -569,7 +533,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 19: Reported Rent Below Payment Standard in El Paso County
+### Scenario 17: Reported Rent Below Payment Standard in El Paso County
 
 **What we're checking**: When a household reports actual rent lower than the Payment Standard, HAP uses `min(Payment Standard, reported rent)` — not Payment Standard alone. Confirms the calculator reads the `rent` expense field rather than defaulting to the Payment-Standard-only estimate every time it's available.
 
@@ -585,7 +549,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 20: Household Exceeding the HOTMA Net-Asset Limit in Harris County
+### Scenario 18: Household Exceeding the HOTMA Net-Asset Limit in Harris County
 
 **What we're checking**: The net-assets eligibility gate (Criterion 9) — a household otherwise well within the income limit is correctly rejected once reported assets exceed the $100,000 HOTMA cap.
 
@@ -601,7 +565,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 21: Elderly Head of Household with an 18+ Disabled Dependent in Bexar County
+### Scenario 19: Elderly Head of Household with an 18+ Disabled Dependent in Bexar County
 
 **What we're checking**: Two previously-untested branches of the dependent deduction at once — (1) a dependent who qualifies via the "18+ and disabled or a full-time student" path rather than being under 18, and (2) the $480/dependent and $525/elderly-family deductions both applying to the same household simultaneously (every other scenario with dependents has a non-elderly head, and Scenario 4's elderly-family case has no dependents).
 
@@ -617,7 +581,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 22: Foster Child Correctly Excluded from the Dependent Deduction in Harris County
+### Scenario 20: Foster Child Correctly Excluded from the Dependent Deduction in Harris County
 
 **What we're checking**: The dependent deduction must exclude foster children — MFB's `relationship` field has a distinct `fosterChild` value specifically so the calculator can tell them apart from a household's own children, but no prior scenario actually included one to confirm the exclusion works.
 
@@ -633,7 +597,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 23: Working Teenager's Wages Correctly Excluded from Countable Income in El Paso County
+### Scenario 21: Working Teenager's Wages Correctly Excluded from Countable Income in El Paso County
 
 **What we're checking**: 24 CFR 5.609(b)(3) excludes the *earned* income of a household member under 18 entirely — their unearned income (SS, child support) would still count, but wages don't. This is a different, previously-untested branch of the income calculation from the dependent deduction: it's about what counts as *gross income* in the first place, not about the per-dependent deduction. No prior scenario has a child with any income at all.
 
@@ -649,9 +613,9 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 
 ---
 
-### Scenario 24: Foster Child's Unearned Income Correctly Excluded in Harris County
+### Scenario 22: Foster Child's Unearned Income Correctly Excluded in Harris County
 
-**What we're checking**: 24 CFR 5.609(b)(8) excludes *all* income of a foster child — earned or unearned — which is broader than the under-18 exclusion tested in Scenario 23 (that one only excludes a regular minor's *earned* income; their unearned income, like Social Security, would still count). Giving the foster child unearned income specifically isolates this broader rule from the narrower one.
+**What we're checking**: 24 CFR 5.609(b)(8) excludes *all* income of a foster child — earned or unearned — which is broader than the under-18 exclusion tested in Scenario 21 (that one only excludes a regular minor's *earned* income; their unearned income, like Social Security, would still count). Giving the foster child unearned income specifically isolates this broader rule from the narrower one.
 
 **Expected**: Eligible, $11,556/year
 
@@ -661,4 +625,4 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 - **Person 1**: Birth month/year: `March 1991` (age 35), Relationship: Head of Household, Has income: Yes, Employment income: `$1,200` per month, No current Section 8/HCV assistance
 - **Person 2**: Birth month/year: `June 2016` (age 10), Relationship: Foster Child, Has income: Yes, Income type: Social Security, Amount: `$200` per month
 
-**Why this matters**: This scenario is identical to Scenario 22 except the foster child now has $200/month in Social Security income — and the expected result is deliberately **unchanged** from Scenario 22 ($11,556/year), because that income must be excluded entirely. If the foster child's income were wrongly included, gross annual income would be $16,800 instead of $14,400, adjusted monthly would rise to $1,400, TTP would rise to $420 (30% of $1,400), and HAP would drop to $903/month = $10,836/year — a $720/year detectable shortfall versus the correct value. The unchanged expected value, next to Scenario 22, is the point: it proves adding income to a foster child doesn't affect the result, the way it would for any other household member.
+**Why this matters**: This scenario is identical to Scenario 20 except the foster child now has $200/month in Social Security income — and the expected result is deliberately **unchanged** from Scenario 20 ($11,556/year), because that income must be excluded entirely. If the foster child's income were wrongly included, gross annual income would be $16,800 instead of $14,400, adjusted monthly would rise to $1,400, TTP would rise to $420 (30% of $1,400), and HAP would drop to $903/month = $10,836/year — a $720/year detectable shortfall versus the correct value. The unchanged expected value, next to Scenario 20, is the point: it proves adding income to a foster child doesn't affect the result, the way it would for any other household member.

--- a/programs/programs/tx/hcv/spec.md
+++ b/programs/programs/tx/hcv/spec.md
@@ -20,9 +20,9 @@
 
 2. **Applicant must not currently be receiving HCV/Section 8 assistance.**
 
-   - **Screener fields:** `has_section_8`
+   - **Screener fields:** `tx_hcv` current benefit — "Section 8" is the HCV program itself (base_program `section_8`), checked via `has_base_benefit("section_8")` so it matches every white-label variant (`tx_hcv`, `wa_hcv`, `co_section_8`, …).
    - **Source:** 24 CFR 982.551(n)
-   - **Implementation:** `has_section_8 == true` → ineligible, as a hard override. A household already receiving Section 8/HCV assistance cannot receive a second voucher.
+   - **Implementation:** `has_base_benefit("section_8") == true` → ineligible, as a hard override. A household already receiving Section 8/HCV assistance cannot receive a second voucher.
 
 3. **Head of household, spouse, or co-head must have the legal capacity to enter a lease under Texas law** — in practice, age 18, unless the applicant is an emancipated minor. ⚠️ *data gap — handled conservatively, not by inclusivity default*
 
@@ -421,9 +421,9 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 - **Location**: Enter ZIP code `77001`, Select county `Harris`
 - **Household**: Number of people: `1`
 - **Person 1**: Birth month/year: `March 1986` (age 40), Relationship: Head of Household, Has income: No
-- **Current Benefits**: Indicate household is **already receiving Section 8 / Housing Choice Voucher assistance** (`has_section_8: true`)
+- **Current Benefits**: Indicate household is **already receiving Section 8 / Housing Choice Voucher assistance** — select the `tx_hcv` current benefit
 
-**Why this matters**: 24 CFR 982.551(n) prohibits duplicate HCV assistance. The JSON test case must include `has_section_8: true` at the household level to trigger this exclusion (see Criterion 2).
+**Why this matters**: 24 CFR 982.551(n) prohibits duplicate HCV assistance. The JSON test case must include `tx_hcv` in the household's `current_benefits` list to trigger this exclusion — the check is `has_base_benefit("section_8")` (see Criterion 2).
 
 ---
 
@@ -439,7 +439,7 @@ SSN is a document requirement (the config's `tx_ssn` document), not an eligibili
 - **Person 1**: Birth month/year: `March 1988` (age 38), Relationship: Head of Household, Has income: Yes, Employment income: `$1,800` per month
 - **Person 2**: Birth month/year: `September 2014` (age 11), Relationship: Child, Has income: No
 - **Person 3**: Birth month/year: `January 2018` (age 8), Relationship: Child, Has income: No
-- **Current Benefits**: Indicate household is currently receiving Section 8 / Housing Choice Voucher assistance (`has_section_8: true`)
+- **Current Benefits**: Indicate household is currently receiving Section 8 / Housing Choice Voucher assistance — select the `tx_hcv` current benefit
 
 **Why this matters**: Confirms the exclusion holds for larger households too, not just single-person ones.
 

--- a/programs/programs/tx/hcv/tests/test_tx_hcv.py
+++ b/programs/programs/tx/hcv/tests/test_tx_hcv.py
@@ -248,17 +248,6 @@ class TestTxHcvEligibility(TestCase):
             calc.household_eligible(e)
             self.assertTrue(e.eligible)
 
-    def test_already_has_section_8_not_self_excluded_by_calculator(self):
-        """tx_hcv *is* the "section_8" program, so the duplicate-subsidy case is
-        handled by the results-layer `already_has` filter, not the calculator.
-        An otherwise-eligible household reporting Section 8 stays eligible here."""
-        calc = make_calculator(members=[make_member(age=35, earned=10_000)])
-        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
-        with patch_hud(il_ami=46_800):
-            e = Eligibility()
-            calc.household_eligible(e)
-            self.assertTrue(e.eligible)
-
     def test_assets_above_100k_ineligible(self):
         calc = make_calculator(members=[make_member(age=35, earned=14_400)], household_assets=150_000)
         with patch_hud(il_ami=46_800):
@@ -410,28 +399,7 @@ class TestTxHcvScenarios(TestCase):
         members = [make_member(age=35, earned=14_400)]
         self._assert_scenario(members, il_ami=35_000, payment_standard=1424, expected_value=12_768, county="Midland")
 
-    def test_scenario_10_already_receiving_section8_harris(self):
-        # tx_hcv *is* the Section 8 program, so the duplicate case is filtered by the
-        # results-layer `already_has` workflow, not the calculator. The calculator
-        # itself still returns eligible (income permitting).
-        members = [make_member(age=40, earned=0)]
-        calc = make_calculator(members=members, county="Harris")
-        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
-        with patch_hud(il_ami=46_800):
-            self.assertTrue(calc.calc().eligible)
-
-    def test_scenario_11_already_receiving_section8_dallas(self):
-        members = [
-            make_member(age=38, earned=21_600),
-            make_member(age=11, relationship="child"),
-            make_member(age=8, relationship="child"),
-        ]
-        calc = make_calculator(members=members, county="Dallas")
-        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
-        with patch_hud(il_ami=60_550):
-            self.assertTrue(calc.calc().eligible)
-
-    def test_scenario_12_mixed_generation_hidalgo(self):
+    def test_scenario_10_mixed_generation_hidalgo(self):
         members = [
             make_member(age=35, earned=16_800),
             make_member(age=68, relationship="parent", unearned=9_000),
@@ -439,7 +407,7 @@ class TestTxHcvScenarios(TestCase):
         ]
         self._assert_scenario(members, il_ami=37_700, payment_standard=1060, expected_value=5_124, county="Hidalgo")
 
-    def test_scenario_13_two_working_adults_two_children_collin(self):
+    def test_scenario_11_two_working_adults_two_children_collin(self):
         members = [
             make_member(age=35, earned=16_800),
             make_member(age=32, relationship="spouse", earned=14_400),
@@ -448,15 +416,15 @@ class TestTxHcvScenarios(TestCase):
         ]
         self._assert_scenario(members, il_ami=60_550, payment_standard=2580, expected_value=21_888, county="Collin")
 
-    def test_scenario_14_zero_income_cameron(self):
+    def test_scenario_12_zero_income_cameron(self):
         members = [make_member(age=30, earned=0)]
         self._assert_scenario(members, il_ami=20_000, payment_standard=773, expected_value=8_976, county="Cameron")
 
-    def test_scenario_15_full_time_student_lubbock(self):
+    def test_scenario_13_full_time_student_lubbock(self):
         members = [make_member(age=22, earned=9_600, student_full_time=True)]
         self._assert_scenario(members, il_ami=29_300, payment_standard=818, expected_value=6_936, county="Lubbock")
 
-    def test_scenario_16_household_of_five_mclennan(self):
+    def test_scenario_14_household_of_five_mclennan(self):
         members = [
             make_member(age=41, earned=24_000),
             make_member(age=38, relationship="spouse"),
@@ -466,11 +434,11 @@ class TestTxHcvScenarios(TestCase):
         ]
         self._assert_scenario(members, il_ami=48_800, payment_standard=1599, expected_value=12_420, county="McLennan")
 
-    def test_scenario_17_between_50_and_80_ami_travis_ineligible(self):
+    def test_scenario_15_between_50_and_80_ami_travis_ineligible(self):
         members = [make_member(age=35, earned=55_000)]
         self._assert_ineligible(members, il_ami=47_050, county="Travis")
 
-    def test_scenario_18_family_of_seven_mclennan_4br(self):
+    def test_scenario_16_family_of_seven_mclennan_4br(self):
         members = [
             make_member(age=41, earned=27_600),
             make_member(age=38, relationship="spouse"),
@@ -482,17 +450,17 @@ class TestTxHcvScenarios(TestCase):
         ]
         self._assert_scenario(members, il_ami=55_000, payment_standard=1644, expected_value=12_168, county="McLennan")
 
-    def test_scenario_19_reported_rent_el_paso(self):
+    def test_scenario_17_reported_rent_el_paso(self):
         members = [make_member(age=35, earned=18_000)]
         self._assert_scenario(
             members, il_ami=29_300, payment_standard=821, expected_value=1_800, county="El Paso", reported_rent=600
         )
 
-    def test_scenario_20_assets_over_limit_harris_ineligible(self):
+    def test_scenario_18_assets_over_limit_harris_ineligible(self):
         members = [make_member(age=35, earned=14_400)]
         self._assert_ineligible(members, il_ami=46_800, household_assets=150_000, county="Harris")
 
-    def test_scenario_21_elderly_head_disabled_adult_dependent_bexar(self):
+    def test_scenario_19_elderly_head_disabled_adult_dependent_bexar(self):
         members = [
             make_member(age=63, earned=16_800),
             make_member(age=19, relationship="child", disabled=True),
@@ -501,21 +469,21 @@ class TestTxHcvScenarios(TestCase):
             members, il_ami=40_250, payment_standard=870, expected_value=5_700, county="Bexar", zipcode="78207"
         )
 
-    def test_scenario_22_foster_child_excluded_from_dependent_deduction_harris(self):
+    def test_scenario_20_foster_child_excluded_from_dependent_deduction_harris(self):
         members = [
             make_member(age=35, earned=14_400),
             make_member(age=10, relationship="fosterChild"),
         ]
         self._assert_scenario(members, il_ami=41_600, payment_standard=1323, expected_value=11_556, county="Harris")
 
-    def test_scenario_23_teen_wages_excluded_el_paso(self):
+    def test_scenario_21_teen_wages_excluded_el_paso(self):
         members = [
             make_member(age=38, earned=12_000),
             make_member(age=16, relationship="child", earned=4_800),
         ]
         self._assert_scenario(members, il_ami=33_500, payment_standard=1013, expected_value=8_700, county="El Paso")
 
-    def test_scenario_24_foster_child_unearned_income_excluded_harris(self):
+    def test_scenario_22_foster_child_unearned_income_excluded_harris(self):
         members = [
             make_member(age=35, earned=14_400),
             make_member(age=10, relationship="fosterChild", unearned=2_400),

--- a/programs/programs/tx/hcv/tests/test_tx_hcv.py
+++ b/programs/programs/tx/hcv/tests/test_tx_hcv.py
@@ -45,7 +45,6 @@ def make_calculator(
     county="Harris",
     zipcode="77002",
     household_assets=0,
-    has_section_8=False,
     reported_rent=0,
 ):
     if members is None:
@@ -60,8 +59,7 @@ def make_calculator(
     screen.household_assets = household_assets
     screen.household_members.all = Mock(return_value=members)
     screen.has_benefit = Mock(return_value=False)
-    # Section 8 is matched via base_program ("section_8" → tx_hcv), not an exact name.
-    screen.has_base_benefit = Mock(side_effect=lambda base: has_section_8 if base == "section_8" else False)
+    screen.has_base_benefit = Mock(return_value=False)
     screen.calc_expenses = Mock(return_value=reported_rent)
     head = next((m for m in members if m.relationship == "headOfHousehold"), members[0] if members else None)
     screen.get_head = Mock(return_value=head)
@@ -250,25 +248,16 @@ class TestTxHcvEligibility(TestCase):
             calc.household_eligible(e)
             self.assertTrue(e.eligible)
 
-    def test_has_section_8_is_ineligible(self):
-        calc = make_calculator(members=[make_member(age=35, earned=10_000)], has_section_8=True)
-        with patch_hud(il_ami=46_800):
-            e = Eligibility()
-            calc.household_eligible(e)
-            self.assertFalse(e.eligible)
-
-    def test_section_8_check_uses_base_benefit_not_exact_name(self):
-        """Section 8 is the HCV program via base_program ("section_8" → tx_hcv);
-        the gate must call has_base_benefit, not the dead has_benefit("section_8")."""
+    def test_already_has_section_8_not_self_excluded_by_calculator(self):
+        """tx_hcv *is* the "section_8" program, so the duplicate-subsidy case is
+        handled by the results-layer `already_has` filter, not the calculator.
+        An otherwise-eligible household reporting Section 8 stays eligible here."""
         calc = make_calculator(members=[make_member(age=35, earned=10_000)])
-        # Exact-name has_benefit is always False; only has_base_benefit("section_8") is True.
-        calc.screen.has_benefit = Mock(return_value=False)
         calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
         with patch_hud(il_ami=46_800):
             e = Eligibility()
             calc.household_eligible(e)
-            self.assertFalse(e.eligible)
-            calc.screen.has_base_benefit.assert_any_call("section_8")
+            self.assertTrue(e.eligible)
 
     def test_assets_above_100k_ineligible(self):
         calc = make_calculator(members=[make_member(age=35, earned=14_400)], household_assets=150_000)
@@ -422,8 +411,14 @@ class TestTxHcvScenarios(TestCase):
         self._assert_scenario(members, il_ami=35_000, payment_standard=1424, expected_value=12_768, county="Midland")
 
     def test_scenario_10_already_receiving_section8_harris(self):
+        # tx_hcv *is* the Section 8 program, so the duplicate case is filtered by the
+        # results-layer `already_has` workflow, not the calculator. The calculator
+        # itself still returns eligible (income permitting).
         members = [make_member(age=40, earned=0)]
-        self._assert_ineligible(members, il_ami=46_800, has_section_8=True, county="Harris")
+        calc = make_calculator(members=members, county="Harris")
+        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
+        with patch_hud(il_ami=46_800):
+            self.assertTrue(calc.calc().eligible)
 
     def test_scenario_11_already_receiving_section8_dallas(self):
         members = [
@@ -431,7 +426,10 @@ class TestTxHcvScenarios(TestCase):
             make_member(age=11, relationship="child"),
             make_member(age=8, relationship="child"),
         ]
-        self._assert_ineligible(members, il_ami=60_550, has_section_8=True, county="Dallas")
+        calc = make_calculator(members=members, county="Dallas")
+        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
+        with patch_hud(il_ami=60_550):
+            self.assertTrue(calc.calc().eligible)
 
     def test_scenario_12_mixed_generation_hidalgo(self):
         members = [

--- a/programs/programs/tx/hcv/tests/test_tx_hcv.py
+++ b/programs/programs/tx/hcv/tests/test_tx_hcv.py
@@ -59,7 +59,9 @@ def make_calculator(
     screen.zipcode = zipcode
     screen.household_assets = household_assets
     screen.household_members.all = Mock(return_value=members)
-    screen.has_benefit = Mock(side_effect=lambda name: has_section_8 if name == "section_8" else False)
+    screen.has_benefit = Mock(return_value=False)
+    # Section 8 is matched via base_program ("section_8" → tx_hcv), not an exact name.
+    screen.has_base_benefit = Mock(side_effect=lambda base: has_section_8 if base == "section_8" else False)
     screen.calc_expenses = Mock(return_value=reported_rent)
     head = next((m for m in members if m.relationship == "headOfHousehold"), members[0] if members else None)
     screen.get_head = Mock(return_value=head)
@@ -254,6 +256,19 @@ class TestTxHcvEligibility(TestCase):
             e = Eligibility()
             calc.household_eligible(e)
             self.assertFalse(e.eligible)
+
+    def test_section_8_check_uses_base_benefit_not_exact_name(self):
+        """Section 8 is the HCV program via base_program ("section_8" → tx_hcv);
+        the gate must call has_base_benefit, not the dead has_benefit("section_8")."""
+        calc = make_calculator(members=[make_member(age=35, earned=10_000)])
+        # Exact-name has_benefit is always False; only has_base_benefit("section_8") is True.
+        calc.screen.has_benefit = Mock(return_value=False)
+        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
+        with patch_hud(il_ami=46_800):
+            e = Eligibility()
+            calc.household_eligible(e)
+            self.assertFalse(e.eligible)
+            calc.screen.has_base_benefit.assert_any_call("section_8")
 
     def test_assets_above_100k_ineligible(self):
         calc = make_calculator(members=[make_member(age=35, earned=14_400)], household_assets=150_000)

--- a/programs/programs/wa/hcv/calculator.py
+++ b/programs/programs/wa/hcv/calculator.py
@@ -72,12 +72,11 @@ class WaHcv(ProgramCalculator):
         return self.program.year.period
 
     def household_eligible(self, e: Eligibility):
-        # "Section 8" is the HCV program itself (base_program "section_8"): wa_hcv,
-        # co_section_8, ma_section_8, etc. Use has_base_benefit so it matches every
-        # white-label variant
-        has_section_8 = self.screen.has_base_benefit("section_8")
-        e.condition(not has_section_8, messages.must_not_have_benefit("Section 8"))
-
+        # No self-exclusion for already receiving Section 8: wa_hcv *is* the
+        # "section_8" program, so "already has Section 8" == "already has wa_hcv".
+        # That duplicate-subsidy case is handled generically by the results-layer
+        # `already_has` filter (screen.has_benefit(program.name_abbreviated)), not
+        # here — calculators only check *other* programs to inform eligibility.
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0
         e.condition(assets <= self.asset_limit, messages.assets(self.asset_limit))
 

--- a/programs/programs/wa/hcv/calculator.py
+++ b/programs/programs/wa/hcv/calculator.py
@@ -72,7 +72,10 @@ class WaHcv(ProgramCalculator):
         return self.program.year.period
 
     def household_eligible(self, e: Eligibility):
-        has_section_8 = self.screen.has_benefit("section_8")
+        # "Section 8" is the HCV program itself (base_program "section_8"): wa_hcv,
+        # co_section_8, ma_section_8, etc. Use has_base_benefit so it matches every
+        # white-label variant
+        has_section_8 = self.screen.has_base_benefit("section_8")
         e.condition(not has_section_8, messages.must_not_have_benefit("Section 8"))
 
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0

--- a/programs/programs/wa/hcv/calculator.py
+++ b/programs/programs/wa/hcv/calculator.py
@@ -1,6 +1,10 @@
+import logging
+
 from integrations.clients.hud_income_limits import hud_client, HudIncomeClientError
 from programs.programs.calc import Eligibility, ProgramCalculator
 import programs.programs.messages as messages
+
+logger = logging.getLogger(__name__)
 
 
 class WaHcv(ProgramCalculator):
@@ -86,6 +90,17 @@ class WaHcv(ProgramCalculator):
                 self.screen.household_size = original_hh
             e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
         except HudIncomeClientError:
+            # Expected when HUD data is unavailable (API down, county/ZIP not found,
+            # year unconfigured) — mark not eligible without noise.
+            e.condition(False, messages.income_limit_unknown())
+        except Exception:
+            # Unexpected failure — still degrade to not eligible rather than raise,
+            # so one program can't 500 the whole eligibility run, and log it.
+            logger.exception(
+                "WaHcv.household_eligible income check failed unexpectedly (white_label=%s, household_size=%s)",
+                getattr(self.screen.white_label, "code", None),
+                self.screen.household_size,
+            )
             e.condition(False, messages.income_limit_unknown())
 
     def household_value(self) -> int:
@@ -101,11 +116,29 @@ class WaHcv(ProgramCalculator):
             ttp = max(0.30 * monthly_adjusted, 0.10 * monthly_gross, self.min_rent_monthly)
 
             bedrooms = self._estimate_bedrooms()
-            fmr = hud_client.get_screen_fmr(self.screen, bedrooms, self._get_year_period())
+            # Payment standard = ZIP-level SAFMR for mandatory-SAFMR metros
+            # (Seattle-Bellevue HMFA), metro/county FMR everywhere else and on
+            # missing-ZIP fallback. Assumed at 100% of FMR (WA PHAs set 90-110%).
+            payment_standard = hud_client.get_screen_payment_standard(self.screen, bedrooms, self._get_year_period())
 
-            hap = max(0, fmr - ttp)
+            # Gross rent = the household's reported rent when available (lower of it
+            # and the payment standard), else the payment standard alone
+            # (24 CFR § 982.505: HAP uses the lower of payment standard / gross rent).
+            reported_rent = self.screen.calc_expenses("monthly", ["rent", "mortgage"])
+            gross_rent = min(payment_standard, reported_rent) if reported_rent > 0 else payment_standard
+
+            hap = max(0, gross_rent - ttp)
             return int(hap * 12)
         except HudIncomeClientError:
+            # Expected when HUD data is unavailable (API down, county/ZIP not found,
+            # year unconfigured) — degrade to $0 without noise.
             return 0
         except Exception:
+            # Unexpected bug in the value calculation — still degrade to $0 so one
+            # program can't 500 the whole eligibility response, but log it.
+            logger.exception(
+                "WaHcv.household_value failed unexpectedly (white_label=%s, household_size=%s)",
+                getattr(self.screen.white_label, "code", None),
+                self.screen.household_size,
+            )
             return 0

--- a/programs/programs/wa/hcv/calculator.py
+++ b/programs/programs/wa/hcv/calculator.py
@@ -72,11 +72,6 @@ class WaHcv(ProgramCalculator):
         return self.program.year.period
 
     def household_eligible(self, e: Eligibility):
-        # No self-exclusion for already receiving Section 8: wa_hcv *is* the
-        # "section_8" program, so "already has Section 8" == "already has wa_hcv".
-        # That duplicate-subsidy case is handled generically by the results-layer
-        # `already_has` filter (screen.has_benefit(program.name_abbreviated)), not
-        # here — calculators only check *other* programs to inform eligibility.
         assets = self.screen.household_assets if self.screen.household_assets is not None else 0
         e.condition(assets <= self.asset_limit, messages.assets(self.asset_limit))
 

--- a/programs/programs/wa/hcv/spec.md
+++ b/programs/programs/wa/hcv/spec.md
@@ -316,13 +316,13 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 - **Location**: ZIP `98201`, county `Snohomish County`
 - **Household size**: 3
 - **Person 1** (head): birth `Aug 1986` (age 39)
-  - Income: Employment / Wages, `$3,542`/month
+  - Income: Employment / Wages, `$4,500`/month
 - **Person 2**: birth `Nov 1988` (age 37), `relationship: spouse`
-  - Income: Employment / Wages, `$1,250`/month
+  - Income: Employment / Wages, `$1,750`/month
 - **Person 3**: birth `Mar 2018` (age 8), `relationship: child`
 - **Current benefits**: none
 
-*(Combined annual income should be ~$50–$200 above the FY2026 3-person VLI for Seattle-Bellevue HMFA — verify against table.)*
+*(Combined annual income $75,000 is just above the FY2026 3-person VLI for the Seattle-Bellevue HMFA — $74,000, verified against the live HUD Section 8 Income Limits on 2026-07-14. Re-verify if the FY changes.)*
 
 **Why this matters**: Confirms the calculator correctly EXCLUDES households just above the VLI threshold. Pairs with Scenario 2 to lock down both sides of the boundary.
 

--- a/programs/programs/wa/hcv/spec.md
+++ b/programs/programs/wa/hcv/spec.md
@@ -54,7 +54,7 @@
    - Applies to both tenant-based (HCV) and project-based Section 8 — duplicate Section 8 subsidies are prohibited.
    - Screener fields:
      - `wa_hcv` current benefit — "Section 8" *is* this program (base_program `section_8`), so "already receiving Section 8" means "already has `wa_hcv`".
-   - **Implementation**: Not a calculator check. The generic results-layer `already_has` workflow filters `wa_hcv` out of results when the household reports it (via `screen.has_benefit("wa_hcv")`). The calculator does not self-exclude — it only checks *other* programs to inform eligibility.
+   - **Implementation**: Not a calculator check. Because `wa_hcv` *is* the Section 8 program, checking "already receiving Section 8" would be a self-check, which calculators don't do.
    - Note: Verified at application via HUD's EIV Existing Tenant Search. There is no single clean CFR/USC citation for the prohibition itself — it is operationalized through the EIV procedural check at admission.
    - Source: HCV Guidebook (Eligibility Determination chapter), § 2.2 and § 11.1 (EIV Existing Tenant Search and Avoiding Duplicate Subsidy)
 
@@ -365,26 +365,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 7: Currently Receiving Section 8 (Criterion 4 — handled by `already_has`)
-
-**What we're checking**: Duplicate-Section-8 exclusion (Criterion 4). `wa_hcv` *is* the Section 8 program, so this is not a calculator check — the generic results-layer `already_has` filter removes `wa_hcv` from results when the household reports it. The calculator itself still returns eligible (income permitting).
-**Expected**: Eligible from the calculator; filtered out of results by `already_has` (not shown to the user).
-
-**Steps**:
-- **Location**: ZIP `98103`, county `King County`
-- **Household size**: 3
-- **Person 1** (head): birth `Mar 1980` (age 46)
-  - Income: Employment / Wages, `$2,000`/month
-- **Person 2**: birth `Jul 1982` (age 43), `relationship: spouse`
-  - Income: Employment / Wages, `$1,200`/month
-- **Person 3**: birth `Sep 2016` (age 9), `relationship: child`
-- **Current benefits**: `wa_hcv` (Housing Choice Voucher / Section 8)
-
-**Why this matters**: The duplicate-subsidy prohibition is one of two fully evaluable criteria. A household that's otherwise income-eligible must still be excluded if they already have a voucher.
-
----
-
-### Scenario 8: Multi-Generational Household with Multiple Income Types, Grant County
+### Scenario 7: Multi-Generational Household with Multiple Income Types, Grant County
 
 **What we're checking**: Multi-member income aggregation (Criterion 1) across multiple income types (Social Security Retirement, VA Pension, SSDI, wages), with elderly and disability indicators on different members.
 **Expected**: Eligible
@@ -409,7 +390,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 9: Three Adult Siblings Sharing Household, Whatcom County
+### Scenario 8: Three Adult Siblings Sharing Household, Whatcom County
 
 **What we're checking**: Family-definition flexibility (Criterion 2) and multi-adult income aggregation (Criterion 1) for a non-traditional household.
 **Expected**: Eligible
@@ -429,7 +410,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 10: Household of 8 at VLI, King County (Large Household Edge Case)
+### Scenario 9: Household of 8 at VLI, King County (Large Household Edge Case)
 
 **What we're checking**: Large-household income-limit lookup (Criterion 1 — 8-person VLI for Seattle-Bellevue HMFA, applying the 1.32× 4-person multiplier).
 **Expected**: Eligible
@@ -456,7 +437,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 11: Otherwise-Eligible Household with Liquid Assets > $100K, Spokane County (Asset Cap Ineligible)
+### Scenario 10: Otherwise-Eligible Household with Liquid Assets > $100K, Spokane County (Asset Cap Ineligible)
 
 **What we're checking**: HOTMA asset cap exclusion (Criterion 5 — `household_assets > $100,000` disqualifies regardless of income).
 **Expected**: Not eligible
@@ -475,7 +456,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 12: Single Pregnant Adult, Pierce County (Pregnant = 2-Person Family Rule)
+### Scenario 11: Single Pregnant Adult, Pierce County (Pregnant = 2-Person Family Rule)
 
 **What we're checking**: Pregnancy + household-size special rule (Criterion 2 — a pregnant person with no other household members is counted as 2 for income-limit purposes per 24 CFR § 982.402(b)(5)).
 **Expected**: Eligible
@@ -492,7 +473,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 13: Single Student Under 24, No Disqualifying Factors (Student Inclusivity)
+### Scenario 12: Single Student Under 24, No Disqualifying Factors (Student Inclusivity)
 
 **What we're checking**: Student-rule inclusivity (Criterion 11 — a single student under 24 with no parent/spouse/child/disability/VA-insurance indicator should still be eligible per the inclusivity assumption).
 **Expected**: Eligible

--- a/programs/programs/wa/hcv/spec.md
+++ b/programs/programs/wa/hcv/spec.md
@@ -53,8 +53,8 @@
 4. **Applicant household must not currently be receiving Section 8 assistance from any PHA.**
    - Applies to both tenant-based (HCV) and project-based Section 8 — duplicate Section 8 subsidies are prohibited.
    - Screener fields:
-     - `section_8` current benefit (checked via `has_benefit("section_8")`)
-   - Note: Verified at application via HUD's EIV Existing Tenant Search. In the screener, this maps directly to the household's current benefits — when `has_benefit("section_8")` is true, the household is currently receiving Section 8 and is excluded from a duplicate voucher. There is no single clean CFR/USC citation for the prohibition itself — it is operationalized through the EIV procedural check at admission.
+     - `wa_hcv` current benefit — "Section 8" is the HCV program itself (base_program `section_8`), checked via `has_base_benefit("section_8")` so it matches every white-label variant (`wa_hcv`, `co_section_8`, …).
+   - Note: Verified at application via HUD's EIV Existing Tenant Search. In the screener, this maps directly to the household's current benefits — when `has_base_benefit("section_8")` is true, the household is currently receiving Section 8 and is excluded from a duplicate voucher. There is no single clean CFR/USC citation for the prohibition itself — it is operationalized through the EIV procedural check at admission.
    - Source: HCV Guidebook (Eligibility Determination chapter), § 2.2 and § 11.1 (EIV Existing Tenant Search and Avoiding Duplicate Subsidy)
 
 5. **Net family assets must not exceed $100,000.** ⚠️ *data gap (partial)*
@@ -366,7 +366,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ### Scenario 7: Currently Receiving Section 8 (Criterion 4 Ineligible)
 
-**What we're checking**: Duplicate-Section-8 exclusion (Criterion 4 — `has_benefit("section_8")` should disqualify regardless of income).
+**What we're checking**: Duplicate-Section-8 exclusion (Criterion 4 — `has_base_benefit("section_8")` should disqualify regardless of income).
 **Expected**: Not eligible
 
 **Steps**:
@@ -377,7 +377,7 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 - **Person 2**: birth `Jul 1982` (age 43), `relationship: spouse`
   - Income: Employment / Wages, `$1,200`/month
 - **Person 3**: birth `Sep 2016` (age 9), `relationship: child`
-- **Current benefits**: `section_8` (Housing Choice Voucher / Section 8)
+- **Current benefits**: `wa_hcv` (Housing Choice Voucher / Section 8)
 
 **Why this matters**: The duplicate-subsidy prohibition is one of two fully evaluable criteria. A household that's otherwise income-eligible must still be excluded if they already have a voucher.
 

--- a/programs/programs/wa/hcv/spec.md
+++ b/programs/programs/wa/hcv/spec.md
@@ -53,8 +53,9 @@
 4. **Applicant household must not currently be receiving Section 8 assistance from any PHA.**
    - Applies to both tenant-based (HCV) and project-based Section 8 — duplicate Section 8 subsidies are prohibited.
    - Screener fields:
-     - `wa_hcv` current benefit — "Section 8" is the HCV program itself (base_program `section_8`), checked via `has_base_benefit("section_8")` so it matches every white-label variant (`wa_hcv`, `co_section_8`, …).
-   - Note: Verified at application via HUD's EIV Existing Tenant Search. In the screener, this maps directly to the household's current benefits — when `has_base_benefit("section_8")` is true, the household is currently receiving Section 8 and is excluded from a duplicate voucher. There is no single clean CFR/USC citation for the prohibition itself — it is operationalized through the EIV procedural check at admission.
+     - `wa_hcv` current benefit — "Section 8" *is* this program (base_program `section_8`), so "already receiving Section 8" means "already has `wa_hcv`".
+   - **Implementation**: Not a calculator check. The generic results-layer `already_has` workflow filters `wa_hcv` out of results when the household reports it (via `screen.has_benefit("wa_hcv")`). The calculator does not self-exclude — it only checks *other* programs to inform eligibility.
+   - Note: Verified at application via HUD's EIV Existing Tenant Search. There is no single clean CFR/USC citation for the prohibition itself — it is operationalized through the EIV procedural check at admission.
    - Source: HCV Guidebook (Eligibility Determination chapter), § 2.2 and § 11.1 (EIV Existing Tenant Search and Avoiding Duplicate Subsidy)
 
 5. **Net family assets must not exceed $100,000.** ⚠️ *data gap (partial)*
@@ -364,10 +365,10 @@ Each scenario in the Test Scenarios section below is an acceptance criterion. Th
 
 ---
 
-### Scenario 7: Currently Receiving Section 8 (Criterion 4 Ineligible)
+### Scenario 7: Currently Receiving Section 8 (Criterion 4 — handled by `already_has`)
 
-**What we're checking**: Duplicate-Section-8 exclusion (Criterion 4 — `has_base_benefit("section_8")` should disqualify regardless of income).
-**Expected**: Not eligible
+**What we're checking**: Duplicate-Section-8 exclusion (Criterion 4). `wa_hcv` *is* the Section 8 program, so this is not a calculator check — the generic results-layer `already_has` filter removes `wa_hcv` from results when the household reports it. The calculator itself still returns eligible (income permitting).
+**Expected**: Eligible from the calculator; filtered out of results by `already_has` (not shown to the user).
 
 **Steps**:
 - **Location**: ZIP `98103`, county `King County`

--- a/programs/programs/wa/hcv/tests/test_wa_hcv.py
+++ b/programs/programs/wa/hcv/tests/test_wa_hcv.py
@@ -42,7 +42,6 @@ def make_calculator(
     county="King County",
     zipcode="98108",
     household_assets=0,
-    has_section_8=False,
     gross_income=21600,
     il_ami_value=50000,
     fmr_value=2000,
@@ -63,8 +62,7 @@ def make_calculator(
     mock_screen.calc_gross_income = Mock(return_value=gross_income)
     mock_screen.calc_expenses = Mock(return_value=reported_rent)
     mock_screen.has_benefit = Mock(return_value=False)
-    # Section 8 is matched via base_program ("section_8" → wa_hcv), not an exact name.
-    mock_screen.has_base_benefit = Mock(side_effect=lambda base: has_section_8 if base == "section_8" else False)
+    mock_screen.has_base_benefit = Mock(return_value=False)
     mock_screen.get_head = Mock(return_value=members[0] if members else None)
 
     mock_program = Mock()
@@ -154,27 +152,17 @@ class TestWaHcvEligibility(TestCase):
             calc.household_eligible(e)
             self.assertTrue(e.eligible)
 
-    def test_has_section_8_is_ineligible(self):
-        head = make_member(age=35)
-        calc = make_calculator(members=[head], has_section_8=True, gross_income=21600)
-        with patch_hud_client(il_ami_value=50000):
-            e = Eligibility()
-            calc.household_eligible(e)
-            self.assertFalse(e.eligible)
-
-    def test_section_8_check_uses_base_benefit_not_exact_name(self):
-        """Section 8 is the HCV program via base_program ("section_8" → wa_hcv);
-        the gate must call has_base_benefit, not the dead has_benefit("section_8")."""
+    def test_already_has_section_8_not_self_excluded_by_calculator(self):
+        """wa_hcv *is* the "section_8" program, so the duplicate-subsidy case is
+        handled by the results-layer `already_has` filter, not the calculator.
+        An otherwise-eligible household reporting Section 8 stays eligible here."""
         head = make_member(age=35)
         calc = make_calculator(members=[head], gross_income=21600)
-        # Exact-name has_benefit is always False; only has_base_benefit("section_8") is True.
-        calc.screen.has_benefit = Mock(return_value=False)
         calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
         with patch_hud_client(il_ami_value=50000):
             e = Eligibility()
             calc.household_eligible(e)
-            self.assertFalse(e.eligible)
-            calc.screen.has_base_benefit.assert_any_call("section_8")
+            self.assertTrue(e.eligible)
 
     def test_assets_above_100k_is_ineligible(self):
         head = make_member(age=35)
@@ -394,11 +382,13 @@ class TestWaHcvCalc(TestCase):
             self.assertEqual(e.value, 23832)
 
     def test_calc_ineligible_returns_zero_value(self):
+        # Income above the 50% AMI limit → ineligible → value 0.
         head = make_member(age=35)
-        calc = make_calculator(members=[head], has_section_8=True, gross_income=21600)
+        calc = make_calculator(members=[head], gross_income=60000)
         with patch_hud_client(il_ami_value=50000, fmr_value=2000):
             e = calc.calc()
             self.assertFalse(e.eligible)
+            self.assertEqual(e.value, 0)
 
     def test_calc_pregnant_single_eligible(self):
         head = make_member(age=31, pregnant=True)

--- a/programs/programs/wa/hcv/tests/test_wa_hcv.py
+++ b/programs/programs/wa/hcv/tests/test_wa_hcv.py
@@ -152,18 +152,6 @@ class TestWaHcvEligibility(TestCase):
             calc.household_eligible(e)
             self.assertTrue(e.eligible)
 
-    def test_already_has_section_8_not_self_excluded_by_calculator(self):
-        """wa_hcv *is* the "section_8" program, so the duplicate-subsidy case is
-        handled by the results-layer `already_has` filter, not the calculator.
-        An otherwise-eligible household reporting Section 8 stays eligible here."""
-        head = make_member(age=35)
-        calc = make_calculator(members=[head], gross_income=21600)
-        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
-        with patch_hud_client(il_ami_value=50000):
-            e = Eligibility()
-            calc.household_eligible(e)
-            self.assertTrue(e.eligible)
-
     def test_assets_above_100k_is_ineligible(self):
         head = make_member(age=35)
         calc = make_calculator(members=[head], household_assets=150000, gross_income=21600)

--- a/programs/programs/wa/hcv/tests/test_wa_hcv.py
+++ b/programs/programs/wa/hcv/tests/test_wa_hcv.py
@@ -46,6 +46,7 @@ def make_calculator(
     gross_income=21600,
     il_ami_value=50000,
     fmr_value=2000,
+    reported_rent=0,
 ):
     if members is None:
         members = [make_member()]
@@ -60,6 +61,7 @@ def make_calculator(
     mock_screen.household_assets = household_assets
     mock_screen.household_members.all = Mock(return_value=members)
     mock_screen.calc_gross_income = Mock(return_value=gross_income)
+    mock_screen.calc_expenses = Mock(return_value=reported_rent)
     mock_screen.has_benefit = Mock(side_effect=lambda name: has_section_8 if name == "section_8" else False)
     mock_screen.get_head = Mock(return_value=members[0] if members else None)
 
@@ -76,7 +78,11 @@ def make_calculator(
 
 
 def patch_hud_client(il_ami_value=50000, fmr_value=2000, il_error=False, fmr_error=False):
-    """Return a context manager that patches both HUD client methods."""
+    """Return a context manager that patches both HUD client methods.
+
+    ``fmr_value`` / ``fmr_error`` feed the payment standard returned by
+    ``get_screen_payment_standard`` (ZIP-level SAFMR or metro FMR).
+    """
     from integrations.clients.hud_income_limits import HudIncomeClientError
 
     def il_side_effect(*args, **kwargs):
@@ -84,7 +90,7 @@ def patch_hud_client(il_ami_value=50000, fmr_value=2000, il_error=False, fmr_err
             raise HudIncomeClientError("test error")
         return il_ami_value
 
-    def fmr_side_effect(*args, **kwargs):
+    def payment_standard_side_effect(*args, **kwargs):
         if fmr_error:
             raise HudIncomeClientError("test error")
         return fmr_value
@@ -92,7 +98,7 @@ def patch_hud_client(il_ami_value=50000, fmr_value=2000, il_error=False, fmr_err
     return patch.multiple(
         "programs.programs.wa.hcv.calculator.hud_client",
         get_screen_il_ami=Mock(side_effect=il_side_effect),
-        get_screen_fmr=Mock(side_effect=fmr_side_effect),
+        get_screen_payment_standard=Mock(side_effect=payment_standard_side_effect),
     )
 
 
@@ -297,6 +303,23 @@ class TestWaHcvBenefitValue(TestCase):
             value = calc.household_value()
             self.assertEqual(value, 12780)
 
+    def test_reported_rent_below_payment_standard_caps_gross_rent(self):
+        """Reported rent below the payment standard caps gross rent (24 CFR § 982.505)."""
+        head = make_member(age=35)
+        calc = make_calculator(members=[head], household_size=1, gross_income=21600, reported_rent=600)
+        # TTP = 540 (as in basic case). gross_rent = min(1605, 600) = 600
+        # HAP = max(0, 600 - 540) = 60 → annual = 720
+        with patch_hud_client(fmr_value=1605):
+            self.assertEqual(calc.household_value(), 720)
+
+    def test_reported_rent_above_payment_standard_uses_payment_standard(self):
+        """Reported rent above the payment standard leaves the payment standard as gross rent."""
+        head = make_member(age=35)
+        calc = make_calculator(members=[head], household_size=1, gross_income=21600, reported_rent=3000)
+        # gross_rent = min(1605, 3000) = 1605 → same as no-rent basic case (12780)
+        with patch_hud_client(fmr_value=1605):
+            self.assertEqual(calc.household_value(), 12780)
+
     def test_hap_with_dependents(self):
         """Single mother + 2 children, $1,800/mo, 2 dependents."""
         head = make_member(age=35)
@@ -390,13 +413,26 @@ class TestWaHcvCalc(TestCase):
         with patch_hud_client(fmr_value=2000):
             self.assertEqual(calc.household_value(), 0)
 
-    def test_household_value_unexpected_fmr_error_returns_zero(self):
-        """Non-HudIncomeClientError from get_screen_fmr must not propagate as a 500."""
+    def test_household_value_unexpected_error_returns_zero(self):
+        """Non-HudIncomeClientError from get_screen_payment_standard must not propagate as a 500."""
         head = make_member(age=35)
         calc = make_calculator(members=[head], household_size=1, gross_income=21600)
         with patch.multiple(
             "programs.programs.wa.hcv.calculator.hud_client",
             get_screen_il_ami=Mock(return_value=50000),
-            get_screen_fmr=Mock(side_effect=KeyError("unexpected")),
+            get_screen_payment_standard=Mock(side_effect=KeyError("unexpected")),
         ):
             self.assertEqual(calc.household_value(), 0)
+
+    def test_household_eligible_unexpected_error_makes_ineligible(self):
+        """Non-HudIncomeClientError from get_screen_il_ami must degrade to not eligible, not 500."""
+        head = make_member(age=35)
+        calc = make_calculator(members=[head], gross_income=21600)
+        with patch.multiple(
+            "programs.programs.wa.hcv.calculator.hud_client",
+            get_screen_il_ami=Mock(side_effect=KeyError("unexpected")),
+            get_screen_payment_standard=Mock(return_value=2000),
+        ):
+            e = Eligibility()
+            calc.household_eligible(e)
+            self.assertFalse(e.eligible)

--- a/programs/programs/wa/hcv/tests/test_wa_hcv.py
+++ b/programs/programs/wa/hcv/tests/test_wa_hcv.py
@@ -62,7 +62,9 @@ def make_calculator(
     mock_screen.household_members.all = Mock(return_value=members)
     mock_screen.calc_gross_income = Mock(return_value=gross_income)
     mock_screen.calc_expenses = Mock(return_value=reported_rent)
-    mock_screen.has_benefit = Mock(side_effect=lambda name: has_section_8 if name == "section_8" else False)
+    mock_screen.has_benefit = Mock(return_value=False)
+    # Section 8 is matched via base_program ("section_8" → wa_hcv), not an exact name.
+    mock_screen.has_base_benefit = Mock(side_effect=lambda base: has_section_8 if base == "section_8" else False)
     mock_screen.get_head = Mock(return_value=members[0] if members else None)
 
     mock_program = Mock()
@@ -159,6 +161,20 @@ class TestWaHcvEligibility(TestCase):
             e = Eligibility()
             calc.household_eligible(e)
             self.assertFalse(e.eligible)
+
+    def test_section_8_check_uses_base_benefit_not_exact_name(self):
+        """Section 8 is the HCV program via base_program ("section_8" → wa_hcv);
+        the gate must call has_base_benefit, not the dead has_benefit("section_8")."""
+        head = make_member(age=35)
+        calc = make_calculator(members=[head], gross_income=21600)
+        # Exact-name has_benefit is always False; only has_base_benefit("section_8") is True.
+        calc.screen.has_benefit = Mock(return_value=False)
+        calc.screen.has_base_benefit = Mock(side_effect=lambda base: base == "section_8")
+        with patch_hud_client(il_ami_value=50000):
+            e = Eligibility()
+            calc.household_eligible(e)
+            self.assertFalse(e.eligible)
+            calc.screen.has_base_benefit.assert_any_call("section_8")
 
     def test_assets_above_100k_is_ineligible(self):
         head = make_member(age=35)

--- a/programs/programs/wa/wap/calculator.py
+++ b/programs/programs/wa/wap/calculator.py
@@ -31,14 +31,13 @@ class WaWap(ProgramCalculator):
     ]
 
     def household_eligible(self, e: Eligibility):
-        # If currently receiving weatherization, uesr is ineligible
-        if self.screen.has_benefit("wa_wap"):
-            e.condition(False, messages.must_not_have_benefit("wa_wap"))
-
         has_wa_wap_eligible_benefit = (
             self.screen.has_benefit("wa_snap")
             or self.screen.has_benefit("wa_tanf")
             or self.screen.has_benefit("wa_ssi")
+            # Section 8 is the HCV program (base_program "section_8", e.g. wa_hcv);
+            # has_base_benefit matches every white-label variant, whereas the bare
+            # has_benefit("section_8") is a dead check — that name_abbreviated exists nowhere.
             or self.screen.has_base_benefit("section_8")
         )
 

--- a/programs/programs/wa/wap/calculator.py
+++ b/programs/programs/wa/wap/calculator.py
@@ -39,8 +39,6 @@ class WaWap(ProgramCalculator):
             self.screen.has_benefit("wa_snap")
             or self.screen.has_benefit("wa_tanf")
             or self.screen.has_benefit("wa_ssi")
-            # Section 8 is the HCV program (base_program "section_8", e.g. wa_hcv);
-            # has_base_benefit matches every white-label variant.
             or self.screen.has_base_benefit("section_8")
         )
 

--- a/programs/programs/wa/wap/calculator.py
+++ b/programs/programs/wa/wap/calculator.py
@@ -39,9 +39,8 @@ class WaWap(ProgramCalculator):
             self.screen.has_benefit("wa_snap")
             or self.screen.has_benefit("wa_tanf")
             or self.screen.has_benefit("wa_ssi")
-            # Section 8 = the HCV program (base_program "section_8", e.g. wa_hcv).
-            # has_base_benefit matches every variant; has_benefit("section_8") is a
-            # dead check because the bare name_abbreviated "section_8" exists nowhere.
+            # Section 8 is the HCV program (base_program "section_8", e.g. wa_hcv);
+            # has_base_benefit matches every white-label variant.
             or self.screen.has_base_benefit("section_8")
         )
 

--- a/programs/programs/wa/wap/calculator.py
+++ b/programs/programs/wa/wap/calculator.py
@@ -39,7 +39,10 @@ class WaWap(ProgramCalculator):
             self.screen.has_benefit("wa_snap")
             or self.screen.has_benefit("wa_tanf")
             or self.screen.has_benefit("wa_ssi")
-            or self.screen.has_benefit("wa_hcv")
+            # Section 8 = the HCV program (base_program "section_8", e.g. wa_hcv).
+            # has_base_benefit matches every variant; has_benefit("section_8") is a
+            # dead check because the bare name_abbreviated "section_8" exists nowhere.
+            or self.screen.has_base_benefit("section_8")
         )
 
         categorically_eligible = has_wa_wap_eligible_benefit or any(

--- a/programs/programs/wa/wap/spec.md
+++ b/programs/programs/wa/wap/spec.md
@@ -145,12 +145,11 @@ The highest-impact criteria (income at or below 200% FPL, federal categorical el
 [ ] Scenario 5 (Person Exactly Age 60 - Meets Elderly Priority Threshold): User should be **eligible**, value: $7,669
 [ ] Scenario 6 (Person Age 59 - Just Below Elderly Priority Threshold): User should be **ineligible**
 [ ] Scenario 7 (Washington State Resident in Spokane County - Eligible Location): User should be **eligible**, value: $7,669
-[ ] Scenario 8 (Household Already Receiving Weatherization Assistance - Exclusion): User should be **ineligible**
-[ ] Scenario 9 (Mixed Household - High-Earning Adult with Elderly Disabled Parent and Young Child): User should be **eligible**, value: $7,669
-[ ] Scenario 10 (Five-Member Multi-Generational Household with TANF/SSI and Disabled Members): User should be **eligible**, value: $7,669
-[ ] Scenario 11 (Zero Income Household with No Current Benefits - Eligible by Income Only): User should be **eligible**, value: $7,669
-[ ] Scenario 12 (Apple Health (Medicaid) Recipient Above 200% FPL - State Categorical Eligibility): User should be **eligible**, value: $7,669
-[ ] Scenario 13 (High Energy Burden Priority - Household with Disproportionate Utility Costs): User should be **eligible**, value: $7,669
+[ ] Scenario 8 (Mixed Household - High-Earning Adult with Elderly Disabled Parent and Young Child): User should be **eligible**, value: $7,669
+[ ] Scenario 9 (Five-Member Multi-Generational Household with TANF/SSI and Disabled Members): User should be **eligible**, value: $7,669
+[ ] Scenario 10 (Zero Income Household with No Current Benefits - Eligible by Income Only): User should be **eligible**, value: $7,669
+[ ] Scenario 11 (Apple Health (Medicaid) Recipient Above 200% FPL - State Categorical Eligibility): User should be **eligible**, value: $7,669
+[ ] Scenario 12 (High Energy Burden Priority - Household with Disproportionate Utility Costs): User should be **eligible**, value: $7,669
 
 ## Test Scenarios
 
@@ -262,23 +261,7 @@ The highest-impact criteria (income at or below 200% FPL, federal categorical el
 
 ---
 
-### Scenario 8: Household Already Receiving Weatherization Assistance - Exclusion
-**What we're checking**: Whether a household that already receives the Weatherization Assistance Program benefit is flagged as ineligible or shown a different message, since the program typically weatherizes a home only once
-**Expected**: Not eligible
-
-**Steps**:
-- **Location**: Enter ZIP code `98103`, Select county `King County`
-- **Household**: Number of people: `2`
-- **Person 1**: Birth month/year: `March 1980` (age 46), Relationship: Head of Household, Has income: Yes, Employment income: `$1,500` per month, Citizenship: US Citizen
-- **Person 2**: Birth month/year: `July 1982` (age 43), Relationship: Spouse, Has income: Yes, Employment income: `$1,200` per month
-- **Current Benefits**: Select that the household currently receives **Weatherization Assistance Program** (WAP) benefits, If the screener lists WAP or similar energy assistance weatherization benefit, check/select it
-- **Housing**: Select homeowner
-
-**Why this matters**: The Weatherization Assistance Program is typically a one-time service per dwelling. A household that has already received weatherization should not be directed to apply again. This tests that the screener correctly handles the exclusion case where the applicant already has the benefit, preventing duplicate referrals and ensuring accurate program recommendations.
-
----
-
-### Scenario 9: Mixed Household - High-Earning Adult with Elderly Disabled Parent and Young Child
+### Scenario 8: Mixed Household - High-Earning Adult with Elderly Disabled Parent and Young Child
 **What we're checking**: Validates that household-level income eligibility is assessed collectively (total household income vs. household size FPL), even when individual members have varying characteristics - one high-earning adult, one elderly disabled member on SSI, and one child
 **Expected**: Eligible, value: $7,669
 
@@ -295,7 +278,7 @@ The highest-impact criteria (income at or below 200% FPL, federal categorical el
 
 ---
 
-### Scenario 10: Five-Member Multi-Generational Household with TANF/SSI and Disabled Members
+### Scenario 9: Five-Member Multi-Generational Household with TANF/SSI and Disabled Members
 **What we're checking**: Validates that a multi-member household where multiple members independently trigger eligibility criteria (categorical eligibility via TANF/SSI, disability priority, child priority, elderly priority) is correctly identified as eligible with all priority flags
 **Expected**: Eligible, value: $7,669
 
@@ -314,7 +297,7 @@ The highest-impact criteria (income at or below 200% FPL, federal categorical el
 
 ---
 
-### Scenario 11: Zero Income Household with No Current Benefits - Eligible by Income Only
+### Scenario 10: Zero Income Household with No Current Benefits - Eligible by Income Only
 **What we're checking**: Tests whether a household reporting exactly $0 income (an edge case boundary) qualifies based on income alone without any categorical eligibility from benefits, and verifies the system handles zero income correctly
 **Expected**: Eligible, value: $7,669
 
@@ -327,7 +310,7 @@ The highest-impact criteria (income at or below 200% FPL, federal categorical el
 
 ---
 
-### Scenario 12: Apple Health (Medicaid) Recipient Above 200% FPL - State Categorical Eligibility
+### Scenario 11: Apple Health (Medicaid) Recipient Above 200% FPL - State Categorical Eligibility
 **What we're checking**: Validates that a household enrolled in Apple Health (Medicaid) qualifies via WA state-level categorical eligibility expansion (Criterion 3) even when income exceeds 200% FPL and no federal categorical benefit (TANF/SSI/SNAP) applies
 **Expected**: Eligible, value: $7,669
 
@@ -342,7 +325,7 @@ The highest-impact criteria (income at or below 200% FPL, federal categorical el
 
 ---
 
-### Scenario 13: High Energy Burden Priority - Household with Disproportionate Utility Costs
+### Scenario 12: High Energy Burden Priority - Household with Disproportionate Utility Costs
 **What we're checking**: Validates that a household with income at or below 200% FPL AND high energy costs relative to income triggers the high energy burden priority flag (Priority Criterion 4)
 **Expected**: Eligible, value: $7,669
 

--- a/programs/programs/wa/wap/spec.md
+++ b/programs/programs/wa/wap/spec.md
@@ -26,7 +26,7 @@
 
 3. **Categorical eligibility (WA state-level expansion): Households receiving Section 8 / HUD housing assistance or Medicaid (Apple Health) are also categorically income-eligible**
    - Screener fields:
-     - `has_benefit("section_8")`
+     - `has_base_benefit("section_8")` — "Section 8" is the HCV program (base_program `section_8`, e.g. `wa_hcv`); `has_base_benefit` matches every variant, whereas the bare `has_benefit("section_8")` matches nothing.
      - `has_benefit("medicaid")`
    - Source: OIC of Washington Weatherization page; local WA agency pages referencing Section 8 and Medicaid/Apple Health as qualifying benefits
    - Note: This is a state/local extension of federal WAP categorical eligibility. While the federal statute (42 U.S.C. § 6862(7)) lists only TANF/SSI/SNAP, multiple Washington sub-grantees (OIC of Washington and others) accept Section 8 and Medicaid as automatically qualifying. Implementing both gives broader screener accuracy for WA applicants but may overstate eligibility at agencies that don't accept these pathways; document this in the program description so applicants verify with their local agency.

--- a/programs/programs/wa/wap/tests/test_wa_wap.py
+++ b/programs/programs/wa/wap/tests/test_wa_wap.py
@@ -27,7 +27,7 @@ def make_calculator(
     has_wa_snap=False,
     has_wa_tanf=False,
     has_wa_ssi=False,
-    has_wa_hcv=False,
+    has_section_8=False,
     members=None,
 ):
     mock_screen = Mock()
@@ -39,10 +39,11 @@ def make_calculator(
             "wa_snap": has_wa_snap,
             "wa_tanf": has_wa_tanf,
             "wa_ssi": has_wa_ssi,
-            "wa_hcv": has_wa_hcv,
         }.get(name, False)
 
     mock_screen.has_benefit = Mock(side_effect=benefit_side_effect)
+    # Section 8 is matched via base_program ("section_8" → wa_hcv), not an exact name.
+    mock_screen.has_base_benefit = Mock(side_effect=lambda base: has_section_8 if base == "section_8" else False)
 
     mock_program = Mock()
     mock_program.year.get_limit = Mock(return_value=fpl_limit)
@@ -106,8 +107,21 @@ class TestWaWapHouseholdEligibility(TestCase):
     def test_ssi_bypasses_income(self):
         self.assertTrue(self._run(50_000, has_wa_ssi=True))
 
-    def test_hcv_bypasses_income(self):
-        self.assertTrue(self._run(50_000, has_wa_hcv=True))
+    def test_section_8_bypasses_income(self):
+        # Section 8 receipt (HCV, via base_program "section_8") is a categorical pathway.
+        self.assertTrue(self._run(50_000, has_section_8=True))
+
+    def test_section_8_check_uses_base_benefit_not_exact_name(self):
+        """Section 8 categorical eligibility must match via has_base_benefit("section_8"),
+        not a dead exact-name has_benefit("section_8")/("wa_hcv") lookup."""
+        calc = make_calculator(yearly_income=50_000, has_section_8=True)
+        e = Eligibility()
+        me = MemberEligibility(make_member())
+        me.eligible = True
+        e.add_member_eligibility(me)
+        calc.household_eligible(e)
+        self.assertTrue(e.eligible)
+        calc.screen.has_base_benefit.assert_any_call("section_8")
 
     def test_no_categorical_no_income_ineligible(self):
         self.assertFalse(self._run(40_000))


### PR DESCRIPTION
## Context & Motivation

- Linear ticket: [MFB-1307 — Improve benefit value for WA HCV program](https://linear.app/myfriendben/issue/MFB-1307/improve-benefit-value-for-wa-hcv-program)
- Related PR: [#1625 — MFB-1121: TX Section 8 Housing](https://github.com/MyFriendBen/benefits-api/pull/1625)

The WA HCV calculator (`programs/programs/wa/hcv/calculator.py`) shipped **before** the HUD client gained ZIP-level Small Area FMR (SAFMR) support, so its `household_value()` still calls `hud_client.get_screen_fmr()`, which always returns the **metro-wide** Fair Market Rent. Seattle-Bellevue is a HUD **mandatory-SAFMR metro** — the correct HCV payment standard there is the ZIP-level SAFMR, not the metro FMR. Since most WA HCV applicants (and most of the program's test scenarios) fall in King/Snohomish County ZIPs inside the Seattle-Bellevue HMFA, the current metro-only lookup materially misestimates the subsidy for them.

PR #1625 already added `hud_client.get_screen_payment_standard()` and seeded `Seattle-Bellevue, WA HUD Metro FMR Area` into `MANDATORY_SAFMR_AREA_NAMES` **specifically so WA HCV could reuse it**. This PR makes WA HCV consume that capability, back-ports two refinements from the newer TX HCV calculator, and — discovered during QA — corrects how the WA/TX HCV and WA WAP calculators handle "already receiving Section 8."

## Changes Made

### Benefit value (WA HCV)
- **Payment standard now honors mandatory SAFMR** (`programs/programs/wa/hcv/calculator.py`): `household_value()` calls `hud_client.get_screen_payment_standard(...)` instead of `get_screen_fmr(...)`. Returns ZIP-level SAFMR for Seattle-Bellevue HMFA households; falls back to metro/county FMR elsewhere and when a ZIP is missing from HUD's SAFMR table. `zipcode` is already in `dependencies`.
- **Gross rent capped at reported rent** (24 CFR § 982.505 "lower of Payment Standard or Gross Rent"): `gross_rent = min(payment_standard, reported_rent)` when reported, else the payment standard alone.
- **Resilience back-port from `TxHcv`:** both `household_eligible` and `household_value` catch unexpected (non-`HudIncomeClientError`) exceptions, `logger.exception(...)` them with context, and degrade to *not eligible* / *$0* — an unexpected error can no longer 500 the eligibility run.

### Section 8 duplicate-subsidy handling (WA/TX)

Background: the old `has_benefit("section_8")` check **never matched** — "Section 8" is stored per white label with `base_program = "section_8"` (`wa_hcv`, `tx_hcv`, `co_section_8`, `ma_section_8`, …), so the bare `name_abbreviated` `"section_8"` exists nowhere and the check was silently always-False.

We're adopting the workflow rule that **a calculator must not check whether the household already has its own program** — that duplicate case is handled generically by the results-layer `already_has` filter (`screen.has_benefit(program.name_abbreviated)` in `screener/views.py`), which removes a program from results when the household reports it. Calculators only check *other* programs to inform eligibility.

- **`wa_hcv` and `tx_hcv`:** these programs **are** the `section_8` program in their white labels, so an "already receiving Section 8" gate is a self-check. **Removed it entirely** — the duplicate-voucher case is now handled by the generic `already_has` results-layer filter, not the calculator. (An otherwise-eligible household that reports Section 8 now computes as *eligible* in the calculator and is filtered from results by `already_has`.)
- **`wa_wap`:** here Section 8 is a *different* program that informs weatherization eligibility (a categorical-eligibility bypass), so the check stays. Changed the concrete `has_benefit("wa_hcv")` → `has_base_benefit("section_8")` so it matches every white-label variant.

### Tests & specs
- `programs/programs/wa/hcv/tests/test_wa_hcv.py`: `patch_hud_client` now patches `get_screen_payment_standard`; `make_calculator` gained `reported_rent` and dropped `has_section_8`; added reported-rent-cap and unexpected-exception tests; replaced the Section 8 exclusion test with one asserting the calculator does **not** self-exclude (duplicate case left to `already_has`).
- `programs/programs/tx/hcv/tests/test_tx_hcv.py`: dropped `has_section_8`; the former "Section 8 → ineligible" tests (incl. scenarios 10/11) now assert the calculator returns **eligible**, with the duplicate case delegated to `already_has`.
- `programs/programs/wa/wap/tests/test_wa_wap.py`: rewired Section 8 mock to `has_base_benefit("section_8")` + regression test for the categorical pathway.
- `programs/programs/wa/hcv/spec.md`: Criterion 4 and Scenario 7 now describe the duplicate case as handled by the `already_has` results-layer filter (not a calculator check); **corrected Scenario 4** income to $75,000/yr (its "just above" income of $57,504 was below the live FY2026 3-person Seattle-Bellevue VLI of $74,000, so it wrongly passed as Eligible — spec-accuracy fix, no calculator change).
- `programs/programs/tx/hcv/spec.md`: Criterion 2 and Scenarios 10/11 updated the same way (duplicate case → `already_has`, not a calculator self-check).
- `programs/programs/wa/wap/spec.md`: Section 8 categorical reference updated to `has_base_benefit("section_8")`.

## Testing

- Migrations / config / env vars: none (`HUD_API_TOKEN` already required)
- `pytest programs/programs/wa/hcv/ programs/programs/tx/hcv/ programs/programs/wa/wap/` → 140 passed
- **API QA (local, all 13 WA HCV spec scenarios): 13/13 pass** after the Scenario 4 spec correction. Pregnancy 2-person rule and SAFMR-based values verified; the Section 8 scenario is now verified as "calculator eligible, filtered by `already_has`."
- **Manual per-white-label check — go through each impacted white label's screener (WA and TX) and confirm behavior when the Section 8 / HCV benefit is selected on the "benefits you already have" step:**
  - **WA → `wa_hcv`:** select Housing Choice Voucher → `wa_hcv` is filtered from results by `already_has`; with it unselected, an otherwise-eligible household qualifies.
  - **WA → `wa_wap`:** select Housing Choice Voucher → `wa_wap` becomes categorically eligible even above 200% FPL (Section 8 → WA categorical pathway).
  - **TX → `tx_hcv`:** select Housing Choice Voucher → `tx_hcv` is filtered from results by `already_has`. (Depends on the config change in Deployment — the option must be selectable first.)
  - For each, confirm the inverse too: with the benefit **not** selected, the program is shown / the categorical branch does not fire.

## Deployment

- No migrations or code-side config. Notify team: WA HCV estimated values will shift (toward more accurate, ZIP-specific amounts) for Seattle-Bellevue households; the WA WAP Section 8 categorical pathway now actually takes effect.
- **Admin config to verify — every Section 8 / HCV program must be selectable on the "has current benefits" step (`show_in_has_benefits_step = True`), or the household can't report Section 8 and neither the `already_has` filter (WA/TX HCV) nor the `wa_wap` categorical pathway can receive real user input:**
  - **WA `wa_hcv`** — currently `True` ✅ (no change needed) — backs the `already_has` filter.
  - **WA `wa_wap`** — currently `True` ✅ (backs its own "already weatherized" self-exclusion input).
  - **TX `tx_hcv`** — currently **`False` ⚠️ must be flipped to `True`** (Django admin → Programs → `tx_hcv` → "Show in has benefits step"); otherwise TX users can't declare Section 8 receipt and `already_has` can never filter out a duplicate `tx_hcv`.
  - Confirm the same flag for any other white label whose HCV / Section 8 program should be filterable via `already_has`.

## Acceptance Criteria

1. **SAFMR routing** — Seattle-Bellevue HMFA households use the ZIP-level SAFMR payment standard, not metro FMR.
2. **Non-SAFMR fallback** — WA counties outside mandatory-SAFMR metros (e.g. Walla Walla) use metro/county FMR; value unchanged.
3. **Missing-ZIP fallback** — a ZIP absent from HUD's SAFMR table falls back to metro FMR, no error.
4. **Gross-rent cap** — reported rent below the payment standard caps HAP; no reported rent → payment standard.
5. **HAP floor & annualization unchanged** — floored at $0, returned as `HAP × 12`; TTP logic unchanged.
6. **Eligibility resilience** — unexpected exception in `household_eligible` → *not eligible* + `income_limit_unknown()`, logged, never 500s.
7. **Value resilience** — unexpected exception in `household_value` → `$0`, logged; `HudIncomeClientError` still → `$0` quietly.
8. **No HCV self-check** — `wa_hcv`/`tx_hcv` do not gate on already having Section 8; the duplicate case is handled by the `already_has` results-layer filter. `wa_wap`'s Section 8 categorical pathway fires via `has_base_benefit("section_8")`.
9. **Tests pass** — the three suites pass (140), incl. new SAFMR, cap, resilience, and no-self-check tests.

## Notes for Reviewers

- **Workflow rule:** calculators no longer self-check "does the household already have this program?" — that's the generic `already_has` results-layer filter's job. `wa_hcv`/`tx_hcv` are themselves the `section_8` program, so their old duplicate-subsidy gate was a self-check and was removed. `wa_wap` keeps its check because there Section 8 is a *different* program informing eligibility.
- **Scope:** the Section 8 change (wa_hcv/tx_hcv/wa_wap) is broader than "benefit value," but it was found while QA'ing this program and touches the same `wa_hcv` calculator. Folded in at the maintainer's request.
- **Follow-up (separate ticket):** `wa_lifeline` (`WaLifeline`, pure PolicyEngine) implements **none** of the screener-level categorical overrides its spec prescribes — Section 8, TANF (non-tribal), and WIC. That's a missing-feature gap, not a wrong-check, and is intentionally out of scope here.
- Known limitations: payment standard still assumed at 100% of FMR/SAFMR; medical/childcare deductions and utility allowances remain out of scope per the WA HCV spec.
- WA `BEDROOM_MAP` (1-person → 1BR) and `$50` min rent intentionally differ from TX and are left as-is; TX income-exclusion parity (24 CFR § 5.609(b)) remains a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HCV benefit value calculations now use payment standards with reported rent capped to the payment standard (then compute HAP from the capped amount).

- **Bug Fixes**
  - Eligibility/value behavior is more resilient to HUD lookup failures, avoiding unexpected errors and returning safe “not eligible” or zero-value outcomes.
  - Section 8/HCV recognition is consistent across program variants, and duplicate-benefit filtering aligns with the results-layer handling.

- **Documentation**
  - Updated HCV and WAP eligibility criteria and scenario numbering to match the revised duplicate-benefit and rent-payment-standard rules.

- **Tests**
  - Adjusted calculators and acceptance scenarios for the updated inputs and error-handling expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->