### PR TITLE
RFC 0003 prototype (1/3): JSON Schema for program config/data layers

### DIFF
--- a/schemas/config_layer.schema.json
+++ b/schemas/config_layer.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://myfriendben.org/schemas/config-layer-v1.json",
+  "title": "Program config layer",
+  "description": "Wires a state's program to a PolicyEngine variable. Depth constraint (not expressible in this schema, enforced at runtime/CI instead): a config whose 'extends' is non-null must point to a config whose own 'extends' is null -- one level only, no chains, no cycles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "program",
+    "state",
+    "pe_name",
+    "pe_entity",
+    "state_dependency",
+    "extends",
+    "additional_inputs",
+    "pe_period_month"
+  ],
+  "properties": {
+    "program": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string",
+      "description": "Use \"federal\" as the sentinel for a base config that other configs extend."
+    },
+    "pe_name": {
+      "type": "string",
+      "description": "The PolicyEngine variable name, e.g. 'snap', 'co_tanf'."
+    },
+    "pe_entity": {
+      "type": "string",
+      "enum": ["spm_unit", "tax_unit", "person", "household", "family", "marital_unit"]
+    },
+    "state_dependency": {
+      "type": ["string", "null"],
+      "description": "The one state-code dependency class, e.g. CoStateCodeDependency. Null for federal-only configs."
+    },
+    "extends": {
+      "type": ["string", "null"],
+      "description": "The 'program' name of the base config this one extends, e.g. 'snap'. Null if fully self-contained."
+    },
+    "additional_inputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Dependency class names beyond extends's base (or the complete list if extends is null). Does not include state_dependency."
+    },
+    "pe_period_month": {
+      "type": ["string", "null"],
+      "description": "Default null (use pe_period as-is). Only federal SNAP sets this today, to '01'."
+    }
+  }
+}

