### PR TITLE
Add KS Lifeline Phone and Internet Discount (ks) + wire phone_cost for Lifeline

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -1,0 +1,81 @@
+{
+  "white_label": {
+    "code": "ks"
+  },
+  "program_category": {
+    "external_name": "ks_housing",
+    "name": "Housing and Utilities",
+    "icon": "housing"
+  },
+  "program": {
+    "name_abbreviated": "ks_lifeline_phone_and_internet_discount",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission",
+      "non_citizen"
+    ],
+    "name": "Kansas Lifeline Phone and Internet Discount",
+    "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. Kansas adds an extra discount for phone service on top of the federal amount. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs.\n\nTo get this benefit, you must choose an approved company in Kansas and sign up for service. The company will then apply the discount directly to your bill every month. You must be at least 18 years old to apply.\n\nOnly one Lifeline benefit is allowed per household. A household is a group of people who live together and share money. This might be different from how other programs count your household. You can also qualify through Tribal assistance programs.\n\nYou can apply online at the Lifeline Support website by clicking \"Apply Now\", or by contacting an approved phone company in Kansas. You will need to show a photo ID and proof of income. Once you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
+    "description_short": "Discount on monthly phone or internet service",
+    "learn_more_link": "https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program",
+    "apply_button_link": "https://www.lifelinesupport.org/",
+    "apply_button_description": "Apply Now",
+    "estimated_application_time": "10 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "website_description": "Discount on monthly phone or internet service",
+    "base_program": "lifeline",
+    "value_format": null,
+    "value_type": "benefit",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "documents": [
+    {
+      "external_name": "ks_id_proof",
+      "text": "Proof of identity (ex: driver's license, state ID, passport)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_home",
+      "text": "Proof of home address (ex: lease, utility bill, mortgage statement)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_earned_income",
+      "text": "Proof of income (ex: pay stubs, tax return, benefits letter)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "ks_qualifying_program_proof",
+      "text": "Proof of participation in a qualifying program such as SNAP, Medicaid, SSI, or Federal Public Housing Assistance (ex: award letter, benefits statement)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "lifeline_support_center",
+      "name": "Universal Service Administrative Co - Lifeline Support Center",
+      "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
+      "phone_number": "+18002349473",
+      "email": "LifelineSupport@usac.org",
+      "assistance_link": "https://www.lifelinesupport.org/get-help/"
+    },
+    {
+      "external_name": "ks_kcc_consumer_protection",
+      "name": "Kansas Corporation Commission - Office of Public Affairs and Consumer Protection",
+      "description": "State agency that administers the Kansas Lifeline supplement and can answer questions about applying for or using the Kansas Lifeline Program.",
+      "phone_number": "+18006620027",
+      "assistance_link": "https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program"
+    }
+  ]
+}

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -8,7 +8,7 @@
     "icon": "housing"
   },
   "program": {
-    "name_abbreviated": "ks_lifeline_phone_and_internet_discount",
+    "name_abbreviated": "ks_lifeline",
     "year": "2026",
     "legal_status_required": [
       "citizen",

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -75,6 +75,7 @@
       "name": "Kansas Corporation Commission - Office of Public Affairs and Consumer Protection",
       "description": "State agency that administers the Kansas Lifeline supplement and can answer questions about applying for or using the Kansas Lifeline Program.",
       "phone_number": "+18006620027",
+      "email": "kcc.public.affairs@ks.gov",
       "assistance_link": "https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program"
     }
   ]

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -84,6 +84,11 @@ class Lifeline(PolicyEngineSpmCalulator):
     pe_name = "lifeline"
     pe_inputs = [
         dependency.spm.BroadbandCostDependency,
+        # phone_cost gates PE's state Lifeline supplements (e.g. KS: the supplement is
+        # released only up to phone_cost). Sent for all states that inherit Lifeline so
+        # a phone-service supplement is never silently zeroed out; states without such a
+        # supplement (TX, WA) are unaffected since their value doesn't depend on it.
+        dependency.spm.PhoneCostDependency,
         *dependency.irs_gross_income,
     ]
     pe_outputs = [dependency.spm.Lifeline]

