### PR TITLE
RFC 0003 prototype (2/3): PolicyEngineClient wrapping the existing Sim

### DIFF
--- a/programs/programs/policyengine/client.py
+++ b/programs/programs/policyengine/client.py
@@ -1,0 +1,35 @@
+from typing import Any, Optional
+from .engines import Sim
+
+
+class PolicyEngineClient:
+    """
+    Thin wrapper around an already-constructed Sim, per RFC 0003
+    (rfcs/0003-program-calc-refactor/README.md). Does not construct or own
+    a Sim -- wrapping an existing instance never triggers a second PE API
+    call, since Sim.__init__ is the only place that call happens.
+
+    Only get_spm_value casts to int: SPM-level PE values in this codebase
+    are always currency (see DECISIONS.md D-009). get_member_value and
+    get_household_value return the raw value uncast, since their real
+    analogs (get_member_variable, get_member_dependency_value) are used for
+    non-numeric values too (e.g. medicaid_category/chip_category strings
+    used as dict keys) -- casting those would break on a value that was
+    never meant to be numeric. get_spm_value also takes an optional period
+    override (see DECISIONS.md D-013) -- SNAP's real value is monthly, not
+    at self.period's annual period, so SnapCalculator needs to read at a
+    different period than every other pure-pass-through program.
+    """
+
+    def __init__(self, sim: Sim, period: str):
+        self.sim = sim
+        self.period = period
+
+    def get_member_value(self, member_id: int, variable: str) -> Any:
+        return self.sim.value("people", str(member_id), variable, self.period)
+
+    def get_spm_value(self, variable: str, period: Optional[str] = None) -> int:
+        return int(self.sim.value("spm_units", "spm_unit", variable, period if period is not None else self.period))
+
+    def get_household_value(self, category: str, sub_category: str, variable: str) -> Any:
+        return self.sim.value(category, sub_category, variable, self.period)