--- a/schemas/data_layer.schema.json
+++ b/schemas/data_layer.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://myfriendben.org/schemas/data-layer-v1.json",
+  "title": "Benefit amount data layer",
+  "description": "Benefit amount tables for in-kind programs PolicyEngine does not compute a dollar value for (e.g. Medicaid, WIC). Not needed for pure cash pass-through programs (SNAP/TANF) — see PATTERNS.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["program", "state", "category_amounts", "source"],
+  "properties": {
+    "program": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "category_amounts": {
+      "type": "object",
+      "description": "Maps a category key (e.g. ADULT, INFANT) to a monthly dollar amount. No fixed key enum here deliberately — different programs use different taxonomies (Medicaid's 11 keys, WIC's 6).",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "Required, not optional — see DECISIONS.md D-005. Distinguishes a real citation from an honest gap, rather than relying on free-text convention alone.",
+      "additionalProperties": false,
+      "required": ["status", "citation"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["cited", "unsourced", "guessed"]
+        },
+        "citation": {
+          "type": ["string", "null"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "cited" } }
+          },
+          "then": {
+            "properties": { "citation": { "type": "string", "minLength": 1 } }
+          },
+          "else": {
+            "properties": { "citation": { "type": "null" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/examples/co_snap_config.json
+++ b/schemas/examples/co_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "co",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "CoStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/snap_federal.json
+++ b/schemas/examples/snap_federal.json
@@ -1,0 +1,33 @@
+{
+  "program": "snap",
+  "state": "federal",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": null,
+  "extends": null,
+  "additional_inputs": [
+    "SnapUnearnedIncomeDependency",
+    "SnapEarnedIncomeDependency",
+    "SnapAssetsDependency",
+    "SnapChildSupportDependency",
+    "PropertyTaxExpenseDependency",
+    "AgeDependency",
+    "MedicalExpenseDependency",
+    "IsDisabledDependency",
+    "SnapEmergencyAllotmentDependency",
+    "HousingCostDependency",
+    "HasPhoneExpenseDependency",
+    "HasHeatingCoolingExpenseDependency",
+    "HeatingCoolingExpenseDependency",
+    "ChildCareDependency",
+    "WaterExpenseDependency",
+    "PhoneExpenseDependency",
+    "HoaFeesExpenseDependency",
+    "HomeownersInsuranceExpenseDependency",
+    "FullTimeCollegeStudentDependency",
+    "PartTimeCollegeStudentDependency",
+    "SnapWorkExceptionDependency",
+    "SnapJobTrainingStudentDependency"
+  ],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/tx_snap_config.json
+++ b/schemas/examples/tx_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "tx",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "TxStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/wic_co.json
+++ b/schemas/examples/wic_co.json
@@ -1,0 +1,16 @@
+{
+  "program": "wic",
+  "state": "co",
+  "category_amounts": {
+    "NONE": 0,
+    "INFANT": 130,
+    "CHILD": 79,
+    "PREGNANT": 104,
+    "POSTPARTUM": 88,
+    "BREASTFEEDING": 121
+  },
+  "source": {
+    "status": "unsourced",
+    "citation": null
+  }
+}

--- a/schemas/examples/wic_nc.json
+++ b/schemas/examples/wic_nc.json
@@ -1,0 +1,16 @@
+{
+  "program": "wic",
+  "state": "nc",
+  "category_amounts": {
+    "NONE": 0,
+    "INFANT": 60,
+    "CHILD": 60,
+    "PREGNANT": 60,
+    "POSTPARTUM": 60,
+    "BREASTFEEDING": 60
+  },
+  "source": {
+    "status": "guessed",
+    "citation": null
+  }
+}


### PR DESCRIPTION
## Context & Motivation

This is PR 1 of a 3-part series prototyping [RFC 0003 (Program Calculator
Architecture Refactor)](https://github.com/MyFriendBen/rfc/pull/5) — an
unsolicited, outside exploration, not something the team asked for. I
posted an intent-to-build comment on the RFC PR itself with more background
and two open questions; flagging it here too so this isn't your first
contact with zero context.

The RFC's own worked example is Medicaid, but Medicaid isn't one pattern —
it's at least three (CO/IL/NC's category-dict pattern, MA's Medicaid→CHIP
fallback, TX's population-segmented calculators). This series pilots the
composition-based architecture on SNAP first instead, since every state's
`pe/spm.py` subclass today is a pure pass-through
(`[*Snap.pe_inputs, <State>CodeDependency]`, zero overrides) — it isolates
"does composition work at all" from "does it also handle Medicaid's harder
shapes," which seemed safer to prove separately.

This PR is step 1: JSON Schemas for the two layers RFC 0003 proposes
extracting out of the per-state Python subclasses — the config layer
(`pe_name`, `pe_entity`, dependency list) and the data layer (benefit
amount tables). No behavior changes anywhere; this PR adds JSON files only.

## Changes Made

- `schemas/data_layer.schema.json` — benefit-amount-table schema, validated
  by hand against real WIC examples (`schemas/examples/wic_co.json`,
  `wic_nc.json`). Notably, `source` is a structured
  `{status: "cited"|"unsourced"|"guessed", citation: string|null}` object,
  not a free-text string — checking WIC's actual existing data while
  building this surfaced that CO/IL/NC's WIC values have no citation
  anywhere in git history, and MA's/IL's dollar amounts look like an
  uncredited copy of CO's own uncited numbers (`ma/pe/member.py`'s own code
  comment admits `# NOTE: guesses based off Colorado`). A free-text
  `source` field can't distinguish a real citation from a confident-looking
  fabrication; a structured status can. Happy to open a separate issue with
  the full git-history trail on that finding if useful — didn't want to
  bundle a data-accuracy report into an architecture PR.
- `schemas/config_layer.schema.json` — `pe_name`/`pe_entity`/
  `state_dependency`/`base_inputs`, validated against real SNAP examples
  (federal base, CO, TX). `base_inputs` is an `extends` (parent program
  name or null) + `additional_inputs` (the delta) pair rather than a flat
  list — SNAP's federal dependency list is 22 entries, and every state
  subclass today repeats it in full via Python's `[*Snap.pe_inputs, ...]`
  spread; a flat JSON list would repeat that 22-entry list once per state.
  `extends` is capped at one level (state → federal only).

## Testing

- No code changes — pure JSON addition, nothing to run. Both schemas were
  hand-validated against the real examples included in this PR
  (`schemas/examples/`) before this PR was opened.
- Migrations to run: none.
- Configuration updates needed: none.

## Deployment

- Nothing to deploy — no code path reads these files yet. PR 3 in this
  series (a JSON-loading layer) is what actually reads them; this PR is
  additive schema definition only.

## Notes for Reviewers

- Known limitations: the schema currently has no way to express a mixin
  (e.g. `IlMedicaidFplIncomeCheckMixin`) — checked, and every real mixin in
  this codebase today is used only by fully custom, non-PolicyEngine
  calculators, so there's no live PolicyEngine-backed case to validate a
  mixin mechanism against yet. Flagged as an open gap, not solved
  speculatively.
- Future considerations: PR 2 adds a thin `PolicyEngineClient` wrapper
  (no schema dependency); PR 3 adds the factory + JSON-loading layer that
  actually consumes these two schemas together with PR 2's client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schemas for validating program configuration layers and benefit amount data.
  * Added example configurations for SNAP programs in Colorado, Texas, and federally, plus WIC examples for Colorado and North Carolina.
  * Added validation for required fields, accepted values, monthly amounts, and source citation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->