--- a/programs/programs/ks/lifeline/spec.md
+++ b/programs/programs/ks/lifeline/spec.md
@@ -1,0 +1,88 @@
+# Implement Lifeline Phone and Internet Discount (KS) Program — Light Spec
+
+**Tier**: Fed (value varies) · **Engine**: PE · **State**: KS · **White Label**: ks
+**Research Date**: 2026-06-30 · **Revised to light spec**: 2026-07-12 · **PE-verified**: 2026-07-12
+
+---
+
+## Program Details
+
+- **Program**: Lifeline Phone and Internet Discount
+- **PE variable**: `lifeline` (federal, KS state branch)
+- **Config category**: `ks_housing`
+
+## Value Delta (what actually varies for KS)
+
+- **Federal baseline**: $9.25/month, per 47 CFR § 54.403(a)(1): *"Federal Lifeline support in the amount of $9.25 per month will be made available to an eligible telecommunications carrier providing Lifeline service to a qualifying low-income consumer."* PE's `gov.fcc.lifeline.amount.standard` parameter = 9.25, matches.
+- **KS-specific Δ**: Kansas Lifeline state supplement of **$7.77/month**, and it applies to **phone service only** — this is not a PE quirk, it's the actual program rule. Verbatim, from the Kansas Citizens' Utility Ratepayer Board (CURB) Lifeline/ACP fact sheet (Kansas state source, current as of the 2025-09-08 KCC news release which reconfirms the same $7.77/$17.02 figures):
+  > *"The Kansas portion of the discount may only be applied to phone service. The federal discount may be used for internet or phone service. Total federal and state discounts of up to $17.02 per month are available."*
+  — Source: https://curb.kansas.gov/documents/Lifeline_Program_Affordable_Connectivity_Program_2024_02262025.pdf ; confirmed current at https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program and https://www.kcc.ks.gov/news-9-8-25
+  - PE's KS branch matches this exactly: `ks_lifeline_supplement` ($7.77/month, `policyengine_us/parameters/gov/states/ks/kcc/lifeline/supplement.yaml`) is only released in `lifeline.py` up to the household's `phone_cost` (`min_(phone_cost, ks_supplement * MONTHS_IN_YEAR)`) — `broadband_cost` does not count toward it. **PE's implementation is correct, not a bug.**
+- **Confirmed value matrix MFB should display** (live PE API results, KS, SNAP-eligible single adult, `broadband_cost=500`):
+
+  | Household reports a phone/telephone cost? | PE `lifeline` result | MFB display |
+  |---|---|---|
+  | Yes (any nonzero `phone_cost`) | **$17.02/month** ($204.24/year) | Combined federal + KS |
+  | No (broadband/internet-only) | **$9.25/month** ($111.00/year) | Federal only |
+
+- ⚠️ **BLOCKING — confirmed implementation gap, MFB-side, not PE-side**: MFB's shared `Lifeline` PE calculator (`programs/programs/federal/pe/spm.py:79-85`) sends `broadband_cost` (hardcoded `500`) but has **no dependency supplying `phone_cost` at all**. Ran this exact input set (no `phone_cost` key sent) live against PE: result was **$111.00/year** — confirmed, not estimated. Every KS household gets shortchanged $93.24/year today, regardless of whether they'd otherwise qualify for the phone-based supplement, until `KsLifeline` adds a `phone_cost` PE input dependency (reusing the existing telephone-expense screener data already used by `PhoneExpenseDependency`, `programs/programs/policyengine/calculators/dependencies/spm.py:98`, which reads `self.screen.calc_expenses("yearly", ["telephone"])` for a different PE field today). **Resolved decision** (not a fork): map that same telephone-expense screener data directly to the new `phone_cost` field — this isn't a UX choice, it's just matching PE's variable semantics to data MFB already collects. Documented as a required implementation step on [MFB-1057](https://linear.app/myfriendben/issue/MFB-1057/ks-lifeline-phone-and-internet-discount); see the PE delta report comment for full detail. Not a Discovery blocker; is an Implementation blocker.
+## Test Scenarios (value-isolating only — not re-testing federal eligibility)
+
+### Scenario 1: Eligible KS household with a phone cost — combined value
+**What we're checking**: A household that clearly passes PE's federal eligibility test (SNAP) and reports a telephone expense gets the **combined** $17.02/month, not the federal-only $9.25/month.
+**Expected (post phone_cost fix)**: Eligible, **$17.02/month** ($204.24/year)
+⚠️ **Known-broken until implementation fix lands**: live-verified today (no `phone_cost` sent) → PE returns **$111.00/year**. Do not treat a $111/year result as a scenario failure pre-fix; treat it as confirmation the `phone_cost` dependency is still outstanding.
+
+**Steps**:
+- **Location**: ZIP `67202`, Sedgwick County, KS
+- **Household**: 1 person, Head of Household, age 40, US Citizen, employment income $1,200/month ($14,400/year)
+- **Current Benefits**: SNAP
+- **Expenses**: Telephone expense reported (any nonzero monthly amount, e.g. $50/month)
+
+**PE verification** (`api.policyengine.org`, `household.state_name=KS`, `employment_income=14400`, `snap=1`, `broadband_cost=500`, `phone_cost=600`): `is_lifeline_eligible=true`, `ks_lifeline_supplement=93.24`, `lifeline=204.24` ✅ matches expected.
+
+**Why this matters**: This is the scenario that actually exercises the Tier's "value varies" concern — if the KS state branch or the `phone_cost` input isn't wired correctly, this silently returns $111/year instead of $204.24/year, and nothing about federal eligibility logic would catch it.
+
+---
+
+### Scenario 2: Eligible KS household, broadband-only (no phone cost) — federal-only value
+**What we're checking**: Confirms the source-documented rule that the KS supplement is phone-service-only — a household with only broadband/internet cost and no telephone expense should get federal-only, both today and after the `phone_cost` fix ships.
+**Expected**: Eligible, **$9.25/month** ($111.00/year) — same result before and after the fix, since `phone_cost` is genuinely $0 for this household (not a bug in either state).
+
+**Steps**:
+- **Location**: ZIP `67202`, Sedgwick County, KS
+- **Household**: 1 person, Head of Household, age 40, US Citizen, employment income $1,200/month ($14,400/year)
+- **Current Benefits**: SNAP
+- **Expenses**: No telephone expense reported (broadband/internet only)
+
+**PE verification**: `employment_income=14400`, `snap=1`, `broadband_cost=500`, `phone_cost=0` → `is_lifeline_eligible=true`, `ks_lifeline_supplement=93.24` (computed but capped by `phone_cost=0`... `min_(0, 93.24)=0`), `lifeline=111.00` ✅ matches expected.
+
+**Why this matters**: Proves the $9.25-vs-$17.02 split is a real, source-documented distinction (not just a PE modeling artifact) and gives a scenario whose expected value doesn't depend on the pending implementation fix — useful as a control case.
+
+---
+
+### Scenario 3: Clearly ineligible KS household — not shown
+**What we're checking**: A KS household well above the federal income threshold with no qualifying program participation is correctly excluded — confirms the KS state branch doesn't accidentally short-circuit federal eligibility (full FPL/categorical boundary testing itself is PE's responsibility and out of scope here).
+**Expected**: Ineligible.
+
+**Steps**:
+- **Location**: ZIP `67202`, Sedgwick County, KS
+- **Household**: 1 person, Head of Household, age 40, US Citizen, employment income $3,333/month ($40,000/year)
+- **Current Benefits**: None
+
+**PE verification**: `employment_income=40000`, no benefits, `broadband_cost=500`, `phone_cost=600` → `fcc_fpg_ratio=2.51` (251% of FPL, well above the 135% limit), `is_lifeline_income_eligible=false`, `is_lifeline_eligible=false`, `lifeline=0.0` ✅ matches expected.
+
+**Why this matters**: Basic regression guard — confirms the KS branch is additive to eligibility (adjusts value only) and doesn't make every KS household eligible regardless of income.
+
+---
+
+## Source Documentation
+
+- 47 CFR § 54.403 (federal benefit amount): https://www.ecfr.gov/current/title-47/chapter-I/subchapter-B/part-54/subpart-E/section-54.403
+- Kansas Lifeline Program (KCC): https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program
+- Kansas Lifeline/ACP fact sheet (CURB, source of the "phone service only" KS supplement rule and $7.77/$17.02 figures): https://curb.kansas.gov/documents/Lifeline_Program_Affordable_Connectivity_Program_2024_02262025.pdf
+- KCC news release reconfirming figures as of 2025-09-08: https://www.kcc.ks.gov/news-9-8-25
+
+## Out of Scope for This Light Spec
+
+Full federal eligibility criteria (135% FPL / qualifying-program test, KS residency, age 18+, one-per-household, and the FPL boundary/multi-member-household edge cases that go with it) are owned by PE's federal `lifeline` calculator and are **not** re-derived here — Scenario 3 above is a basic sanity check only, not full eligibility boundary coverage. 

--- a/programs/programs/ks/pe/__init__.py
+++ b/programs/programs/ks/pe/__init__.py
@@ -22,6 +22,7 @@ ks_tax_unit_calculators = {
 ks_spm_calculators = {
     "ks_snap": spm.KsSnap,
     "ks_nslp": spm.KsNslp,
+    "ks_lifeline_phone_and_internet_discount": spm.KsLifeline,
 }
 
 ks_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {

--- a/programs/programs/ks/pe/__init__.py
+++ b/programs/programs/ks/pe/__init__.py
@@ -22,7 +22,7 @@ ks_tax_unit_calculators = {
 ks_spm_calculators = {
     "ks_snap": spm.KsSnap,
     "ks_nslp": spm.KsNslp,
-    "ks_lifeline_phone_and_internet_discount": spm.KsLifeline,
+    "ks_lifeline": spm.KsLifeline,
 }
 
 ks_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {

--- a/programs/programs/ks/pe/spm.py
+++ b/programs/programs/ks/pe/spm.py
@@ -1,5 +1,5 @@
 import programs.programs.policyengine.calculators.dependencies as dependency
-from programs.programs.federal.pe.spm import Snap, SchoolLunch
+from programs.programs.federal.pe.spm import Snap, SchoolLunch, Lifeline
 
 
 class KsSnap(Snap):
@@ -32,5 +32,27 @@ class KsNslp(SchoolLunch):
 
     pe_inputs = [
         *SchoolLunch.pe_inputs,
+        dependency.household.KsStateCodeDependency,
+    ]
+
+
+class KsLifeline(Lifeline):
+    """
+    Kansas Lifeline Phone and Internet Discount calculator.
+
+    Uses PolicyEngine's federal ``lifeline`` calculator with the KS state branch.
+    Kansas layers a state supplement ($7.77/month, phone service only) on top of
+    the federal benefit ($9.25/month), for a combined $17.02/month ($204.24/year).
+
+    The KS supplement is released by PE only up to the household's ``phone_cost``
+    (``min_(phone_cost, ks_supplement * MONTHS_IN_YEAR)`` in PE's ``lifeline.py``).
+    ``phone_cost`` is supplied via the base ``Lifeline.pe_inputs`` (PhoneCostDependency),
+    so without it every KS household would silently receive only the federal-only
+    $111/year instead of $204.24/year. Mirrors the TxLifeline / WaLifeline pattern,
+    adding the KS state code so PE resolves the KS supplement parameters.
+    """
+
+    pe_inputs = [
+        *Lifeline.pe_inputs,
         dependency.household.KsStateCodeDependency,
     ]

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -339,10 +339,22 @@ class NcSccaCountableIncomeDependency(SpmUnit):
 
 
 class BroadbandCostDependency(SpmUnit):
+    # PE's Lifeline benefit is capped at the household's phone + broadband spend
+    # (min_(phone_cost + broadband_cost, max_amount)). A blank internet expense means
+    # "not reported," not "$0 spent" — sending 0 would let PE cap the benefit to $0 and,
+    # via MFB's value>0 rule, hide an eligible household. So: send the reported internet
+    # cost when we have one (PE legitimately caps the discount at actual spend), otherwise
+    # fall back to a value above the benefit ceiling so an eligible household still sees
+    # the full benefit they'd receive once enrolled in service. NO_DATA_FALLBACK keeps the
+    # prior hardcoded behavior for the no-data case (strict improvement: no regression when
+    # the field is blank, real data used when it's present).
     field = "broadband_cost"
+    NO_DATA_FALLBACK = 500
 
     def value(self):
-        return 500
+        if self.screen.has_expense(["internet"]):
+            return int(self.screen.calc_expenses("yearly", ["internet"]))
+        return self.NO_DATA_FALLBACK
 
 
 class SchoolMealCountableIncomeDependency(SpmUnit):

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -101,6 +101,18 @@ class PhoneExpenseDependency(SpmUnit):
         return self.screen.calc_expenses("yearly", ["telephone"])
 
 
+class PhoneCostDependency(SpmUnit):
+    # PE's Lifeline formula reads phone_cost (distinct from phone_expense, which SNAP
+    # uses for a yes/no utility check) to release the KS Lifeline state supplement:
+    # min_(phone_cost, ks_supplement * MONTHS_IN_YEAR). Same underlying screener data
+    # as PhoneExpenseDependency, just mapped to the field PE's Lifeline branch expects.
+    # Without it PE treats phone_cost as $0 and the KS supplement always computes to $0.
+    field = "phone_cost"
+
+    def value(self):
+        return self.screen.calc_expenses("yearly", ["telephone"])
+
+
 class ElectricityExpenseDependency(SpmUnit):
     field = "electricity_expense"
 

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -159,6 +159,31 @@ class TestUtilityExpenseDependency(TestCase):
         self.assertEqual(dep.value(), 600)  # $50 * 12
         self.assertEqual(dep.field, "phone_expense")
 
+    def test_phone_cost_calculates_annual_phone_cost(self):
+        """PhoneCostDependency.value() sends annual telephone cost under the phone_cost
+        field that PE's Lifeline formula reads for the KS state supplement."""
+        Expense.objects.create(screen=self.screen, type="telephone", amount=50, frequency="monthly")
+
+        dep = spm.PhoneCostDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), 600)  # $50 * 12
+        self.assertEqual(dep.field, "phone_cost")
+
+    def test_phone_cost_shares_phone_expense_data_source(self):
+        """phone_cost and phone_expense are distinct PE fields but must derive from the
+        same telephone screener data — guards against them drifting apart."""
+        Expense.objects.create(screen=self.screen, type="telephone", amount=50, frequency="monthly")
+
+        phone_cost = spm.PhoneCostDependency(self.screen, None, {})
+        phone_expense = spm.PhoneExpenseDependency(self.screen, None, {})
+        self.assertEqual(phone_cost.value(), phone_expense.value())
+        self.assertNotEqual(phone_cost.field, phone_expense.field)
+
+    def test_phone_cost_is_zero_without_telephone_expense(self):
+        """No telephone expense -> phone_cost 0, so PE's KS supplement (min_(phone_cost, ...))
+        correctly stays $0 for broadband-only households."""
+        dep = spm.PhoneCostDependency(self.screen, None, {})
+        self.assertEqual(dep.value(), 0)
+
     def test_value_calculates_annual_water_from_other_utilities(self):
         """Test WaterExpenseDependency.value() calculates annual water costs from otherUtilities expense."""
         Expense.objects.create(screen=self.screen, type="otherUtilities", amount=60, frequency="monthly")

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -325,20 +325,20 @@ class TestBroadbandCostDependency(TestCase):
             white_label=self.white_label, zipcode="78701", county="Test County", household_size=2, completed=False
         )
 
-    def test_value_returns_fixed_broadband_cost(self):
-        """Test value() returns hardcoded broadband cost of 500."""
+    def test_value_reads_annual_internet_expense_when_reported(self):
+        """value() sends the household's reported annual internet expense as broadband_cost."""
+        Expense.objects.create(screen=self.screen, type="internet", amount=50, frequency="monthly")
+
         dep = spm.BroadbandCostDependency(self.screen, None, {})
-        self.assertEqual(dep.value(), 500)
+        self.assertEqual(dep.value(), 600)  # $50 * 12
         self.assertEqual(dep.field, "broadband_cost")
 
-    def test_value_returns_constant_regardless_of_household_data(self):
-        """Test value() returns 500 regardless of household characteristics."""
-        # Test with different household size
-        self.screen.household_size = 5
-        self.screen.save()
-
+    def test_value_falls_back_when_no_internet_expense_reported(self):
+        """No reported internet expense -> fall back to NO_DATA_FALLBACK (not $0), so an
+        eligible household isn't capped to $0 and hidden by the value>0 rule."""
         dep = spm.BroadbandCostDependency(self.screen, None, {})
-        self.assertEqual(dep.value(), 500)
+        self.assertEqual(dep.value(), spm.BroadbandCostDependency.NO_DATA_FALLBACK)
+        self.assertGreater(dep.value(), 0)
 
 
 class TestSchoolMealCountableIncomeDependency(TestCase):


### PR DESCRIPTION
## Context & Motivation

Implements the **Kansas Lifeline Phone and Internet Discount** ([MFB-1057](https://linear.app/myfriendben/issue/MFB-1057/ks-lifeline-phone-and-internet-discount)) as a PolicyEngine program (federal `lifeline` + KS state branch), and fixes two related Lifeline input-wiring bugs on the MFB side.

PE's KS Lifeline formula releases the KS state supplement only up to the household's `phone_cost` (`ks_supplement_amount = min_(phone_cost, ks_supplement * MONTHS_IN_YEAR)` in `lifeline.py`). MFB's shared `Lifeline` calculator sent `broadband_cost` but **no** `phone_cost`, so PE treated it as `$0` and the KS supplement always computed to `$0` — KS households would get **$111/yr (federal only)** instead of the correct **$204.24/yr**, with no error surfaced. This was flagged in the ticket's PE delta report as an implementation blocker.

While wiring that, we found a second bug in the same formula's spend cap (`lifeline = min_(phone_cost + broadband_cost, max_amount)`): `broadband_cost` was hardcoded to `$500`, ignoring real internet cost. See the `broadband_cost` section below.

## Changes Made

**KS Lifeline program**
- `programs/programs/ks/lifeline/spec.md` + `.../data/ks_lifeline_initial_config.json` (research artifacts from discovery).
- `KsLifeline` (`ks/pe/spm.py`) — federal `Lifeline` + `KsStateCodeDependency`, mirroring `TxLifeline`. Registered as `ks_lifeline_phone_and_internet_discount` in `ks/pe/__init__.py`.

**`phone_cost` wiring (the "silently low KS benefit" fix)**
- New `PhoneCostDependency` (`field = "phone_cost"`), sourced from the same telephone screener expense (`calc_expenses("yearly", ["telephone"])`) as the existing `PhoneExpenseDependency`.
- Added to the **base** `Lifeline.pe_inputs`, so **every Lifeline program** supplies `phone_cost` (matches how `broadband_cost` already lives on the base). Only KS has a `phone_cost`-gated supplement, so CO/IL/MA/NC/TX/WA benefit values are unaffected.
- Dependency test coverage in `dependencies/tests/test_spm.py`.

**`broadband_cost` now sourced from the reported internet expense (+ no-data floor)**
- `BroadbandCostDependency` was hardcoded to `$500`. PE uses `broadband_cost` only in the benefit-**amount** cap (`min_(phone_cost + broadband_cost, max_amount)`) — never in eligibility.
- It now sends the household's reported `internet` expense (`calc_expenses("yearly", ["internet"])`) when present. When **not** reported it falls back to `NO_DATA_FALLBACK = 500` (above the benefit ceiling), because a blank optional expense means "not reported," not "$0 spent" — sending `$0` would cap the benefit to `$0`, and MFB's `eligible = value > 0` rule would then **hide an eligible household**.
- `phone_cost` is intentionally **not** floored: the KS supplement is phone-service-only, so a floor would over-grant it to phone-less households and break the "no telephone → federal-only" behavior (spec Scenario 2). The broadband floor alone removes the hiding risk.
- Verified on the private PE API: a KS household reporting neither internet nor phone now returns **$111** (federal, shown) instead of **$0** (hidden). Tests updated.

**Audits requested on the ticket**
- **Other PE Lifeline programs:** `broadband_cost` / `phone_cost` are on the shared base, so **all 7 active Lifeline programs — CO, IL, MA, NC (federal base calculator), TX, WA, KS — plus the dormant CO `acp`** are affected. Verified benefit values are unchanged for the non-KS programs.
- **SNAP regression:** no impact. MFB sends all PE programs in one shared household payload, so `phone_cost` is now present alongside SNAP's `phone_expense`. Per PE-US source, `phone_cost` is consumed only by `lifeline.py`; `phone_expense` (used by SNAP) is defined as `adds = ["phone_cost"]` but MFB sets `phone_expense` explicitly to the same value, so SNAP's input is unchanged. No SNAP code change needed.

**Discovery-artifact deviations (surfaced for QA tracking)**
- Description "how to apply" copy now names the **"Apply Now"** button instead of "following the link" (per the QA-team feedback doc / Cycle 8 Batch lesson #3).
- Added the required `email` (`kcc.public.affairs@ks.gov`) to the new `ks_kcc_consumer_protection` navigator — the discovery config omitted it and the importer requires it for new navigators.
- `value_format: null` verified to match `wa_lifeline` (Cycle 8 Batch lesson #1 — mirror the equivalent program's `value_format`).

## Testing

- Migrations to run: none.
- Configuration updates needed: import the config — `python manage.py import_program_config programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json` — then set the program `active = True`.
- Manual testing steps: run the 3 spec Test Scenarios (posted on MFB-1057). Scenario 1 (KS + telephone expense) should return **$204.24/yr**; Scenario 2 (broadband-only) stays $111/yr; Scenario 3 (over income) ineligible.
- Automated: `python manage.py test programs.programs.policyengine programs.programs.ks programs.programs.tx.pe programs.programs.wa.pe` → 681 passing. New `PhoneCostDependency` and `BroadbandCostDependency` tests in `dependencies.tests.test_spm`.

## Deployment

- Post-deployment: run `import_program_config` for `ks_lifeline_initial_config.json` on staging/prod and activate the program.
- Notify team/users of: all Lifeline programs (CO/IL/MA/NC/TX/WA/KS) now send `phone_cost`, and `broadband_cost` now reflects the reported internet expense (with a no-data floor) rather than a hardcoded $500.

## Notes for Reviewers

- **Blast radius:** both the `phone_cost` and `broadband_cost` changes live on the shared base `Lifeline`, so they touch **all 7 active Lifeline programs** (CO/IL/MA/NC run the federal `lifeline` calculator directly; TX/WA/KS subclass it). Behaviorally safe: only KS has a `phone_cost`-gated supplement, and the `broadband_cost` no-data fallback (`500`) preserves the prior amount for households that don't report internet — so non-KS benefit values don't move, and the only new behavior is (a) KS combined value now works and (b) a household reporting a *low* internet cost sees a truthfully lower estimate instead of the hardcoded max.
- **Why `broadband_cost` floors but `phone_cost` doesn't:** the federal benefit is service-agnostic (phone *or* internet), so flooring broadband when unreported is safe. The KS supplement is phone-only, so flooring phone would over-grant it. Confirmed on the private PE API (omitting an input == sending 0; the cap is unconditional).
- No `min_pe_version` gate added — `phone_cost`/`broadband_cost` exist in current PE (verified via PE-US source + live private-API calls), consistent with the ungated `phone_expense`.
- If reviewers prefer, the `broadband_cost` change (cross-cutting, beyond KS) can be split into its own PR — currently folded here per discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kansas Lifeline Phone and Internet Discount program.
  * Kansas households may now receive the federal Lifeline benefit plus the applicable phone-service supplement.
  * Phone and internet costs are calculated from reported household expenses.
  * Added program details, required documents, application links, and navigator contact information.

* **Bug Fixes**
  * Broadband cost calculations now use reported internet expenses, with a fallback when no data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->