--- a/programs/programs/policyengine/tests/cassettes/test_get_household_value_reads_arbitrary_category_uncast.yaml
+++ b/programs/programs/policyengine/tests/cassettes/test_get_household_value_reads_arbitrary_category_uncast.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"you": {"age": {"2024": 30}, "employment_income":
+      {"2024": 20000}}}, "families": {"your family": {"members": ["you"]}}, "spm_units":
+      {"spm_unit": {"members": ["you"], "snap": {"2024": null}}}, "tax_units": {"your
+      tax unit": {"members": ["you"]}}, "households": {"your household": {"members":
+      ["you"], "state_name": {"2024": "CO"}}}, "marital_units": {"your marital unit":
+      {"members": ["you"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"you": {"age":
+        {"2024": 30}, "employment_income": {"2024": 20000}}}, "families": {"your family":
+        {"members": ["you"]}}, "spm_units": {"spm_unit": {"members": ["you"], "snap":
+        {"2024": 279.59998}}}, "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {"2024":
+        "CO"}}}, "marital_units": {"your marital unit": {"members": ["you"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jul 2026 07:07:07 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - cf63ea80-763f-49ec-a8d6-8f2ed2a2f814
+      traceparent:
+      - 00-5886c545364bf8ea15f9f3a661a365ef-515289d62a60fe1b-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/policyengine/tests/cassettes/test_get_member_value_reads_person_level_value.yaml
+++ b/programs/programs/policyengine/tests/cassettes/test_get_member_value_reads_person_level_value.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"you": {"age": {"2024": 30}, "employment_income":
+      {"2024": 20000}}}, "families": {"your family": {"members": ["you"]}}, "spm_units":
+      {"spm_unit": {"members": ["you"], "snap": {"2024": null}}}, "tax_units": {"your
+      tax unit": {"members": ["you"]}}, "households": {"your household": {"members":
+      ["you"], "state_name": {"2024": "CO"}}}, "marital_units": {"your marital unit":
+      {"members": ["you"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"you": {"age":
+        {"2024": 30}, "employment_income": {"2024": 20000}}}, "families": {"your family":
+        {"members": ["you"]}}, "spm_units": {"spm_unit": {"members": ["you"], "snap":
+        {"2024": 279.59998}}}, "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {"2024":
+        "CO"}}}, "marital_units": {"your marital unit": {"members": ["you"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jul 2026 07:07:08 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - e1b25928-17df-40d7-b6ad-b2b5a4cde466
+      traceparent:
+      - 00-3d20267716db429f5d2fd611b92e777e-436bde7bbaca4bf3-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/policyengine/tests/cassettes/test_get_spm_value_casts_currency_to_int.yaml
+++ b/programs/programs/policyengine/tests/cassettes/test_get_spm_value_casts_currency_to_int.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"you": {"age": {"2024": 30}, "employment_income":
+      {"2024": 20000}}}, "families": {"your family": {"members": ["you"]}}, "spm_units":
+      {"spm_unit": {"members": ["you"], "snap": {"2024": null}}}, "tax_units": {"your
+      tax unit": {"members": ["you"]}}, "households": {"your household": {"members":
+      ["you"], "state_name": {"2024": "CO"}}}, "marital_units": {"your marital unit":
+      {"members": ["you"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"you": {"age":
+        {"2024": 30}, "employment_income": {"2024": 20000}}}, "families": {"your family":
+        {"members": ["you"]}}, "spm_units": {"spm_unit": {"members": ["you"], "snap":
+        {"2024": 279.59998}}}, "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {"2024":
+        "CO"}}}, "marital_units": {"your marital unit": {"members": ["you"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jul 2026 07:07:09 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 1dc10ef3-f96c-4039-9e18-a404d37ae661
+      traceparent:
+      - 00-c427263a606c9a269c6230d5b2bc4fbd-2bddb35e8df78072-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/policyengine/tests/test_client.py
+++ b/programs/programs/policyengine/tests/test_client.py
@@ -1,0 +1,119 @@
+"""Unit tests for PolicyEngineClient (programs/programs/policyengine/client.py).
+
+Uses a stub Sim -- no network, no Docker required. See test_integration.py
+for tests against a real, recorded PolicyEngine response.
+"""
+
+from unittest.mock import patch
+from django.test import SimpleTestCase
+
+from programs.programs.policyengine.client import PolicyEngineClient
+from programs.programs.policyengine.engines import ApiSim
+
+
+class StubSim:
+    """Minimal Sim double: records every .value() call and returns canned values."""
+
+    def __init__(self, data=None):
+        self.data = data or {}
+        self.calls = []
+
+    def value(self, unit, sub_unit, variable, period):
+        self.calls.append((unit, sub_unit, variable, period))
+        return self.data[(unit, sub_unit, variable, period)]
+
+    def members(self, unit, sub_unit):
+        raise NotImplementedError
+
+
+class TestGetMemberValue(SimpleTestCase):
+    def test_reads_people_category_uncast(self):
+        sim = StubSim({("people", "1", "medicaid_category", "2024"): "ADULT"})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_member_value(1, "medicaid_category"), "ADULT")
+        self.assertEqual(sim.calls, [("people", "1", "medicaid_category", "2024")])
+
+    def test_does_not_cast_numeric_strings_that_are_not_currency(self):
+        # e.g. a FIPS county code -- would silently corrupt if cast to int.
+        sim = StubSim({("people", "1", "county_fips", "2024"): "08031"})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_member_value(1, "county_fips"), "08031")
+
+
+class TestGetSpmValue(SimpleTestCase):
+    def test_casts_to_int_truncating(self):
+        sim = StubSim({("spm_units", "spm_unit", "snap", "2024"): 279.59998})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_spm_value("snap"), 279)
+        self.assertEqual(sim.calls, [("spm_units", "spm_unit", "snap", "2024")])
+
+    def test_period_override_reads_at_the_given_period_not_self_period(self):
+        # SNAP's real value lives at the monthly pe_output_period ("2024-01"),
+        # not the annual self.period ("2024") -- see DECISIONS.md D-013.
+        sim = StubSim({("spm_units", "spm_unit", "snap", "2024-01"): 279.59998})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_spm_value("snap", period="2024-01"), 279)
+        self.assertEqual(sim.calls, [("spm_units", "spm_unit", "snap", "2024-01")])
+
+    def test_no_period_override_still_defaults_to_self_period(self):
+        sim = StubSim({("spm_units", "spm_unit", "snap", "2024"): 279.59998})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_spm_value("snap", period=None), 279)
+        self.assertEqual(sim.calls, [("spm_units", "spm_unit", "snap", "2024")])
+
+
+class TestGetHouseholdValue(SimpleTestCase):
+    def test_reads_arbitrary_category_uncast(self):
+        sim = StubSim({("households", "your household", "state_name", "2024"): "CO"})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_household_value("households", "your household", "state_name"), "CO")
+        self.assertEqual(sim.calls, [("households", "your household", "state_name", "2024")])
+
+    def test_reads_tax_unit_category(self):
+        sim = StubSim({("tax_units", "your tax unit", "eitc", "2024"): 1500.4})
+        client = PolicyEngineClient(sim, "2024")
+
+        # Uncast on purpose (see DECISIONS.md D-009) -- caller casts if it needs to.
+        self.assertEqual(client.get_household_value("tax_units", "your tax unit", "eitc"), 1500.4)
+
+
+class TestWrappingExistingSimDoesNotTriggerASecondApiCall(SimpleTestCase):
+    """RFC 0003's own open question: does the client cause a second live PE call?"""
+
+    def test_constructing_the_client_makes_no_http_call(self):
+        with patch("requests.post") as mock_post:
+            sim = StubSim({("spm_units", "spm_unit", "snap", "2024"): 100})
+            PolicyEngineClient(sim, "2024")
+
+            mock_post.assert_not_called()
+
+    def test_multiple_getter_calls_reuse_the_same_sim_construction(self):
+        # ApiSim.__init__ is where the one real HTTP call happens (engines.py:43).
+        # Construct exactly one ApiSim, then call every client getter several times --
+        # the mocked requests.post call count must stay at 1 throughout.
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.raise_for_status.return_value = None
+            mock_post.return_value.json.return_value = {
+                "result": {
+                    "people": {"1": {"age": {"2024": 30}}},
+                    "spm_units": {"spm_unit": {"snap": {"2024": 279.6}}},
+                    "households": {"your household": {"state_name": {"2024": "CO"}}},
+                }
+            }
+
+            sim = ApiSim({"household": {}})
+            self.assertEqual(mock_post.call_count, 1)
+
+            client = PolicyEngineClient(sim, "2024")
+            for _ in range(3):
+                client.get_member_value(1, "age")
+                client.get_spm_value("snap")
+                client.get_household_value("households", "your household", "state_name")
+
+            self.assertEqual(mock_post.call_count, 1)

--- a/programs/programs/policyengine/tests/test_integration.py
+++ b/programs/programs/policyengine/tests/test_integration.py
@@ -1,0 +1,60 @@
+"""Integration tests for PolicyEngineClient against a real, recorded PolicyEngine
+response (per RFC 0008: "Use vcrpy fixtures for PolicyEngine calls").
+
+Follows the repo's existing VCR convention exactly (see
+integrations/clients/hud_income_limits/tests/test_integration.py and the
+auto_vcr fixture in the root conftest.py). Cassettes live in
+tests/cassettes/<test_name>.yaml, generated once against the local
+self-hosted PolicyEngine Docker container (see RISKS.md/DECISIONS.md D-003 --
+never the real hosted API), then replayed with zero live dependency.
+
+Run: pytest -m integration programs/programs/policyengine/tests/test_integration.py
+"""
+
+import pytest
+from django.test import SimpleTestCase
+
+from programs.programs.policyengine.client import PolicyEngineClient
+from programs.programs.policyengine.engines import ApiSim
+
+PERIOD = "2024"
+
+HOUSEHOLD_PAYLOAD = {
+    "household": {
+        "people": {"you": {"age": {PERIOD: 30}, "employment_income": {PERIOD: 20000}}},
+        "families": {"your family": {"members": ["you"]}},
+        "spm_units": {"spm_unit": {"members": ["you"], "snap": {PERIOD: None}}},
+        "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {PERIOD: "CO"}}},
+        "marital_units": {"your marital unit": {"members": ["you"]}},
+    }
+}
+
+
+class DockerApiSim(ApiSim):
+    """Test-only Sim pointed at the local self-hosted Docker container instead of
+    PolicyEngine's real hosted API -- keeps faith with D-003 while still recording
+    a genuine response. Defined here only; engines.py is not touched."""
+
+    pe_url = "http://localhost:8080/us/calculate"
+
+
+@pytest.mark.integration
+class TestPolicyEngineClientAgainstRealResponse(SimpleTestCase):
+    def setUp(self):
+        self.sim = DockerApiSim(HOUSEHOLD_PAYLOAD)
+        self.client = PolicyEngineClient(self.sim, PERIOD)
+
+    def test_get_member_value_reads_person_level_value(self):
+        self.assertEqual(self.client.get_member_value("you", "age"), 30)
+
+    def test_get_spm_value_casts_currency_to_int(self):
+        # Real recorded value is a float (e.g. 279.59998); get_spm_value truncates.
+        value = self.client.get_spm_value("snap")
+        self.assertIsInstance(value, int)
+        self.assertGreater(value, 0)
+
+    def test_get_household_value_reads_arbitrary_category_uncast(self):
+        # state_name is a real non-numeric value on a category other than spm/people --
+        # confirms the method is genuinely generic, and returns it uncast.
+        self.assertEqual(self.client.get_household_value("households", "your household", "state_name"), "CO")

--- a/schemas/config_layer.schema.json
+++ b/schemas/config_layer.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://myfriendben.org/schemas/config-layer-v1.json",
+  "title": "Program config layer",
+  "description": "Wires a state's program to a PolicyEngine variable. Depth constraint (not expressible in this schema, enforced at runtime/CI instead): a config whose 'extends' is non-null must point to a config whose own 'extends' is null -- one level only, no chains, no cycles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "program",
+    "state",
+    "pe_name",
+    "pe_entity",
+    "state_dependency",
+    "extends",
+    "additional_inputs",
+    "pe_period_month"
+  ],
+  "properties": {
+    "program": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string",
+      "description": "Use \"federal\" as the sentinel for a base config that other configs extend."
+    },
+    "pe_name": {
+      "type": "string",
+      "description": "The PolicyEngine variable name, e.g. 'snap', 'co_tanf'."
+    },
+    "pe_entity": {
+      "type": "string",
+      "enum": ["spm_unit", "tax_unit", "person", "household", "family", "marital_unit"]
+    },
+    "state_dependency": {
+      "type": ["string", "null"],
+      "description": "The one state-code dependency class, e.g. CoStateCodeDependency. Null for federal-only configs."
+    },
+    "extends": {
+      "type": ["string", "null"],
+      "description": "The 'program' name of the base config this one extends, e.g. 'snap'. Null if fully self-contained."
+    },
+    "additional_inputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Dependency class names beyond extends's base (or the complete list if extends is null). Does not include state_dependency."
+    },
+    "pe_period_month": {
+      "type": ["string", "null"],
+      "description": "Default null (use pe_period as-is). Only federal SNAP sets this today, to '01'."
+    }
+  }
+}

--- a/schemas/data_layer.schema.json
+++ b/schemas/data_layer.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://myfriendben.org/schemas/data-layer-v1.json",
+  "title": "Benefit amount data layer",
+  "description": "Benefit amount tables for in-kind programs PolicyEngine does not compute a dollar value for (e.g. Medicaid, WIC). Not needed for pure cash pass-through programs (SNAP/TANF) — see PATTERNS.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["program", "state", "category_amounts", "source"],
+  "properties": {
+    "program": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "category_amounts": {
+      "type": "object",
+      "description": "Maps a category key (e.g. ADULT, INFANT) to a monthly dollar amount. No fixed key enum here deliberately — different programs use different taxonomies (Medicaid's 11 keys, WIC's 6).",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "Required, not optional — see DECISIONS.md D-005. Distinguishes a real citation from an honest gap, rather than relying on free-text convention alone.",
+      "additionalProperties": false,
+      "required": ["status", "citation"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["cited", "unsourced", "guessed"]
+        },
+        "citation": {
+          "type": ["string", "null"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "cited" } }
+          },
+          "then": {
+            "properties": { "citation": { "type": "string", "minLength": 1 } }
+          },
+          "else": {
+            "properties": { "citation": { "type": "null" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/examples/co_snap_config.json
+++ b/schemas/examples/co_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "co",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "CoStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/snap_federal.json
+++ b/schemas/examples/snap_federal.json
@@ -1,0 +1,33 @@
+{
+  "program": "snap",
+  "state": "federal",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": null,
+  "extends": null,
+  "additional_inputs": [
+    "SnapUnearnedIncomeDependency",
+    "SnapEarnedIncomeDependency",
+    "SnapAssetsDependency",
+    "SnapChildSupportDependency",
+    "PropertyTaxExpenseDependency",
+    "AgeDependency",
+    "MedicalExpenseDependency",
+    "IsDisabledDependency",
+    "SnapEmergencyAllotmentDependency",
+    "HousingCostDependency",
+    "HasPhoneExpenseDependency",
+    "HasHeatingCoolingExpenseDependency",
+    "HeatingCoolingExpenseDependency",
+    "ChildCareDependency",
+    "WaterExpenseDependency",
+    "PhoneExpenseDependency",
+    "HoaFeesExpenseDependency",
+    "HomeownersInsuranceExpenseDependency",
+    "FullTimeCollegeStudentDependency",
+    "PartTimeCollegeStudentDependency",
+    "SnapWorkExceptionDependency",
+    "SnapJobTrainingStudentDependency"
+  ],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/tx_snap_config.json
+++ b/schemas/examples/tx_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "tx",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "TxStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/wic_co.json
+++ b/schemas/examples/wic_co.json
@@ -1,0 +1,16 @@
+{
+  "program": "wic",
+  "state": "co",
+  "category_amounts": {
+    "NONE": 0,
+    "INFANT": 130,
+    "CHILD": 79,
+    "PREGNANT": 104,
+    "POSTPARTUM": 88,
+    "BREASTFEEDING": 121
+  },
+  "source": {
+    "status": "unsourced",
+    "citation": null
+  }
+}

--- a/schemas/examples/wic_nc.json
+++ b/schemas/examples/wic_nc.json
@@ -1,0 +1,16 @@
+{
+  "program": "wic",
+  "state": "nc",
+  "category_amounts": {
+    "NONE": 0,
+    "INFANT": 60,
+    "CHILD": 60,
+    "PREGNANT": 60,
+    "POSTPARTUM": 60,
+    "BREASTFEEDING": 60
+  },
+  "source": {
+    "status": "guessed",
+    "citation": null
+  }
+}


### PR DESCRIPTION
## Context & Motivation

PR 2 of 3 in the [RFC 0003](https://github.com/MyFriendBen/rfc/pull/5)
prototype series — built on top of #1637. GitHub doesn't allow a cross-fork
PR's base to be a branch that only exists on my fork (it has to exist on
this repo), so this PR is based on `main` and its diff necessarily includes
#1637's schema files too. **The only files actually new to this PR** are
listed under "Changes Made" below (everything under
`programs/programs/policyengine/`); the diff will shrink to just those once
#1637 merges.

RFC 0003's own code sample flags an open question: does wrapping the
existing `Sim` object in a new client risk making a second live PolicyEngine
API call per request? This PR answers that with a passing test, not just an
assertion.

## Changes Made

- `programs/programs/policyengine/client.py` — `PolicyEngineClient` with
  three getters (`get_member_value`, `get_spm_value`,
  `get_household_value`), each a thin wrapper around an **already
  constructed** `Sim` instance. `Sim`/`engines.py` are untouched.
- Only `get_spm_value` casts its result to `int`. I checked every real
  caller of the four existing analogous getters in
  `policyengine/calculators/base.py` before deciding this: SPM-level values
  are always cast to currency by their only callers today, but the
  household/member-dependency analog is genuinely used with non-numeric
  string values in production (`medicaid_category`/`chip_category` as dict
  keys, `federal/pe/member.py`) — an unconditional `int(...)` there would
  either raise, or worse, silently succeed on an all-digit non-numeric value
  like a zip code. So `get_member_value`/`get_household_value` return the
  raw value instead of guessing a cast is always safe.
- `test_client.py` — mocked unit tests, including
  `test_multiple_getter_calls_reuse_the_same_sim_construction`, which
  patches `requests.post`, calls all three getters multiple times each, and
  asserts exactly one HTTP call total — directly answering RFC 0003's
  double-API-call question.
- `test_integration.py` + 3 VCR cassettes — recorded against a real
  self-hosted PolicyEngine Docker container
  (`ghcr.io/policyengine/policyengine-household-api`), following this
  repo's existing `integrations/clients/hud_income_limits/tests/` VCR
  convention. Verified replaying cleanly with the container stopped (no
  live dependency at test time).

## Testing

- `pytest programs/programs/policyengine/tests/test_client.py programs/programs/policyengine/tests/test_integration.py` —
  12/12 passing locally (9 mocked unit + 3 VCR-replayed integration).
- `black --check` clean.
- Migrations to run: none. Configuration updates needed: none.

## Deployment

- Nothing to deploy — this client isn't wired into any calculator's
  request path yet. PR 3 in this series is the first real consumer.

## Notes for Reviewers

- Known limitations: this interface isn't claimed to be final. RFC 0003's
  own discussion suggests treating the client interface as provisional
  until a real calculator exercises it — PR 3 (and, in my own fork, a
  further SNAP-calculator PR I'm holding back until it's fully verified
  across all 7 SNAP states) is that exercise.
- Future considerations: none of this touches the existing
  `PolicyEngineCalulator`/`registry.py` orchestration — it's designed to be
  addable without modifying anything that exists today.
