### PR TITLE
RFC 0003 prototype (4/4): SNAP + TANF pilot, full parallel verification

### DIFF
--- a/programs/programs/calculators/base.py
+++ b/programs/programs/calculators/base.py
@@ -1,0 +1,159 @@
+"""
+ConfigurableCalculator: a protocol-only adapter for PE-backed programs, per
+DECISIONS.md D-012.
+
+Deliberately does NOT import or inherit from PolicyEngineCalulator or
+ProgramCalculator. Grepping policy_engine.py/views.py/registry.py confirmed
+the real orchestration path (screener/views.py -> calc_pe_eligibility ->
+pe_input()/all_eligibility()) is 100% duck-typed -- the only issubclass()
+calls anywhere in policy_engine.py check a *dependency* class, never the
+calculator -- so this class only needs to expose the exact attribute/method
+surface those functions actually read:
+
+    pe_inputs, pe_outputs, pe_period, pe_output_period, can_calc(),
+    set_engine(sim), calc(), and a 3-arg __init__(screen, program,
+    missing_dependencies) matching the real call site
+    (screener/views.py:424).
+
+config/benefit_data are bound onto the instance by CalculatorFactory at
+*registration* time (see factories/calculator_factory.py), passed as
+keyword-only constructor args, since the real call site only ever supplies
+the 3 positional args and has no slot for anything else.
+
+The eligible()/household_eligible()/member_eligible() loop below is an
+intentional reimplementation of ProgramCalculator.eligible()
+(programs/programs/calc.py) and PolicyEngineCalulator.eligible()
+(policyengine/calculators/base.py) -- not inherited, since inheriting either
+would reintroduce the coupling this class exists to avoid, or mismatch on
+constructor arity (ProgramCalculator takes a 4th `data` arg unused here).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from programs.programs.calc import Eligibility, MemberEligibility
+from programs.programs.config.loader import ConfigLayer
+from programs.programs.data.loader import DataLayer
+from programs.programs.policyengine.client import PolicyEngineClient
+from programs.programs.policyengine.engines import Sim
+from programs.util import Dependencies, DependencyError
+from screener.models import HouseholdMember, Screen
+
+if TYPE_CHECKING:
+    from programs.models import Program
+
+
+class ConfigurableCalculator:
+    dependencies: tuple = tuple()  # ProgramCalculator.can_calc()'s own-dependency analog
+
+    def __init__(
+        self,
+        screen: Screen,
+        program: "Program",
+        missing_dependencies: Dependencies,
+        *,
+        config: ConfigLayer,
+        benefit_data: Optional[DataLayer] = None,
+    ):
+        self.screen = screen
+        self.program = program
+        self.missing_dependencies = missing_dependencies
+        self.config = config
+        self.benefit_data = benefit_data
+        self._sim: Optional[Sim] = None
+        self._client: Optional[PolicyEngineClient] = None
+
+    # ---- duck-typed orchestration surface (pe_input()/all_eligibility()) ----
+
+    @property
+    def pe_inputs(self) -> list:
+        return self.config.pe_inputs
+
+    @property
+    def pe_outputs(self) -> list:
+        return self.config.pe_outputs
+
+    @property
+    def pe_period(self) -> str:
+        if self.program.year is None:
+            raise Exception(f"the period is not configured for: {self.config.pe_name}")
+        return self.program.year.period
+
+    @property
+    def pe_output_period(self) -> str:
+        # policy_engine.py gates use of this on hasattr(program,
+        # "pe_output_period") -- reproduces Snap's real min-period-vs-
+        # output-period split (pe_period_month is null for every non-SNAP
+        # config today) generically, via AttributeError, with no SNAP-only
+        # subclass.
+        if self.config.pe_period_month is None:
+            raise AttributeError("pe_output_period")
+        return f"{self.pe_period}-{self.config.pe_period_month}"
+
+    def can_calc(self) -> bool:
+        for input_cls in self.pe_inputs:
+            if self.missing_dependencies.has(*input_cls.dependencies):
+                return False
+        return not self.missing_dependencies.has(*self.dependencies)
+
+    def set_engine(self, sim: Sim) -> None:
+        self._sim = sim
+        self._client = PolicyEngineClient(sim, self.pe_period)
+
+    @property
+    def client(self) -> PolicyEngineClient:
+        if self._client is None:
+            raise Exception("Engine is not configured")
+        return self._client
+
+    def calc(self) -> Eligibility:
+        if not self.can_calc():
+            raise DependencyError()
+        return self.eligible()
+
+    # ---- eligibility loop (reimplements calc.py/PolicyEngineCalulator's, not inherited) ----
+
+    def eligible(self) -> Eligibility:
+        e = Eligibility()
+        one_member_eligible = False
+        for member in self.screen.household_members.all():
+            member_eligibility = MemberEligibility(member)
+            self.member_eligible(member_eligibility)
+            e.add_member_eligibility(member_eligibility)
+            if member_eligibility.eligible:
+                one_member_eligible = True
+        e.condition(one_member_eligible)
+        self.household_eligible(e)
+        e.eligible = e.value > 0
+        return e
+
+    def household_eligible(self, e: Eligibility) -> None:
+        e.household_value = self.household_value()
+
+    def member_eligible(self, e: MemberEligibility) -> None:
+        value = self.member_value(e.member)
+        e.value = value
+        e.condition(value > 0)
+
+    # ---- composition logic: reads config/data, calls PolicyEngineClient ----
+
+    def household_value(self) -> int:
+        """Pure pass-through only (D-000's SNAP/TANF shape). Known, flagged
+        gap: reads at pe_period, not pe_output_period, so this does not
+        reproduce Snap's real monthly->annual *12 conversion -- see
+        ROADMAP.md Phase 3 non-goals. category_amounts (benefit_data)-driven
+        lookup logic is also out of scope; benefit_data is bound and
+        available for a future subclass."""
+        if self.config.pe_entity == "spm_unit":
+            return self.client.get_spm_value(self.config.pe_name)
+        if self.config.pe_entity == "household":
+            value = self.client.get_household_value("households", "household", self.config.pe_name)
+            return int(value) if isinstance(value, (int, float)) else 0
+        return 0  # person/tax_unit value comes from member_value()/a future override
+
+    def member_value(self, member: HouseholdMember) -> int:
+        if self.config.pe_entity != "person":
+            return 0
+        value = self.client.get_member_value(member.id, self.config.pe_name)
+        return int(value) if isinstance(value, (int, float)) else 0

--- a/programs/programs/calculators/snap.py
+++ b/programs/programs/calculators/snap.py
@@ -1,0 +1,23 @@
+"""
+SnapCalculator: the one override ConfigurableCalculator's own docstring
+earmarked for "a future subclass" (see calculators/base.py's
+household_value()). Reproduces federal Snap.household_value()'s real
+behavior (federal/pe/spm.py:42-43):
+
+    return int(self.sim.value(...)) * 12
+
+i.e. cast the monthly PE value to int *first*, then multiply by 12 -- not
+the reverse, which gives a different (wrong) answer for any non-integer
+monthly value. get_spm_value already casts internally, so calling it and
+multiplying the result by 12 outside reproduces that exact order (see
+DECISIONS.md D-013).
+"""
+
+from __future__ import annotations
+
+from programs.programs.calculators.base import ConfigurableCalculator
+
+
+class SnapCalculator(ConfigurableCalculator):
+    def household_value(self) -> int:
+        return self.client.get_spm_value(self.config.pe_name, period=self.pe_output_period) * 12

--- a/programs/programs/calculators/tests/test_configurable_calculator.py
+++ b/programs/programs/calculators/tests/test_configurable_calculator.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from programs.programs.calculators.base import ConfigurableCalculator
+from programs.programs.config.loader import ConfigLayer
+from programs.programs.policyengine.calculators.dependencies.member import AgeDependency
+from programs.programs.data.loader import DataLayer, SourceInfo
+from programs.util import DependencyError, Dependencies
+
+
+class StubSim:
+    """Same convention as programs/programs/policyengine/tests/test_client.py's
+    StubSim -- records nothing, just returns from a dict keyed by
+    (unit, sub_unit, variable, period)."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def value(self, unit, sub_unit, variable, period):
+        return self.data[(unit, sub_unit, variable, period)]
+
+
+def make_program(period="2024"):
+    year = SimpleNamespace(period=period) if period is not None else None
+    return SimpleNamespace(year=year)
+
+
+def make_screen(member_ids):
+    members = [SimpleNamespace(id=member_id) for member_id in member_ids]
+    return SimpleNamespace(household_members=SimpleNamespace(all=lambda: members))
+
+
+class TestPeriodProperties(SimpleTestCase):
+    def test_pe_period_raises_when_program_year_is_none(self):
+        config = ConfigLayer(program="p", state="s", pe_name="x", pe_entity="spm_unit", pe_period_month=None)
+        calc = ConfigurableCalculator(make_screen([]), make_program(period=None), Dependencies(), config=config)
+
+        with self.assertRaises(Exception):
+            calc.pe_period
+
+    def test_pe_output_period_raises_attribute_error_when_month_unset(self):
+        config = ConfigLayer(program="p", state="s", pe_name="x", pe_entity="spm_unit", pe_period_month=None)
+        calc = ConfigurableCalculator(make_screen([]), make_program(), Dependencies(), config=config)
+
+        with self.assertRaises(AttributeError):
+            calc.pe_output_period
+
+    def test_pe_output_period_combines_period_and_month_when_set(self):
+        config = ConfigLayer(program="p", state="s", pe_name="x", pe_entity="spm_unit", pe_period_month="01")
+        calc = ConfigurableCalculator(make_screen([]), make_program(period="2024"), Dependencies(), config=config)
+
+        self.assertEqual(calc.pe_output_period, "2024-01")
+
+
+class TestCanCalc(SimpleTestCase):
+    def test_true_when_no_dependency_is_missing(self):
+        config = ConfigLayer(
+            program="p", state="s", pe_name="x", pe_entity="spm_unit", pe_period_month=None, pe_inputs=[AgeDependency]
+        )
+        calc = ConfigurableCalculator(make_screen([]), make_program(), Dependencies(), config=config)
+
+        self.assertTrue(calc.can_calc())
+
+    def test_false_when_a_pe_input_dependency_is_missing(self):
+        config = ConfigLayer(
+            program="p", state="s", pe_name="x", pe_entity="spm_unit", pe_period_month=None, pe_inputs=[AgeDependency]
+        )
+        calc = ConfigurableCalculator(make_screen([]), make_program(), Dependencies({"age"}), config=config)
+
+        self.assertFalse(calc.can_calc())
+
+    def test_calc_raises_dependency_error_when_cannot_calc(self):
+        config = ConfigLayer(
+            program="p", state="s", pe_name="x", pe_entity="spm_unit", pe_period_month=None, pe_inputs=[AgeDependency]
+        )
+        calc = ConfigurableCalculator(make_screen([]), make_program(), Dependencies({"age"}), config=config)
+
+        with self.assertRaises(DependencyError):
+            calc.calc()
+
+
+class TestSpmUnitCalc(SimpleTestCase):
+    def test_household_value_reads_spm_value_via_client(self):
+        config = ConfigLayer(program="p", state="s", pe_name="tanf", pe_entity="spm_unit", pe_period_month=None)
+        calc = ConfigurableCalculator(make_screen([1]), make_program(period="2024"), Dependencies(), config=config)
+        calc.set_engine(StubSim({("spm_units", "spm_unit", "tanf", "2024"): 150.0}))
+
+        eligibility = calc.calc()
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(eligibility.household_value, 150)
+
+
+class TestPersonEntityCalc(SimpleTestCase):
+    def test_member_value_reads_member_value_via_client(self):
+        config = ConfigLayer(program="p", state="s", pe_name="medicaid", pe_entity="person", pe_period_month=None)
+        calc = ConfigurableCalculator(make_screen([7]), make_program(period="2024"), Dependencies(), config=config)
+        calc.set_engine(StubSim({("people", "7", "medicaid", "2024"): 1}))
+
+        eligibility = calc.calc()
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(len(eligibility.eligible_members), 1)
+        self.assertEqual(eligibility.eligible_members[0].value, 1)
+
+
+class TestBenefitDataIsBoundButInert(SimpleTestCase):
+    def test_benefit_data_is_stored_and_not_used_by_household_value(self):
+        config = ConfigLayer(program="p", state="s", pe_name="tanf", pe_entity="spm_unit", pe_period_month=None)
+        data = DataLayer(program="p", state="s", category_amounts={"ADULT": 100}, source=SourceInfo("guessed", None))
+        calc = ConfigurableCalculator(
+            make_screen([1]), make_program(period="2024"), Dependencies(), config=config, benefit_data=data
+        )
+        calc.set_engine(StubSim({("spm_units", "spm_unit", "tanf", "2024"): 150.0}))
+
+        self.assertIs(calc.benefit_data, data)
+        self.assertEqual(calc.calc().household_value, 150)

--- a/programs/programs/calculators/tests/test_snap_calculator.py
+++ b/programs/programs/calculators/tests/test_snap_calculator.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from programs.programs.calculators.snap import SnapCalculator
+from programs.programs.config.loader import ConfigLayer
+from programs.util import Dependencies
+
+
+class StubSim:
+    """Same convention as test_client.py's/test_configurable_calculator.py's
+    StubSim -- returns from a dict keyed by (unit, sub_unit, variable, period)."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def value(self, unit, sub_unit, variable, period):
+        return self.data[(unit, sub_unit, variable, period)]
+
+
+def make_program(period="2024"):
+    return SimpleNamespace(year=SimpleNamespace(period=period))
+
+
+def make_screen():
+    return SimpleNamespace(household_members=SimpleNamespace(all=lambda: []))
+
+
+class TestSnapCalculatorHouseholdValue(SimpleTestCase):
+    def test_reads_at_monthly_output_period_and_multiplies_by_12(self):
+        # Real value from Phase 2's Docker cassette, deliberately non-integer:
+        # distinguishes int(279.59998) * 12 == 3348 from int(279.59998 * 12)
+        # == 3355, matching federal/pe/spm.py:42-43's real cast-then-multiply
+        # order exactly (see DECISIONS.md D-013).
+        config = ConfigLayer(program="snap", state="co", pe_name="snap", pe_entity="spm_unit", pe_period_month="01")
+        calc = SnapCalculator(make_screen(), make_program(period="2024"), Dependencies(), config=config)
+        calc.set_engine(StubSim({("spm_units", "spm_unit", "snap", "2024-01"): 279.59998}))
+
+        self.assertEqual(calc.household_value(), 3348)

--- a/programs/programs/config/data/co_snap_config.json
+++ b/programs/programs/config/data/co_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "co",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "CoStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/il_snap_config.json
+++ b/programs/programs/config/data/il_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "il",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "IlStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/ks_snap_config.json
+++ b/programs/programs/config/data/ks_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "ks",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "KsStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/ma_snap_config.json
+++ b/programs/programs/config/data/ma_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "ma",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "MaStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/nc_snap_config.json
+++ b/programs/programs/config/data/nc_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "nc",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "NcStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/snap_federal.json
+++ b/programs/programs/config/data/snap_federal.json
@@ -1,0 +1,33 @@
+{
+  "program": "snap",
+  "state": "federal",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": null,
+  "extends": null,
+  "additional_inputs": [
+    "SnapUnearnedIncomeDependency",
+    "SnapEarnedIncomeDependency",
+    "SnapAssetsDependency",
+    "SnapChildSupportDependency",
+    "PropertyTaxExpenseDependency",
+    "AgeDependency",
+    "MedicalExpenseDependency",
+    "IsDisabledDependency",
+    "SnapEmergencyAllotmentDependency",
+    "HousingCostDependency",
+    "HasPhoneExpenseDependency",
+    "HasHeatingCoolingExpenseDependency",
+    "HeatingCoolingExpenseDependency",
+    "ChildCareDependency",
+    "WaterExpenseDependency",
+    "PhoneExpenseDependency",
+    "HoaFeesExpenseDependency",
+    "HomeownersInsuranceExpenseDependency",
+    "FullTimeCollegeStudentDependency",
+    "PartTimeCollegeStudentDependency",
+    "SnapWorkExceptionDependency",
+    "SnapJobTrainingStudentDependency"
+  ],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/tanf_federal.json
+++ b/programs/programs/config/data/tanf_federal.json
@@ -1,0 +1,10 @@
+{
+  "program": "tanf",
+  "state": "federal",
+  "pe_name": "tanf",
+  "pe_entity": "spm_unit",
+  "state_dependency": null,
+  "extends": null,
+  "additional_inputs": ["AgeDependency", "FullTimeCollegeStudentDependency"],
+  "pe_period_month": null
+}

--- a/programs/programs/config/data/tx_snap_config.json
+++ b/programs/programs/config/data/tx_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "tx",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "TxStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/tx_tanf_config.json
+++ b/programs/programs/config/data/tx_tanf_config.json
@@ -1,0 +1,20 @@
+{
+  "program": "tanf",
+  "state": "tx",
+  "pe_name": "tx_tanf",
+  "pe_entity": "spm_unit",
+  "state_dependency": "TxStateCodeDependency",
+  "extends": "tanf",
+  "additional_inputs": [
+    "TaxUnitDependentDependency",
+    "EmploymentIncomeDependency",
+    "SelfEmploymentIncomeDependency",
+    "RentalIncomeDependency",
+    "PensionIncomeDependency",
+    "SocialSecurityIncomeDependency",
+    "UnemploymentIncomeDependency",
+    "InvestmentIncomeDependency",
+    "RetirementDistributionsDependency"
+  ],
+  "pe_period_month": null
+}

--- a/programs/programs/config/data/wa_snap_config.json
+++ b/programs/programs/config/data/wa_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "wa",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "WaStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/programs/programs/config/data/wa_tanf_config.json
+++ b/programs/programs/config/data/wa_tanf_config.json
@@ -1,0 +1,18 @@
+{
+  "program": "tanf",
+  "state": "wa",
+  "pe_name": "wa_tanf",
+  "pe_entity": "spm_unit",
+  "state_dependency": "WaStateCodeDependency",
+  "extends": "tanf",
+  "additional_inputs": [
+    "PregnancyDependency",
+    "EmploymentIncomeBeforeLsrDependency",
+    "SelfEmploymentIncomeBeforeLsrDependency",
+    "SocialSecurityIncomeDependency",
+    "UnemploymentIncomeDependency",
+    "CashAssetsDependency",
+    "WaShowAllCashAssistanceProgramsDependency"
+  ],
+  "pe_period_month": null
+}

--- a/programs/programs/config/loader.py
+++ b/programs/programs/config/loader.py
@@ -1,0 +1,157 @@
+"""
+Loads config-layer JSON (schemas/config_layer.schema.json, Phase 1) into a
+frozen ConfigLayer object, per DECISIONS.md D-011: parsed once, in memory,
+at whatever module's import time performs registration (see
+factories/calculator_factory.py) -- no DB table.
+
+additional_inputs/state_dependency are bare dependency-class name strings in
+the JSON (e.g. "CoStateCodeDependency"); resolve_dependency_class() resolves
+them against the four existing dependency modules
+(policyengine/calculators/dependencies/{household,member,spm,tax}.py).
+
+The schema carries no pe_outputs field (checked directly against
+config_layer.schema.json) -- build_output_dependency() derives a minimal
+output-only dependency class from pe_entity + pe_name instead, mirroring
+dependency.spm.Snap's shape (a plain unit subclass with `field` set) without
+reusing Snap itself, since Snap's real value() encodes SNAP-specific
+already-reported-benefit logic this generic derivation has no reason to
+copy.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from programs.programs.policyengine.calculators.dependencies import household, member, spm, tax
+from programs.programs.policyengine.calculators.dependencies.base import (
+    Household,
+    Member,
+    PolicyEngineScreenInput,
+    SpmUnit,
+    TaxUnit,
+)
+
+
+class ConfigLoadError(Exception):
+    """Malformed config-layer JSON or an invalid extends/federal_config pairing."""
+
+
+class UnknownDependencyClassError(ConfigLoadError):
+    """additional_inputs/state_dependency names a class that doesn't exist."""
+
+
+class UnsupportedPeEntityError(ConfigLoadError):
+    """pe_entity is 'family'/'marital_unit' -- no base dependency class exists
+    for either yet (dependencies/base.py only defines Household/TaxUnit/
+    SpmUnit/Member). Not needed by SNAP/TANF; flagged as a known gap in
+    ROADMAP.md, not fixed here."""
+
+
+_ENTITY_BASE_CLASS: dict[str, type[PolicyEngineScreenInput]] = {
+    "spm_unit": SpmUnit,
+    "tax_unit": TaxUnit,
+    "person": Member,
+    "household": Household,
+}
+
+
+def _build_dependency_registry() -> dict[str, type[PolicyEngineScreenInput]]:
+    registry: dict[str, type[PolicyEngineScreenInput]] = {}
+    for module in (household, member, spm, tax):
+        for name, obj in vars(module).items():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, PolicyEngineScreenInput)
+                and obj is not PolicyEngineScreenInput
+            ):
+                registry[name] = obj
+    return registry
+
+
+# Built once, at import time of this module. This is a name->class lookup
+# over four already-explicitly-imported dependency modules -- not calculator
+# auto-discovery (D-001 is unaffected; nothing here scans directories or
+# discovers program/calculator registrations).
+_DEPENDENCY_REGISTRY = _build_dependency_registry()
+
+
+def resolve_dependency_class(name: str) -> type[PolicyEngineScreenInput]:
+    try:
+        return _DEPENDENCY_REGISTRY[name]
+    except KeyError:
+        raise UnknownDependencyClassError(name) from None
+
+
+@functools.lru_cache(maxsize=None)
+def build_output_dependency(pe_entity: str, pe_name: str) -> type[PolicyEngineScreenInput]:
+    """A pure pass-through program's output dependency is always just "the
+    field named pe_name, on the entity's own unit" -- derived rather than
+    configured, since the config schema carries no pe_outputs field."""
+    base_cls = _ENTITY_BASE_CLASS.get(pe_entity)
+    if base_cls is None:
+        raise UnsupportedPeEntityError(pe_entity)
+    class_name = f"_Output_{pe_entity}_{pe_name}"
+    return type(class_name, (base_cls,), {"field": pe_name})
+
+
+@dataclass(frozen=True)
+class ConfigLayer:
+    """Immutable once loaded -- a new, deliberate hardening this phase
+    introduces (see plan Context: existing calculators are ordinary mutable
+    ProgramCalculator subclasses; there is no precedent for immutability,
+    only for the attribute-access style this mirrors)."""
+
+    program: str
+    state: str
+    pe_name: str
+    pe_entity: str
+    pe_period_month: Optional[str]
+    pe_inputs: list[type[PolicyEngineScreenInput]] = field(default_factory=list)
+    pe_outputs: list[type[PolicyEngineScreenInput]] = field(default_factory=list)
+
+
+def load_config_layer(config: dict, *, federal_config: Optional[dict] = None) -> ConfigLayer:
+    extends = config["extends"]
+
+    if extends is not None:
+        if federal_config is None:
+            raise ConfigLoadError(
+                f"{config['program']}/{config['state']}: extends={extends!r} but no federal_config given"
+            )
+        if federal_config.get("extends") is not None:
+            # D-006: chains are capped at one level.
+            raise ConfigLoadError(
+                "federal_config itself has a non-null extends -- chains beyond one level are not supported"
+            )
+        if federal_config["program"] != extends:
+            raise ConfigLoadError(
+                f"federal_config.program={federal_config['program']!r} does not match extends={extends!r}"
+            )
+        base_inputs = [resolve_dependency_class(n) for n in federal_config["additional_inputs"]]
+    else:
+        if federal_config is not None:
+            raise ConfigLoadError("federal_config given but extends is null")
+        base_inputs = []
+
+    own_inputs = [resolve_dependency_class(n) for n in config["additional_inputs"]]
+    state_dep = [resolve_dependency_class(config["state_dependency"])] if config["state_dependency"] else []
+
+    return ConfigLayer(
+        program=config["program"],
+        state=config["state"],
+        pe_name=config["pe_name"],
+        pe_entity=config["pe_entity"],
+        pe_period_month=config["pe_period_month"],
+        pe_inputs=[*base_inputs, *own_inputs, *state_dep],
+        pe_outputs=[build_output_dependency(config["pe_entity"], config["pe_name"])],
+    )
+
+
+def load_config_layer_from_file(path: str | Path, *, federal_path: Optional[str | Path] = None) -> ConfigLayer:
+    config = json.loads(Path(path).read_text())
+    federal_config = json.loads(Path(federal_path).read_text()) if federal_path is not None else None
+    return load_config_layer(config, federal_config=federal_config)

--- a/programs/programs/config/tests/test_loader.py
+++ b/programs/programs/config/tests/test_loader.py
@@ -1,0 +1,145 @@
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from programs.programs.config.loader import (
+    ConfigLoadError,
+    UnknownDependencyClassError,
+    UnsupportedPeEntityError,
+    load_config_layer,
+    load_config_layer_from_file,
+)
+from programs.programs.policyengine.calculators.dependencies.household import CoStateCodeDependency
+from programs.programs.policyengine.calculators.dependencies.member import AgeDependency
+
+EXAMPLES_DIR = settings.BASE_DIR / "schemas" / "examples"
+
+
+class TestLoadConfigLayerFederal(SimpleTestCase):
+    def test_federal_config_with_no_extends_resolves_additional_inputs(self):
+        config = load_config_layer_from_file(EXAMPLES_DIR / "snap_federal.json")
+
+        self.assertEqual(config.program, "snap")
+        self.assertEqual(config.state, "federal")
+        self.assertEqual(config.pe_name, "snap")
+        self.assertEqual(config.pe_entity, "spm_unit")
+        self.assertEqual(config.pe_period_month, "01")
+        self.assertIn(AgeDependency, config.pe_inputs)
+        self.assertEqual(len(config.pe_inputs), 22)
+
+
+class TestLoadConfigLayerState(SimpleTestCase):
+    def test_state_config_extends_federal_and_appends_state_dependency(self):
+        config = load_config_layer_from_file(
+            EXAMPLES_DIR / "co_snap_config.json",
+            federal_path=EXAMPLES_DIR / "snap_federal.json",
+        )
+
+        self.assertEqual(config.state, "co")
+        # base (federal, 22 entries) + own additional_inputs (0) + state_dependency (1)
+        self.assertEqual(len(config.pe_inputs), 23)
+        self.assertEqual(config.pe_inputs[-1], CoStateCodeDependency)
+
+    def test_extends_without_federal_config_raises(self):
+        with self.assertRaises(ConfigLoadError):
+            load_config_layer_from_file(EXAMPLES_DIR / "co_snap_config.json")
+
+    def test_federal_config_program_mismatch_raises(self):
+        state_config = {
+            "program": "snap",
+            "state": "co",
+            "pe_name": "snap",
+            "pe_entity": "spm_unit",
+            "state_dependency": None,
+            "extends": "snap",
+            "additional_inputs": [],
+            "pe_period_month": None,
+        }
+        wrong_federal = {
+            "program": "tanf",
+            "state": "federal",
+            "pe_name": "tanf",
+            "pe_entity": "spm_unit",
+            "state_dependency": None,
+            "extends": None,
+            "additional_inputs": [],
+            "pe_period_month": None,
+        }
+
+        with self.assertRaises(ConfigLoadError):
+            load_config_layer(state_config, federal_config=wrong_federal)
+
+    def test_federal_config_with_non_null_extends_raises(self):
+        state_config = {
+            "program": "snap",
+            "state": "co",
+            "pe_name": "snap",
+            "pe_entity": "spm_unit",
+            "state_dependency": None,
+            "extends": "snap",
+            "additional_inputs": [],
+            "pe_period_month": None,
+        }
+        two_level_federal = {
+            "program": "snap",
+            "state": "federal",
+            "pe_name": "snap",
+            "pe_entity": "spm_unit",
+            "state_dependency": None,
+            "extends": "something_else",
+            "additional_inputs": [],
+            "pe_period_month": None,
+        }
+
+        with self.assertRaises(ConfigLoadError):
+            load_config_layer(state_config, federal_config=two_level_federal)
+
+
+class TestLoadConfigLayerOutputs(SimpleTestCase):
+    def test_pe_outputs_is_derived_from_entity_and_name(self):
+        config = load_config_layer(
+            {
+                "program": "tanf",
+                "state": "federal",
+                "pe_name": "tanf",
+                "pe_entity": "spm_unit",
+                "state_dependency": None,
+                "extends": None,
+                "additional_inputs": [],
+                "pe_period_month": None,
+            }
+        )
+
+        self.assertEqual(len(config.pe_outputs), 1)
+        output_cls = config.pe_outputs[0]
+        self.assertEqual(output_cls.field, "tanf")
+        self.assertEqual(output_cls.unit, "spm_units")
+
+    def test_unknown_dependency_class_name_raises(self):
+        with self.assertRaises(UnknownDependencyClassError):
+            load_config_layer(
+                {
+                    "program": "tanf",
+                    "state": "federal",
+                    "pe_name": "tanf",
+                    "pe_entity": "spm_unit",
+                    "state_dependency": None,
+                    "extends": None,
+                    "additional_inputs": ["ThisClassDoesNotExist"],
+                    "pe_period_month": None,
+                }
+            )
+
+    def test_unsupported_pe_entity_raises(self):
+        with self.assertRaises(UnsupportedPeEntityError):
+            load_config_layer(
+                {
+                    "program": "x",
+                    "state": "federal",
+                    "pe_name": "x",
+                    "pe_entity": "family",
+                    "state_dependency": None,
+                    "extends": None,
+                    "additional_inputs": [],
+                    "pe_period_month": None,
+                }
+            )

--- a/programs/programs/data/loader.py
+++ b/programs/programs/data/loader.py
@@ -1,0 +1,43 @@
+"""
+Loads data-layer JSON (schemas/data_layer.schema.json, Phase 1) into a
+frozen DataLayer object, per DECISIONS.md D-011: in memory, no DB table.
+
+Not needed by Phase 4's pure pass-through SNAP pilot (the schema's own
+description says as much), but built now since Phase 1 already produced
+real, schema-valid fixtures (schemas/examples/wic_co.json, wic_nc.json) to
+validate this loader against.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SourceInfo:
+    status: str  # "cited" | "unsourced" | "guessed" (DECISIONS.md D-005)
+    citation: Optional[str]
+
+
+@dataclass(frozen=True)
+class DataLayer:
+    program: str
+    state: str
+    category_amounts: dict[str, float]
+    source: SourceInfo
+
+
+def load_data_layer(data: dict) -> DataLayer:
+    return DataLayer(
+        program=data["program"],
+        state=data["state"],
+        category_amounts=dict(data["category_amounts"]),
+        source=SourceInfo(status=data["source"]["status"], citation=data["source"]["citation"]),
+    )
+
+
+def load_data_layer_from_file(path: str | Path) -> DataLayer:
+    return load_data_layer(json.loads(Path(path).read_text()))

--- a/programs/programs/data/tests/test_loader.py
+++ b/programs/programs/data/tests/test_loader.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from programs.programs.data.loader import load_data_layer_from_file
+
+EXAMPLES_DIR = settings.BASE_DIR / "schemas" / "examples"
+
+
+class TestLoadDataLayer(SimpleTestCase):
+    def test_loads_unsourced_wic_co(self):
+        data = load_data_layer_from_file(EXAMPLES_DIR / "wic_co.json")
+
+        self.assertEqual(data.program, "wic")
+        self.assertEqual(data.state, "co")
+        self.assertEqual(data.category_amounts["INFANT"], 130)
+        self.assertEqual(data.source.status, "unsourced")
+        self.assertIsNone(data.source.citation)
+
+    def test_loads_guessed_wic_nc(self):
+        data = load_data_layer_from_file(EXAMPLES_DIR / "wic_nc.json")
+
+        self.assertEqual(data.state, "nc")
+        self.assertEqual(data.source.status, "guessed")
+        self.assertIsNone(data.source.citation)

--- a/programs/programs/factories/calculator_factory.py
+++ b/programs/programs/factories/calculator_factory.py
@@ -1,0 +1,58 @@
+"""
+CalculatorFactory: explicit registration (DECISIONS.md D-001 -- one
+.register() call per program, never auto-discovered).
+
+Registry *values* are plain callables satisfying exactly
+Calculator(screen, program, missing_dependencies) -- the real call site
+(screener/views.py:424) -- with config/benefit_data already bound.
+as_dict() produces something directly mergeable into a co_spm_calculators-
+shaped dict (co/pe/__init__.py:28-31) for a future phase to fold into
+registry.py, with zero changes needed to registry.py/views.py themselves.
+
+functools.partial, not a dynamically-built type() subclass: the real call
+site never does isinstance()/issubclass() on the result (confirmed via
+direct grep of policy_engine.py/views.py/registry.py -- see DECISIONS.md
+D-012), so a bare callable with the right signature is all that's required.
+A synthesized subclass would need a made-up class name purely for cosmetics
+and would put config/data back onto a class attribute -- exactly what D-012
+moved away from.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, Optional
+
+from programs.programs.calculators.base import ConfigurableCalculator
+from programs.programs.config.loader import ConfigLayer
+from programs.programs.data.loader import DataLayer
+
+
+class DuplicateRegistrationError(Exception):
+    pass
+
+
+class CalculatorFactory:
+    def __init__(self):
+        self._registry: dict[str, Callable[..., ConfigurableCalculator]] = {}
+
+    def register(
+        self,
+        key: str,
+        config: ConfigLayer,
+        *,
+        calculator_cls: type[ConfigurableCalculator] = ConfigurableCalculator,
+        benefit_data: Optional[DataLayer] = None,
+    ) -> Callable[..., ConfigurableCalculator]:
+        if key in self._registry:
+            raise DuplicateRegistrationError(key)
+
+        bound = functools.partial(calculator_cls, config=config, benefit_data=benefit_data)
+        self._registry[key] = bound
+        return bound
+
+    def get(self, key: str) -> Callable[..., ConfigurableCalculator]:
+        return self._registry[key]
+
+    def as_dict(self) -> dict[str, Callable[..., ConfigurableCalculator]]:
+        return dict(self._registry)

--- a/programs/programs/factories/snap_registration.py
+++ b/programs/programs/factories/snap_registration.py
@@ -1,0 +1,118 @@
+"""
+Real (non-test) registration of per-state SNAP calculators through
+CalculatorFactory + SnapCalculator, per DECISIONS.md D-013. Same shape as
+factories/tests/toy_registration.py, but not fictional and not under
+tests/ -- each *SnapCalculator is a genuine candidate for Phase 4's
+parallel verification against its real old calculator (co/pe/spm.py,
+wa/pe/spm.py, ...). CO SNAP's parity run is human-confirmed (ROADMAP.md
+Phase 4, 2026-07-13); WA is the second state, picked specifically to
+prove the pattern against a real state-specific mechanism (the BBCE
+net-income waiver -- confirmed to live entirely inside PolicyEngine
+itself, not in WaSnap's Python, during the Phase 4 audit).
+
+TX is the third state -- confirmed pure pass-through during the Phase 4
+audit (no state-specific mechanism comparable to WA's BBCE waiver), so its
+parity harness reuses the same generic scenario shapes CO's does rather
+than adding a state-specific stress scenario.
+
+NC is the fourth state. NcSnap (nc/pe/spm.py) is pure pass-through per the
+Phase 4 audit, same shape as TX/WA/CO's Snap subclasses -- but NC has its
+own real state-specific mechanism worth stressing: "Expanded (200%)
+Categorical Eligibility" (NC FNS Manual Section 220, Change #02-2024,
+2024-10-01, ncdhhs.gov), under which a household passing the 200% FPL
+gross-income test is exempt from *both* the gross and net income limits
+tests (Section 220.05.A.2) -- independently derived, NC's own equivalent of
+WA's BBCE net-income waiver, not copied from WA's fixture/spec.
+
+MA is the fifth state. MaSnap (ma/pe/spm.py) is pure pass-through per the
+Phase 4 audit, but MA has its own real, different-shaped state-specific
+mechanism: broad-based categorical eligibility (BBCE) at 200% FPL gross
+income (106 CMR 364.976, "Gross Monthly Categorical Eligibility Income
+Standards", mass.gov) -- but unlike WA's/NC's full gross+net waiver, MA's
+BBCE raises the gross ceiling only; the net income test at 100% FPL still
+applies to the general (non-elderly/disabled, non-cash-assistance)
+population (Massachusetts Legal Help, "68. Is there a gross income test for
+SNAP?", masslegalhelp.org). Independently researched and stress-tested
+rather than assumed to generalize from WA/NC's shape.
+
+KS is the sixth state. KsSnap (ks/pe/spm.py) is pure pass-through per the
+Phase 4 audit. Kansas is confirmed one of only 7 states that has NOT
+adopted BBCE at all (CBPP, "Over 40 States Use Broad-Based Categorical
+Eligibility", cbpp.org/charts/over-40-states-use-broad-based-categorical-eligibility)
+-- straight federal 130% FPL gross test, standard net test, standard asset
+test, no state-specific mechanism comparable to WA's/NC's/MA's BBCE
+variants. Same reasoning as TX: scenarios reuse the generic shapes rather
+than adding a state-specific stress case.
+
+IL is the seventh state -- the last of the original 7 audited states,
+deliberately held back for this demo (not a blocker). IlSnap (il/pe/spm.py)
+is pure pass-through per the Phase 4 audit, same shape as WA/TX/NC/MA/KS.
+IL's own state-specific mechanism (BBCE) was researched directly against
+PolicyEngine's real parameters, not a secondary source, since two secondary
+sources disagreed with each other (165% vs. 200% FPL): PolicyEngine's own
+`gov/hhs/tanf/non_cash/income_limit/gross.yaml` sets IL's BBCE gross
+ceiling at 165% FPL (IDHS MR #15.23 / PA 099-0170), `net_applies/
+non_hheod.yaml` waives the net income test for IL, and `asset_limit.yaml`
+sets IL's asset limit to `.inf` (no asset test) -- a full gross+net+asset
+waiver, the same shape as WA/NC/TX's BBCE, not MA's partial (gross-only)
+pattern.
+
+Deliberately not imported by co/pe/__init__.py, wa/pe/__init__.py,
+tx/pe/__init__.py, nc/pe/__init__.py, ma/pe/__init__.py, ks/pe/__init__.py,
+il/pe/__init__.py, or any real registry yet -- wiring this into production
+orchestration is a separate, later ROADMAP checklist item.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+
+from programs.programs.calculators.snap import SnapCalculator
+from programs.programs.config.loader import load_config_layer_from_file
+from programs.programs.factories.calculator_factory import CalculatorFactory
+
+CONFIG_DATA_DIR = settings.BASE_DIR / "programs" / "programs" / "config" / "data"
+
+snap_factory = CalculatorFactory()
+
+co_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "co_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+CoSnapCalculator = snap_factory.register("co_snap", co_snap_config, calculator_cls=SnapCalculator)
+
+wa_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "wa_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+WaSnapCalculator = snap_factory.register("wa_snap", wa_snap_config, calculator_cls=SnapCalculator)
+
+tx_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "tx_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+TxSnapCalculator = snap_factory.register("tx_snap", tx_snap_config, calculator_cls=SnapCalculator)
+
+nc_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "nc_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+NcSnapCalculator = snap_factory.register("nc_snap", nc_snap_config, calculator_cls=SnapCalculator)
+
+ma_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "ma_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+MaSnapCalculator = snap_factory.register("ma_snap", ma_snap_config, calculator_cls=SnapCalculator)
+
+ks_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "ks_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+KsSnapCalculator = snap_factory.register("ks_snap", ks_snap_config, calculator_cls=SnapCalculator)
+
+il_snap_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "il_snap_config.json",
+    federal_path=CONFIG_DATA_DIR / "snap_federal.json",
+)
+IlSnapCalculator = snap_factory.register("il_snap", il_snap_config, calculator_cls=SnapCalculator)

--- a/programs/programs/factories/tanf_registration.py
+++ b/programs/programs/factories/tanf_registration.py
@@ -1,0 +1,111 @@
+"""
+Real (non-test) registration of per-state TANF calculators through
+CalculatorFactory, mirroring snap_registration.py's shape (D-013) with one
+real difference: **no bespoke TanfCalculator subclass exists, or is needed**.
+
+Verified directly, not assumed: federal `Tanf` (federal/pe/spm.py) does not
+override `household_value()`/`pe_output_period` the way `Snap` does, and
+none of the five existing state `XTanf(Tanf)` subclasses (CO/IL/NC/TX/WA)
+override it either -- every one of them relies on the plain default
+`PolicyEngineCalulator.household_value()` (`return int(self.get_variable())`,
+reading at the calculator's configured period, no monthly output-period
+split). `ConfigurableCalculator.household_value()`'s own default (Phase 3)
+already does the equivalent thing (`self.client.get_spm_value(self.config.
+pe_name)`, no period override, defaulting to `self.period`) -- confirmed by
+directly comparing both implementations side by side, not by running
+anything. So states register straight against `ConfigurableCalculator`
+(the `CalculatorFactory.register()` default), no `calculator_cls=` needed.
+
+MA is a real, separate exception, not a hidden gap in this pattern: MA's
+real cash-assistance programs (`MaTafdc`/`MaEaedc`, ma/pe/spm.py) are their
+own distinct PolicyEngine variables (`ma_tafdc`/`ma_eaedc`), not the
+`{state}_tanf` shape federal `Tanf` composes -- confirmed against
+PolicyEngine's own `gov/hhs/tanf/cash/tanf.py` dispatch list, which buckets
+`ma_tafdc` under "non-standard program names," not the standard `{st}_tanf`
+bucket CO/IL/NC/TX/WA (and Kansas's real `ks_tanf`) fall into. MA is
+deliberately out of scope for this generic architecture; it would need its
+own top-level (non-`extends`) config entries if ever added.
+
+KS has no TANF calculator in this codebase, or in real upstream
+MyFriendBen/benefits-api, at all today (checked directly) -- but
+PolicyEngine's own `ks_tanf` variable is a complete, real implementation in
+the standard `{st}_tanf` bucket, with genuine county-group-based payment
+tiers and KS-specific income-counting rules (KEESM 4113/5110, K.A.R.
+30-4-101). Adding KS is a separate, later decision, deliberately not acted
+on here -- unlike TX below, KS has no existing calculator to build a
+parity check against at all, so it isn't the easiest next state to confirm
+this architecture with.
+
+TX is the first real state registered here. TxTanf (tx/pe/spm.py) is a
+pure pass-through -- unlike CO/IL/NC's already-flagged countable-income
+override (D-020, RISKS.md), TxTanf supplies raw per-person income
+(irs_gross_income) and a dependents flag, and lets PolicyEngine's own
+tx_tanf formula compute the deductions/disregards itself (checked
+directly, not assumed -- confirmed by direct reading, not by copying the
+CO/IL/NC pattern). That makes it the safest first state to confirm this
+architecture against: nothing here should diverge, so a parity pass is a
+real (not merely lucky) confirmation, same discipline as D-017 checking
+each SNAP state directly rather than assuming precedent generalizes.
+
+WA is the second state registered here (D-022 -- swapped in for the
+original CO demo pick, since CO's shipped calculator carries D-020's
+countable-income divergence and would fail parity today, an expected
+mismatch rather than a real confirmation). WaTanf (wa/pe/spm.py) is
+confirmed pure pass-through the same way TxTanf is: the class defines only
+pe_name/pe_inputs/pe_outputs, zero method overrides (no household_value()
+override, no can_calc() override) -- checked directly, not assumed from
+its spec.md's prose describing "the calculator implements this in full,"
+which describes PolicyEngine's own wa_tanf formula's behavior, not custom
+Python in this codebase. WaTanf's pe_inputs list is simply longer than
+TxTanf's (PregnancyDependency, EmploymentIncomeBeforeLsrDependency,
+SelfEmploymentIncomeBeforeLsrDependency, SocialSecurityIncomeDependency,
+UnemploymentIncomeDependency, CashAssetsDependency,
+WaShowAllCashAssistanceProgramsDependency) because wa_tanf's real PE
+formula needs more inputs than tx_tanf's does -- more inputs, not more
+logic. `dependency.spm.WaTanf` (the output dependency WaTanf reads) is
+itself trivial (`field = "wa_tanf"`, no value() override), confirming the
+generic output derivation `build_output_dependency()` already produces is
+equivalent.
+
+Deliberately not imported by any real state's pe/__init__.py yet -- same
+deferred-wiring posture as snap_registration.py (D-013).
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+
+from programs.programs.config.loader import load_config_layer_from_file
+from programs.programs.factories.calculator_factory import CalculatorFactory
+
+CONFIG_DATA_DIR = settings.BASE_DIR / "programs" / "programs" / "config" / "data"
+
+tanf_factory = CalculatorFactory()
+
+# Loaded standalone (no federal_path -- this *is* the federal config, same
+# call shape config/tests/test_loader.py already uses for snap_federal.json)
+# purely so a malformed tanf_federal.json fails loud at import time, before
+# any real state tries to extend it.
+tanf_federal_config = load_config_layer_from_file(CONFIG_DATA_DIR / "tanf_federal.json")
+
+tx_tanf_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "tx_tanf_config.json",
+    federal_path=CONFIG_DATA_DIR / "tanf_federal.json",
+)
+TxTanfCalculator = tanf_factory.register("tx_tanf", tx_tanf_config)
+
+wa_tanf_config = load_config_layer_from_file(
+    CONFIG_DATA_DIR / "wa_tanf_config.json",
+    federal_path=CONFIG_DATA_DIR / "tanf_federal.json",
+)
+WaTanfCalculator = tanf_factory.register("wa_tanf", wa_tanf_config)
+
+# Remaining states (KS, or CO/IL/NC once D-020's discrepancy question is
+# resolved) are a separate, later decision -- see module docstring. A
+# future state adds:
+#
+#   xx_tanf_config = load_config_layer_from_file(
+#       CONFIG_DATA_DIR / "xx_tanf_config.json",
+#       federal_path=CONFIG_DATA_DIR / "tanf_federal.json",
+#   )
+#   XxTanfCalculator = tanf_factory.register("xx_tanf", xx_tanf_config)

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[co-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[co-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3281": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3281"]}}, "families":
+      {"family": {"members": ["3281"]}}, "households": {"household": {"members": ["3281"],
+      "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit": {"members": ["3281"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 10800.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3281": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3281"]}},
+        "families": {"family": {"members": ["3281"]}}, "households": {"household":
+        {"members": ["3281"], "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit":
+        {"members": ["3281"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 10800.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 134.4}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:20:17 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 8580d890-3404-4bbb-bd5a-c92616777d81
+      traceparent:
+      - 00-348580b6a710234ff09b61eb4f01a385-648a1818fa807236-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[co-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[co-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3282": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3282"]}}, "families":
+      {"family": {"members": ["3282"]}}, "households": {"household": {"members": ["3282"],
+      "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit": {"members": ["3282"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 50400.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3282": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3282"]}},
+        "families": {"family": {"members": ["3282"]}}, "households": {"household":
+        {"members": ["3282"], "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit":
+        {"members": ["3282"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 50400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:20:18 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - fe9556ee-c108-454b-90d3-df065acb3070
+      traceparent:
+      - 00-f6d71db7bb79d4a668d1eacaacfaa0f3-618b344ef70ae4da-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[co-elderly_member].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[co-elderly_member].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3269": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3269"]}}, "families":
+      {"family": {"members": ["3269"]}}, "households": {"household": {"members": ["3269"],
+      "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit": {"members": ["3269"],
+      "snap_unearned_income": {"2024": 14400.0}, "snap_earned_income": {"2024": 0.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 10800}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3269": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3269"]}},
+        "families": {"family": {"members": ["3269"]}}, "households": {"household":
+        {"members": ["3269"], "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit":
+        {"members": ["3269"], "snap_unearned_income": {"2024": 14400.0}, "snap_earned_income":
+        {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 10800}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 110.09999}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1326'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:15 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - af939a6a-83b5-47cf-ad06-19000cf0b9d3
+      traceparent:
+      - 00-642dedb4000305f73d2a727f1d47dfce-2fe38f482a1d43e9-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[co-household_size_edge].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[co-household_size_edge].yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3264": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 37}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "3265": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "3266": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 10}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "3267": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 7}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3264", "3265",
+      "3266", "3267"]}}, "families": {"family": {"members": ["3264", "3265", "3266",
+      "3267"]}}, "households": {"household": {"members": ["3264", "3265", "3266",
+      "3267"], "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit": {"members":
+      ["3264", "3265", "3266", "3267"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+      {"2024": 26400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+      0}, "housing_cost": {"2024": 18000}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {"3264-3265": {"members":
+      ["3264", "3265"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2514'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3264": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 37}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "3265": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "3266": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 10}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "3267": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 7}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3264", "3265",
+        "3266", "3267"]}}, "families": {"family": {"members": ["3264", "3265", "3266",
+        "3267"]}}, "households": {"household": {"members": ["3264", "3265", "3266",
+        "3267"], "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit": {"members":
+        ["3264", "3265", "3266", "3267"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 26400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 18000}, "has_phone_expense": {"2024":
+        false}, "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 709.0}}},
+        "marital_units": {"3264-3265": {"members": ["3264", "3265"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2641'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:08 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - b76c279d-3473-4090-9ba6-1d59f050f7ab
+      traceparent:
+      - 00-80e143a2706bb4a12addc059a10bba73-bc82730233bcadd2-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[co-non_integer_income].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[co-non_integer_income].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3268": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 41}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3268"]}}, "families":
+      {"family": {"members": ["3268"]}}, "households": {"household": {"members": ["3268"],
+      "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit": {"members": ["3268"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 13644.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 8400}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1197'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3268": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 41}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3268"]}},
+        "families": {"family": {"members": ["3268"]}}, "households": {"household":
+        {"members": ["3268"], "state_code": {"2024": "CO"}}}, "spm_units": {"spm_unit":
+        {"members": ["3268"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 13644.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 8400}, "has_phone_expense": {"2024":
+        false}, "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 180.9}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:10 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 81400daa-8d72-4344-bdac-bea94dd373bf
+      traceparent:
+      - 00-307bff6e1548106b45c710b1803bad9d-9c033e4b2df07a2d-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[il-bbce_net_income_waiver].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[il-bbce_net_income_waiver].yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10048": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 38}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "10049": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 9}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10048", "10049"]}},
+      "families": {"family": {"members": ["10048", "10049"]}}, "households": {"household":
+      {"members": ["10048", "10049"], "state_code": {"2024": "IL"}}}, "spm_units":
+      {"spm_unit": {"members": ["10048", "10049"], "snap_unearned_income": {"2024":
+      0.0}, "snap_earned_income": {"2024": 30000.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+      {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+      "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense": {"2024":
+      0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense":
+      {"2024": 0.0}, "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance":
+      {"2024": 0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1628'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10048": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 38}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "10049": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 9}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10048", "10049"]}},
+        "families": {"family": {"members": ["10048", "10049"]}}, "households": {"household":
+        {"members": ["10048", "10049"], "state_code": {"2024": "IL"}}}, "spm_units":
+        {"spm_unit": {"members": ["10048", "10049"], "snap_unearned_income": {"2024":
+        0.0}, "snap_earned_income": {"2024": 30000.0}, "snap_assets": {"2024": 0},
+        "snap_emergency_allotment": {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense":
+        {"2024": false}, "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 23.28}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1753'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:35 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 6bc26638-1a68-4ca7-abbe-ad2a885e9f3f
+      traceparent:
+      - 00-b834f1008fca44764102632a37f107a7-f428903d8564c270-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[il-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[il-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10040": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 38}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["10040"]}}, "families":
+      {"family": {"members": ["10040"]}}, "households": {"household": {"members":
+      ["10040"], "state_code": {"2024": "IL"}}}, "spm_units": {"spm_unit": {"members":
+      ["10040"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024":
+      10800.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0},
+      "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1199'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10040": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 38}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10040"]}},
+        "families": {"family": {"members": ["10040"]}}, "households": {"household":
+        {"members": ["10040"], "state_code": {"2024": "IL"}}}, "spm_units": {"spm_unit":
+        {"members": ["10040"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 10800.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 134.4}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1323'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:25 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 782cebc2-bce6-4f23-ba43-596f834a4f3b
+      traceparent:
+      - 00-ce71646a2270f295056b73f26f90e293-24664f9164b48493-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[il-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[il-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10041": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 40}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["10041"]}}, "families":
+      {"family": {"members": ["10041"]}}, "households": {"household": {"members":
+      ["10041"], "state_code": {"2024": "IL"}}}, "spm_units": {"spm_unit": {"members":
+      ["10041"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024":
+      38400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0},
+      "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1199'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10041": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 40}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10041"]}},
+        "families": {"family": {"members": ["10041"]}}, "households": {"household":
+        {"members": ["10041"], "state_code": {"2024": "IL"}}}, "spm_units": {"spm_unit":
+        {"members": ["10041"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 38400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:26 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 1cc36de7-a361-4937-b996-a5b524d8e91a
+      traceparent:
+      - 00-1a4eef10e46dfc01c9f635211f698db0-a0a757e5d6c68aa4-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[il-elderly_member].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[il-elderly_member].yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10047": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["10047"]}}, "families":
+      {"family": {"members": ["10047"]}}, "households": {"household": {"members":
+      ["10047"], "state_code": {"2024": "IL"}}}, "spm_units": {"spm_unit": {"members":
+      ["10047"], "snap_unearned_income": {"2024": 13800.0}, "snap_earned_income":
+      {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+      0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1199'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10047": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10047"]}},
+        "families": {"family": {"members": ["10047"]}}, "households": {"household":
+        {"members": ["10047"], "state_code": {"2024": "IL"}}}, "spm_units": {"spm_unit":
+        {"members": ["10047"], "snap_unearned_income": {"2024": 13800.0}, "snap_earned_income":
+        {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+        {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+        {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+        "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+        0.0}, "snap": {"2024-01": 23.28}}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1323'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:34 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 1e2c113d-0271-4450-beb1-b74f2f2ff3c3
+      traceparent:
+      - 00-843f79a2cb8a62895e55e13d3cf98960-8a7ce1c6251976ec-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[il-household_size_edge].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[il-household_size_edge].yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10042": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 43}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "10043": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 42}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "10044": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 14}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "10045": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 11}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "10046": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 6}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10042", "10043",
+      "10044", "10045", "10046"]}}, "families": {"family": {"members": ["10042", "10043",
+      "10044", "10045", "10046"]}}, "households": {"household": {"members": ["10042",
+      "10043", "10044", "10045", "10046"], "state_code": {"2024": "IL"}}}, "spm_units":
+      {"spm_unit": {"members": ["10042", "10043", "10044", "10045", "10046"], "snap_unearned_income":
+      {"2024": 0.0}, "snap_earned_income": {"2024": 31200.0}, "snap_assets": {"2024":
+      0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense":
+      {"2024": false}, "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+      {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+      0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+      0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": null}}}, "marital_units":
+      {"10042-10043": {"members": ["10042", "10043"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2964'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10042": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 43}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "10043": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 42}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "10044": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 14}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "10045": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 11}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "10046": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 6}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["10042", "10043",
+        "10044", "10045", "10046"]}}, "families": {"family": {"members": ["10042",
+        "10043", "10044", "10045", "10046"]}}, "households": {"household": {"members":
+        ["10042", "10043", "10044", "10045", "10046"], "state_code": {"2024": "IL"}}},
+        "spm_units": {"spm_unit": {"members": ["10042", "10043", "10044", "10045",
+        "10046"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024":
+        31200.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+        {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+        {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+        "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+        0.0}, "snap": {"2024-01": 604.19995}}}, "marital_units": {"10042-10043": {"members":
+        ["10042", "10043"]}}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '3096'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:33 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 3a4c3481-b9ba-4ffd-8228-ca4f1aff68b8
+      traceparent:
+      - 00-0471091808cf615e3ed2054241dd0774-4a7f5c76cdb1474b-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ks-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ks-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5562": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 27}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5562"]}}, "families":
+      {"family": {"members": ["5562"]}}, "households": {"household": {"members": ["5562"],
+      "state_code": {"2024": "KS"}}}, "spm_units": {"spm_unit": {"members": ["5562"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 10200.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5562": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 27}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5562"]}},
+        "families": {"family": {"members": ["5562"]}}, "households": {"household":
+        {"members": ["5562"], "state_code": {"2024": "KS"}}}, "spm_units": {"spm_unit":
+        {"members": ["5562"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 10200.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 146.4}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:23 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 0b106583-c6ed-4410-b67a-45e3f451d0af
+      traceparent:
+      - 00-83f9b1fd40a8799984834848446b4c31-d967b17b2905b5ea-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ks-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ks-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5563": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 33}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5563"]}}, "families":
+      {"family": {"members": ["5563"]}}, "households": {"household": {"members": ["5563"],
+      "state_code": {"2024": "KS"}}}, "spm_units": {"spm_unit": {"members": ["5563"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 46800.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5563": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 33}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5563"]}},
+        "families": {"family": {"members": ["5563"]}}, "households": {"household":
+        {"members": ["5563"], "state_code": {"2024": "KS"}}}, "spm_units": {"spm_unit":
+        {"members": ["5563"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 46800.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:24 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - d62152ca-3c4a-4dde-a95e-e225fd93f655
+      traceparent:
+      - 00-2f992045e899cd85c2ff7bce49dcedad-3fd6bd3c6b0df7ea-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ks-elderly_member].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ks-elderly_member].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5567": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 72}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5567"]}}, "families":
+      {"family": {"members": ["5567"]}}, "households": {"household": {"members": ["5567"],
+      "state_code": {"2024": "KS"}}}, "spm_units": {"spm_unit": {"members": ["5567"],
+      "snap_unearned_income": {"2024": 13200.0}, "snap_earned_income": {"2024": 0.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 9600}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1197'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5567": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 72}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5567"]}},
+        "families": {"family": {"members": ["5567"]}}, "households": {"household":
+        {"members": ["5567"], "state_code": {"2024": "KS"}}}, "spm_units": {"spm_unit":
+        {"members": ["5567"], "snap_unearned_income": {"2024": 13200.0}, "snap_earned_income":
+        {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 9600}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 125.09999}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1325'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:26 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 2eb7fca3-daf8-4e23-8924-a5ab718ef1fd
+      traceparent:
+      - 00-574d1cc79ebe37138e6cbc7b0f0486fc-33ebdd79c57ba6ed-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ks-household_size_edge].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ks-household_size_edge].yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5564": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 36}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "5565": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 10}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "5566": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 7}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5564", "5565",
+      "5566"]}}, "families": {"family": {"members": ["5564", "5565", "5566"]}}, "households":
+      {"household": {"members": ["5564", "5565", "5566"], "state_code": {"2024": "KS"}}},
+      "spm_units": {"spm_unit": {"members": ["5564", "5565", "5566"], "snap_unearned_income":
+      {"2024": 0.0}, "snap_earned_income": {"2024": 22800.0}, "snap_assets": {"2024":
+      0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost": {"2024": 13200},
+      "has_phone_expense": {"2024": false}, "has_heating_cooling_expense": {"2024":
+      false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses": {"2024":
+      0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees":
+      {"2024": 0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": null}}},
+      "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2047'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5564": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 36}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "5565": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 10}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "5566": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 7}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5564", "5565",
+        "5566"]}}, "families": {"family": {"members": ["5564", "5565", "5566"]}},
+        "households": {"household": {"members": ["5564", "5565", "5566"], "state_code":
+        {"2024": "KS"}}}, "spm_units": {"spm_unit": {"members": ["5564", "5565", "5566"],
+        "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 22800.0},
+        "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+        {"2024": 13200}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+        {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+        {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+        "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+        0.0}, "snap": {"2024-01": 501.09998}}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2177'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:25 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 9e22d82f-1172-49d5-9059-aff93dd99d14
+      traceparent:
+      - 00-0b6b36f2d19aa778e517b5f355e97372-72c3b43e868e7d13-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ma-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ma-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5555": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 29}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5555"]}}, "families":
+      {"family": {"members": ["5555"]}}, "households": {"household": {"members": ["5555"],
+      "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit": {"members": ["5555"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 10200.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5555": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 29}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5555"]}},
+        "families": {"family": {"members": ["5555"]}}, "households": {"household":
+        {"members": ["5555"], "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit":
+        {"members": ["5555"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 10200.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 291.0}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:15 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - a9bf0e77-4825-4dca-b6b1-c05817a95d27
+      traceparent:
+      - 00-0ff9b0138dd9bb459e05faa96545b1fd-be515d4f44cff8e8-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ma-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ma-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5556": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 30}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5556"]}}, "families":
+      {"family": {"members": ["5556"]}}, "households": {"household": {"members": ["5556"],
+      "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit": {"members": ["5556"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 46800.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5556": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 30}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5556"]}},
+        "families": {"family": {"members": ["5556"]}}, "households": {"household":
+        {"members": ["5556"], "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit":
+        {"members": ["5556"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 46800.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:16 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 7faea4a5-a34a-40bd-b819-4887d0d76c28
+      traceparent:
+      - 00-f9db10ac1220cc42729907c26da14f75-a469d966ed42d920-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ma-elderly_member].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ma-elderly_member].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5560": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 71}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5560"]}}, "families":
+      {"family": {"members": ["5560"]}}, "households": {"household": {"members": ["5560"],
+      "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit": {"members": ["5560"],
+      "snap_unearned_income": {"2024": 12000.0}, "snap_earned_income": {"2024": 0.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 11400}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5560": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 71}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5560"]}},
+        "families": {"family": {"members": ["5560"]}}, "households": {"household":
+        {"members": ["5560"], "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit":
+        {"members": ["5560"], "snap_unearned_income": {"2024": 12000.0}, "snap_earned_income":
+        {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 11400}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 291.0}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1322'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:22 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 08c1aa4f-6973-4c06-8f0e-8fc8596969f3
+      traceparent:
+      - 00-709eb08dee60d88e47c3fe588da9dd42-0d0da30b2b50d658-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ma-household_size_edge].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ma-household_size_edge].yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5557": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 39}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "5558": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 36}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "5559": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 8}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5557", "5558",
+      "5559"]}}, "families": {"family": {"members": ["5557", "5558", "5559"]}}, "households":
+      {"household": {"members": ["5557", "5558", "5559"], "state_code": {"2024": "MA"}}},
+      "spm_units": {"spm_unit": {"members": ["5557", "5558", "5559"], "snap_unearned_income":
+      {"2024": 0.0}, "snap_earned_income": {"2024": 30600.0}, "snap_assets": {"2024":
+      0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost": {"2024": 16200},
+      "has_phone_expense": {"2024": false}, "has_heating_cooling_expense": {"2024":
+      false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses": {"2024":
+      0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees":
+      {"2024": 0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": null}}},
+      "marital_units": {"5557-5558": {"members": ["5557", "5558"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2089'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5557": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 39}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "5558": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 36}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "5559": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 8}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5557", "5558",
+        "5559"]}}, "families": {"family": {"members": ["5557", "5558", "5559"]}},
+        "households": {"household": {"members": ["5557", "5558", "5559"], "state_code":
+        {"2024": "MA"}}}, "spm_units": {"spm_unit": {"members": ["5557", "5558", "5559"],
+        "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 30600.0},
+        "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+        {"2024": 16200}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+        {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+        {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+        "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+        0.0}, "snap": {"2024-01": 415.0}}}, "marital_units": {"5557-5558": {"members":
+        ["5557", "5558"]}}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version":
+        null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2215'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:21 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - c84e151b-32b7-4ce1-8a7c-c3aaa8b51325
+      traceparent:
+      - 00-de786e2687d32fba018c20c726542b71-94635e0ce07fb0d4-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[ma-ma_bbce_categorical_net_income_exemption].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[ma-ma_bbce_categorical_net_income_exemption].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"5561": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["5561"]}}, "families":
+      {"family": {"members": ["5561"]}}, "households": {"household": {"members": ["5561"],
+      "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit": {"members": ["5561"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 24000.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"5561": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["5561"]}},
+        "families": {"family": {"members": ["5561"]}}, "households": {"household":
+        {"members": ["5561"], "state_code": {"2024": "MA"}}}, "spm_units": {"spm_unit":
+        {"members": ["5561"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 24000.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 23.28}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 00:22:22 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 971f5352-f531-46b8-ae5b-ef8eb495a620
+      traceparent:
+      - 00-8feb955006d1c99b5e8baf4552c5e648-21d0d1a5fa31af65-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[nc-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[nc-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"4395": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 28}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["4395"]}}, "families":
+      {"family": {"members": ["4395"]}}, "households": {"household": {"members": ["4395"],
+      "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit": {"members": ["4395"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 11760.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"4395": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 28}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["4395"]}},
+        "families": {"family": {"members": ["4395"]}}, "households": {"household":
+        {"members": ["4395"], "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit":
+        {"members": ["4395"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 11760.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 115.2}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 18:39:15 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 04263272-ebdd-49f4-9247-af75ef17eb7c
+      traceparent:
+      - 00-b1acca468418e937fe48b1700044e863-7ecf87a96aa7a35c-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[nc-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[nc-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"4397": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 28}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["4397"]}}, "families":
+      {"family": {"members": ["4397"]}}, "households": {"household": {"members": ["4397"],
+      "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit": {"members": ["4397"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 40200.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"4397": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 28}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["4397"]}},
+        "families": {"family": {"members": ["4397"]}}, "households": {"household":
+        {"members": ["4397"], "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit":
+        {"members": ["4397"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 40200.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 18:39:24 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 19a32f50-c5b0-4967-a338-03ccc232e2c8
+      traceparent:
+      - 00-2087599adf58bd4f93bf1281c93eca46-eb3db07df69ada08-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[nc-elderly_member].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[nc-elderly_member].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"4393": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["4393"]}}, "families":
+      {"family": {"members": ["4393"]}}, "households": {"household": {"members": ["4393"],
+      "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit": {"members": ["4393"],
+      "snap_unearned_income": {"2024": 12600.0}, "snap_earned_income": {"2024": 0.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 9000}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1197'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"4393": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["4393"]}},
+        "families": {"family": {"members": ["4393"]}}, "households": {"household":
+        {"members": ["4393"], "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit":
+        {"members": ["4393"], "snap_unearned_income": {"2024": 12600.0}, "snap_earned_income":
+        {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 9000}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 132.59999}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1325'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 18:38:08 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - fbfa4623-5ae5-4c8b-8880-70e86d3ebfd2
+      traceparent:
+      - 00-68cb8dadfdab3d0dd52c55988f36b05e-277a662a6c531d91-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[nc-household_size_edge].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[nc-household_size_edge].yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"4398": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 40}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "4399": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 38}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "4400": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 9}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["4398", "4399",
+      "4400"]}}, "families": {"family": {"members": ["4398", "4399", "4400"]}}, "households":
+      {"household": {"members": ["4398", "4399", "4400"], "state_code": {"2024": "NC"}}},
+      "spm_units": {"spm_unit": {"members": ["4398", "4399", "4400"], "snap_unearned_income":
+      {"2024": 0.0}, "snap_earned_income": {"2024": 33600.0}, "snap_assets": {"2024":
+      0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost": {"2024": 14400},
+      "has_phone_expense": {"2024": false}, "has_heating_cooling_expense": {"2024":
+      false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses": {"2024":
+      0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees":
+      {"2024": 0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": null}}},
+      "marital_units": {"4398-4399": {"members": ["4398", "4399"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2089'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"4398": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 40}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "4399": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 38}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "4400": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 9}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["4398", "4399",
+        "4400"]}}, "families": {"family": {"members": ["4398", "4399", "4400"]}},
+        "households": {"household": {"members": ["4398", "4399", "4400"], "state_code":
+        {"2024": "NC"}}}, "spm_units": {"spm_unit": {"members": ["4398", "4399", "4400"],
+        "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 33600.0},
+        "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+        {"2024": 14400}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+        {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+        {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+        "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+        0.0}, "snap": {"2024-01": 207.09998}}}, "marital_units": {"4398-4399": {"members":
+        ["4398", "4399"]}}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version":
+        null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2219'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 18:39:25 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 30c12a2a-d6e8-4d17-9f7a-c2e3f2348a96
+      traceparent:
+      - 00-b372e5aea0da0e220f0a904f4e740092-b6632261748baac7-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[nc-nc_expanded_cat_elig_net_income].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[nc-nc_expanded_cat_elig_net_income].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"4394": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 35}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["4394"]}}, "families":
+      {"family": {"members": ["4394"]}}, "households": {"household": {"members": ["4394"],
+      "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit": {"members": ["4394"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 28200.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"4394": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 35}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["4394"]}},
+        "families": {"family": {"members": ["4394"]}}, "households": {"household":
+        {"members": ["4394"], "state_code": {"2024": "NC"}}}, "spm_units": {"spm_unit":
+        {"members": ["4394"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 28200.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 23.28}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 18:38:17 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 094f94b4-2bd2-4f26-b883-ba5f7d8a981d
+      traceparent:
+      - 00-d8a09474c67303f73fbd2b2515a81c95-9c5840357a7cb129-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[tx-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[tx-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3274": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3274"]}}, "families":
+      {"family": {"members": ["3274"]}}, "households": {"household": {"members": ["3274"],
+      "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit": {"members": ["3274"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 10800.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3274": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3274"]}},
+        "families": {"family": {"members": ["3274"]}}, "households": {"household":
+        {"members": ["3274"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit":
+        {"members": ["3274"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 10800.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 134.4}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:22 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - ca295fbd-6157-474d-ac3c-0fea7aff947f
+      traceparent:
+      - 00-145e327e46b7065e77476580c5dd4546-f67bd1b49a017c4d-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[tx-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[tx-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3275": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3275"]}}, "families":
+      {"family": {"members": ["3275"]}}, "households": {"household": {"members": ["3275"],
+      "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit": {"members": ["3275"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 50400.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3275": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3275"]}},
+        "families": {"family": {"members": ["3275"]}}, "households": {"household":
+        {"members": ["3275"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit":
+        {"members": ["3275"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 50400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:24 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 93ed4a81-30b1-4d5e-bfca-220abf110722
+      traceparent:
+      - 00-13b48144c2d5369b985e9d4ffce4afce-c20636b09031716a-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[tx-elderly_member].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[tx-elderly_member].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3280": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3280"]}}, "families":
+      {"family": {"members": ["3280"]}}, "households": {"household": {"members": ["3280"],
+      "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit": {"members": ["3280"],
+      "snap_unearned_income": {"2024": 14400.0}, "snap_earned_income": {"2024": 0.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 10800}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3280": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 68}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3280"]}},
+        "families": {"family": {"members": ["3280"]}}, "households": {"household":
+        {"members": ["3280"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit":
+        {"members": ["3280"], "snap_unearned_income": {"2024": 14400.0}, "snap_earned_income":
+        {"2024": 0.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+        0}, "housing_cost": {"2024": 10800}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 110.09999}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1326'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:28 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 816e519a-7fff-4672-969a-13895343de1d
+      traceparent:
+      - 00-0714d687dfd017c5e8fc192f2b43607d-5f919cbdc7a3792c-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[tx-household_size_edge].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[tx-household_size_edge].yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3276": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 37}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}, "3277": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "3278": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 10}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}, "3279": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+      {"2024": 0}, "age": {"2024": 7}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+      {"2024": null}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+      {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+      {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3276", "3277",
+      "3278", "3279"]}}, "families": {"family": {"members": ["3276", "3277", "3278",
+      "3279"]}}, "households": {"household": {"members": ["3276", "3277", "3278",
+      "3279"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit": {"members":
+      ["3276", "3277", "3278", "3279"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+      {"2024": 26400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024":
+      0}, "housing_cost": {"2024": 18000}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {"3276-3277": {"members":
+      ["3276", "3277"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2514'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3276": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 37}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "3277": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "3278": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 10}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}, "3279": {"child_support_expense": {"2024": 0.0}, "real_estate_taxes":
+        {"2024": 0}, "age": {"2024": 7}, "other_medical_expenses": {"2024": 0}, "is_disabled":
+        {"2024": false}, "is_full_time_college_student": {"2024": false}, "is_part_time_college_student":
+        {"2024": false}, "meets_snap_work_exception": {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3276", "3277",
+        "3278", "3279"]}}, "families": {"family": {"members": ["3276", "3277", "3278",
+        "3279"]}}, "households": {"household": {"members": ["3276", "3277", "3278",
+        "3279"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit": {"members":
+        ["3276", "3277", "3278", "3279"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 26400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 18000}, "has_phone_expense": {"2024":
+        false}, "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 709.0}}},
+        "marital_units": {"3276-3277": {"members": ["3276", "3277"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2641'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:26 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 2d741c2c-ee31-474d-8eb8-0f9a346e5099
+      traceparent:
+      - 00-9b7dbfefe00c07b232580a5853f20de3-12b9319338fa858b-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[wa-bbce_net_income_waiver].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[wa-bbce_net_income_waiver].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3273": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3273"]}}, "families":
+      {"family": {"members": ["3273"]}}, "households": {"household": {"members": ["3273"],
+      "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["3273"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 26400.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3273": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3273"]}},
+        "families": {"family": {"members": ["3273"]}}, "households": {"household":
+        {"members": ["3273"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+        {"members": ["3273"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 26400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 23.28}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1318'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:21 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 6d469487-be18-4bf1-bb20-6526b0b7003b
+      traceparent:
+      - 00-e54fa84b37a5a2f1dffd7c6d7d154549-e36aea63c2e2854d-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[wa-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[wa-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3270": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3270"]}}, "families":
+      {"family": {"members": ["3270"]}}, "households": {"household": {"members": ["3270"],
+      "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["3270"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 14400.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3270": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3270"]}},
+        "families": {"family": {"members": ["3270"]}}, "households": {"household":
+        {"members": ["3270"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+        {"members": ["3270"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 14400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 92.999985}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1322'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:17 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 5c3891e9-c43b-4c07-a55e-7418f09b1a55
+      traceparent:
+      - 00-2777b33d5d6762e10a6324b0b5bc6d60-c1ad79e33e0508f1-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[wa-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[wa-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3271": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3271"]}}, "families":
+      {"family": {"members": ["3271"]}}, "households": {"household": {"members": ["3271"],
+      "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["3271"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 31932.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3271": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 34}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3271"]}},
+        "families": {"family": {"members": ["3271"]}}, "households": {"household":
+        {"members": ["3271"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+        {"members": ["3271"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 31932.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:18 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - f532be4a-1ad2-49e1-ab00-baadb281a8d1
+      traceparent:
+      - 00-43a7064c5dd3fb4991c5fa9ea02689fb-443df13af5345205-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_snap_parity[wa-pregnant_household_size].yaml
+++ b/programs/programs/factories/tests/cassettes/test_snap_parity[wa-pregnant_household_size].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"3272": {"child_support_expense": {"2024": 0.0},
+      "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+      {"2024": 0}, "is_disabled": {"2024": null}, "is_full_time_college_student":
+      {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+      {"2024": false}, "is_snap_employment_training_or_work_incentive_student": {"2024":
+      false}}}, "tax_units": {"main_tax_unit": {"members": ["3272"]}}, "families":
+      {"family": {"members": ["3272"]}}, "households": {"household": {"members": ["3272"],
+      "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["3272"],
+      "snap_unearned_income": {"2024": 0.0}, "snap_earned_income": {"2024": 14400.0},
+      "snap_assets": {"2024": 0}, "snap_emergency_allotment": {"2024": 0}, "housing_cost":
+      {"2024": 0}, "has_phone_expense": {"2024": false}, "has_heating_cooling_expense":
+      {"2024": false}, "heating_cooling_expense": {"2024": 0.0}, "childcare_expenses":
+      {"2024": 0.0}, "water_expense": {"2024": 0.0}, "phone_expense": {"2024": 0.0},
+      "homeowners_association_fees": {"2024": 0.0}, "homeowners_insurance": {"2024":
+      0.0}, "snap": {"2024-01": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1194'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"3272": {"child_support_expense":
+        {"2024": 0.0}, "real_estate_taxes": {"2024": 0}, "age": {"2024": 32}, "other_medical_expenses":
+        {"2024": 0}, "is_disabled": {"2024": false}, "is_full_time_college_student":
+        {"2024": false}, "is_part_time_college_student": {"2024": false}, "meets_snap_work_exception":
+        {"2024": false}, "is_snap_employment_training_or_work_incentive_student":
+        {"2024": false}}}, "tax_units": {"main_tax_unit": {"members": ["3272"]}},
+        "families": {"family": {"members": ["3272"]}}, "households": {"household":
+        {"members": ["3272"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+        {"members": ["3272"], "snap_unearned_income": {"2024": 0.0}, "snap_earned_income":
+        {"2024": 14400.0}, "snap_assets": {"2024": 0}, "snap_emergency_allotment":
+        {"2024": 0}, "housing_cost": {"2024": 0}, "has_phone_expense": {"2024": false},
+        "has_heating_cooling_expense": {"2024": false}, "heating_cooling_expense":
+        {"2024": 0.0}, "childcare_expenses": {"2024": 0.0}, "water_expense": {"2024":
+        0.0}, "phone_expense": {"2024": 0.0}, "homeowners_association_fees": {"2024":
+        0.0}, "homeowners_insurance": {"2024": 0.0}, "snap": {"2024-01": 92.999985}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1322'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Jul 2026 03:19:19 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 6360ab28-3ec1-4c06-be62-3b763c1a236e
+      traceparent:
+      - 00-348a8e69004a29a6d6e5a3aa8caf7055-ca8a8ca9425cbf29-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_tanf_parity[tx-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_tanf_parity[tx-clearly_eligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"8933": {"age": {"2024": 32}, "is_full_time_college_student":
+      {"2024": false}, "is_tax_unit_dependent": {"2024": false}, "employment_income":
+      {"2024": 2400}, "self_employment_income": {"2024": 0}, "rental_income": {"2024":
+      0}, "taxable_pension_income": {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+      {"2024": 0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions":
+      {"2024": 0}}, "8934": {"age": {"2024": 8}, "is_full_time_college_student": {"2024":
+      false}, "is_tax_unit_dependent": {"2024": true}, "employment_income": {"2024":
+      0}, "self_employment_income": {"2024": 0}, "rental_income": {"2024": 0}, "taxable_pension_income":
+      {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+      0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions": {"2024":
+      0}}}, "tax_units": {"main_tax_unit": {"members": ["8933", "8934"]}}, "families":
+      {"family": {"members": ["8933", "8934"]}}, "households": {"household": {"members":
+      ["8933", "8934"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit":
+      {"members": ["8933", "8934"], "tx_tanf": {"2024": null}}}, "marital_units":
+      {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1182'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"8933": {"age":
+        {"2024": 32}, "is_full_time_college_student": {"2024": false}, "is_tax_unit_dependent":
+        {"2024": false}, "employment_income": {"2024": 2400}, "self_employment_income":
+        {"2024": 0}, "rental_income": {"2024": 0}, "taxable_pension_income": {"2024":
+        0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+        0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions": {"2024":
+        0}}, "8934": {"age": {"2024": 8}, "is_full_time_college_student": {"2024":
+        false}, "is_tax_unit_dependent": {"2024": true}, "employment_income": {"2024":
+        0}, "self_employment_income": {"2024": 0}, "rental_income": {"2024": 0}, "taxable_pension_income":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions":
+        {"2024": 0}}}, "tax_units": {"main_tax_unit": {"members": ["8933", "8934"]}},
+        "families": {"family": {"members": ["8933", "8934"]}}, "households": {"household":
+        {"members": ["8933", "8934"], "state_code": {"2024": "TX"}}}, "spm_units":
+        {"spm_unit": {"members": ["8933", "8934"], "tx_tanf": {"2024": 3061.7998}}},
+        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.755.0",
+        "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1309'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 01:52:26 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - ff5ed0be-ed0a-4950-a45d-a71c7ee0bbf2
+      traceparent:
+      - 00-a29a1c937b99d7df69121a0a9afeed9d-69bcbc69aec98fe3-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_tanf_parity[tx-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_tanf_parity[tx-clearly_ineligible].yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"8935": {"age": {"2024": 32}, "is_full_time_college_student":
+      {"2024": false}, "is_tax_unit_dependent": {"2024": false}, "employment_income":
+      {"2024": 60000}, "self_employment_income": {"2024": 0}, "rental_income": {"2024":
+      0}, "taxable_pension_income": {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+      {"2024": 0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions":
+      {"2024": 0}}, "8936": {"age": {"2024": 8}, "is_full_time_college_student": {"2024":
+      false}, "is_tax_unit_dependent": {"2024": true}, "employment_income": {"2024":
+      0}, "self_employment_income": {"2024": 0}, "rental_income": {"2024": 0}, "taxable_pension_income":
+      {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+      0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions": {"2024":
+      0}}}, "tax_units": {"main_tax_unit": {"members": ["8935", "8936"]}}, "families":
+      {"family": {"members": ["8935", "8936"]}}, "households": {"household": {"members":
+      ["8935", "8936"], "state_code": {"2024": "TX"}}}, "spm_units": {"spm_unit":
+      {"members": ["8935", "8936"], "tx_tanf": {"2024": null}}}, "marital_units":
+      {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1183'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"8935": {"age":
+        {"2024": 32}, "is_full_time_college_student": {"2024": false}, "is_tax_unit_dependent":
+        {"2024": false}, "employment_income": {"2024": 60000}, "self_employment_income":
+        {"2024": 0}, "rental_income": {"2024": 0}, "taxable_pension_income": {"2024":
+        0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+        0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions": {"2024":
+        0}}, "8936": {"age": {"2024": 8}, "is_full_time_college_student": {"2024":
+        false}, "is_tax_unit_dependent": {"2024": true}, "employment_income": {"2024":
+        0}, "self_employment_income": {"2024": 0}, "rental_income": {"2024": 0}, "taxable_pension_income":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}, "long_term_capital_gains": {"2024": 0}, "taxable_ira_distributions":
+        {"2024": 0}}}, "tax_units": {"main_tax_unit": {"members": ["8935", "8936"]}},
+        "families": {"family": {"members": ["8935", "8936"]}}, "households": {"household":
+        {"members": ["8935", "8936"], "state_code": {"2024": "TX"}}}, "spm_units":
+        {"spm_unit": {"members": ["8935", "8936"], "tx_tanf": {"2024": 0.0}}}, "marital_units":
+        {}}, "policyengine_bundle": {"model_version": "1.755.0", "data_version": null,
+        "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1304'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 01:52:26 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 5bd876a7-0cbf-4eef-bf35-08c435316959
+      traceparent:
+      - 00-2d33fca37ae3cfbd40d82a4a04e9b30d-86d7faf773830332-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_tanf_parity[wa-clearly_eligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_tanf_parity[wa-clearly_eligible].yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10050": {"age": {"2024": 30}, "is_full_time_college_student":
+      {"2024": false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr":
+      {"2024": 9600}, "self_employment_income_before_lsr": {"2024": 0}, "social_security":
+      {"2024": 0}, "unemployment_compensation": {"2024": 0}}, "10051": {"age": {"2024":
+      7}, "is_full_time_college_student": {"2024": false}, "is_pregnant": {"2024":
+      false}, "employment_income_before_lsr": {"2024": 0}, "self_employment_income_before_lsr":
+      {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+      0}}, "10052": {"age": {"2024": 4}, "is_full_time_college_student": {"2024":
+      false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr": {"2024":
+      0}, "self_employment_income_before_lsr": {"2024": 0}, "social_security": {"2024":
+      0}, "unemployment_compensation": {"2024": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["10050", "10051", "10052"]}}, "families": {"family": {"members":
+      ["10050", "10051", "10052"]}}, "households": {"household": {"members": ["10050",
+      "10051", "10052"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+      {"members": ["10050", "10051", "10052"], "spm_unit_cash_assets": {"2024": 1500},
+      "wa_show_all_cash_assistance_programs": {"2024": true}, "wa_tanf": {"2024":
+      null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10050": {"age":
+        {"2024": 30}, "is_full_time_college_student": {"2024": false}, "is_pregnant":
+        {"2024": false}, "employment_income_before_lsr": {"2024": 9600}, "self_employment_income_before_lsr":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}}, "10051": {"age": {"2024": 7}, "is_full_time_college_student":
+        {"2024": false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr":
+        {"2024": 0}, "self_employment_income_before_lsr": {"2024": 0}, "social_security":
+        {"2024": 0}, "unemployment_compensation": {"2024": 0}}, "10052": {"age": {"2024":
+        4}, "is_full_time_college_student": {"2024": false}, "is_pregnant": {"2024":
+        false}, "employment_income_before_lsr": {"2024": 0}, "self_employment_income_before_lsr":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}}}, "tax_units": {"main_tax_unit": {"members": ["10050", "10051",
+        "10052"]}}, "families": {"family": {"members": ["10050", "10051", "10052"]}},
+        "households": {"household": {"members": ["10050", "10051", "10052"], "state_code":
+        {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["10050", "10051",
+        "10052"], "spm_unit_cash_assets": {"2024": 1500}, "wa_show_all_cash_assistance_programs":
+        {"2024": true}, "wa_tanf": {"2024": 4922.0}}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1452'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:41 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - d96a1ec8-abb6-4030-8ee1-6b2adabd74fd
+      traceparent:
+      - 00-5adf1d0199e447bf0d5c41f62518b069-f62c75ea97cdbd95-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_tanf_parity[wa-clearly_ineligible].yaml
+++ b/programs/programs/factories/tests/cassettes/test_tanf_parity[wa-clearly_ineligible].yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10055": {"age": {"2024": 33}, "is_full_time_college_student":
+      {"2024": false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr":
+      {"2024": 30000}, "self_employment_income_before_lsr": {"2024": 0}, "social_security":
+      {"2024": 0}, "unemployment_compensation": {"2024": 0}}, "10056": {"age": {"2024":
+      8}, "is_full_time_college_student": {"2024": false}, "is_pregnant": {"2024":
+      false}, "employment_income_before_lsr": {"2024": 0}, "self_employment_income_before_lsr":
+      {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+      0}}, "10057": {"age": {"2024": 4}, "is_full_time_college_student": {"2024":
+      false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr": {"2024":
+      0}, "self_employment_income_before_lsr": {"2024": 0}, "social_security": {"2024":
+      0}, "unemployment_compensation": {"2024": 0}}}, "tax_units": {"main_tax_unit":
+      {"members": ["10055", "10056", "10057"]}}, "families": {"family": {"members":
+      ["10055", "10056", "10057"]}}, "households": {"household": {"members": ["10055",
+      "10056", "10057"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+      {"members": ["10055", "10056", "10057"], "spm_unit_cash_assets": {"2024": 2000},
+      "wa_show_all_cash_assistance_programs": {"2024": true}, "wa_tanf": {"2024":
+      null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1329'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10055": {"age":
+        {"2024": 33}, "is_full_time_college_student": {"2024": false}, "is_pregnant":
+        {"2024": false}, "employment_income_before_lsr": {"2024": 30000}, "self_employment_income_before_lsr":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}}, "10056": {"age": {"2024": 8}, "is_full_time_college_student":
+        {"2024": false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr":
+        {"2024": 0}, "self_employment_income_before_lsr": {"2024": 0}, "social_security":
+        {"2024": 0}, "unemployment_compensation": {"2024": 0}}, "10057": {"age": {"2024":
+        4}, "is_full_time_college_student": {"2024": false}, "is_pregnant": {"2024":
+        false}, "employment_income_before_lsr": {"2024": 0}, "self_employment_income_before_lsr":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}}}, "tax_units": {"main_tax_unit": {"members": ["10055", "10056",
+        "10057"]}}, "families": {"family": {"members": ["10055", "10056", "10057"]}},
+        "households": {"household": {"members": ["10055", "10056", "10057"], "state_code":
+        {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["10055", "10056",
+        "10057"], "spm_unit_cash_assets": {"2024": 2000}, "wa_show_all_cash_assistance_programs":
+        {"2024": true}, "wa_tanf": {"2024": 0.0}}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1450'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:43 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 73a33d4e-4f7e-4a8d-bf76-08a52f7e5861
+      traceparent:
+      - 00-656c6a0bcba5de35c946b55685ed5d2d-e1be2e4299fcb2ba-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/cassettes/test_tanf_parity[wa-minimally_eligible_boundary].yaml
+++ b/programs/programs/factories/tests/cassettes/test_tanf_parity[wa-minimally_eligible_boundary].yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"10053": {"age": {"2024": 36}, "is_full_time_college_student":
+      {"2024": false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr":
+      {"2024": 6252}, "self_employment_income_before_lsr": {"2024": 0}, "social_security":
+      {"2024": 0}, "unemployment_compensation": {"2024": 0}}, "10054": {"age": {"2024":
+      18}, "is_full_time_college_student": {"2024": false}, "is_pregnant": {"2024":
+      false}, "employment_income_before_lsr": {"2024": 0}, "self_employment_income_before_lsr":
+      {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation": {"2024":
+      0}}}, "tax_units": {"main_tax_unit": {"members": ["10053", "10054"]}}, "families":
+      {"family": {"members": ["10053", "10054"]}}, "households": {"household": {"members":
+      ["10053", "10054"], "state_code": {"2024": "WA"}}}, "spm_units": {"spm_unit":
+      {"members": ["10053", "10054"], "spm_unit_cash_assets": {"2024": 6000}, "wa_show_all_cash_assistance_programs":
+      {"2024": true}, "wa_tanf": {"2024": null}}}, "marital_units": {}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1012'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"10053": {"age":
+        {"2024": 36}, "is_full_time_college_student": {"2024": false}, "is_pregnant":
+        {"2024": false}, "employment_income_before_lsr": {"2024": 6252}, "self_employment_income_before_lsr":
+        {"2024": 0}, "social_security": {"2024": 0}, "unemployment_compensation":
+        {"2024": 0}}, "10054": {"age": {"2024": 18}, "is_full_time_college_student":
+        {"2024": false}, "is_pregnant": {"2024": false}, "employment_income_before_lsr":
+        {"2024": 0}, "self_employment_income_before_lsr": {"2024": 0}, "social_security":
+        {"2024": 0}, "unemployment_compensation": {"2024": 0}}}, "tax_units": {"main_tax_unit":
+        {"members": ["10053", "10054"]}}, "families": {"family": {"members": ["10053",
+        "10054"]}}, "households": {"household": {"members": ["10053", "10054"], "state_code":
+        {"2024": "WA"}}}, "spm_units": {"spm_unit": {"members": ["10053", "10054"],
+        "spm_unit_cash_assets": {"2024": 6000}, "wa_show_all_cash_assistance_programs":
+        {"2024": true}, "wa_tanf": {"2024": 0.0}}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1133'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 03:08:42 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - fea4550d-509b-47e9-b659-db8c0a1f1428
+      traceparent:
+      - 00-63e5ad3566d036f7da8d5fa8a4cf3f78-dd96be1121c9e0cb-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/factories/tests/snap_parity_manifest.py
+++ b/programs/programs/factories/tests/snap_parity_manifest.py
@@ -1,0 +1,107 @@
+"""
+Per-state manifest for the SNAP parity harness (DECISIONS.md D-017).
+Generalizes what used to be three hand-copied test files
+(test_snap_parity.py/test_wa_snap_parity.py/test_tx_snap_parity.py) into one
+parameterized mechanism -- see test_snap_parity.py for the test itself.
+
+Not pure JSON: each state's *old* calculator (CoSnap/WaSnap/TxSnap, ...) is a
+real Python class in a per-state module, and JSON cannot reference one.
+Adding a state to this harness is one SnapParityState entry (an import + a
+few lines) plus the real fixture-authoring work in
+validations/management/commands/import_validations/data/{state}_snap.json --
+not zero Python. This is separate from, and in addition to,
+snap_registration.py's pre-existing one-line *production* registration for
+the new calculator (D-013).
+
+D-001's rejection of auto-discovery for the production CalculatorFactory
+applies here too: an importlib-convention lookup
+(programs.programs.{state}.pe.spm.{State}Snap) would make this file closer
+to real JSON, but fails at an unhelpful runtime AttributeError instead of a
+known import line if a future state's class doesn't follow the convention,
+and buys nothing against the loud-failure requirement below, which an
+explicit registry gets from a plain ImportError/AssertionError for free.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from django.conf import settings
+
+from programs.programs.co.pe.spm import CoSnap
+from programs.programs.factories.snap_registration import snap_factory
+from programs.programs.il.pe.spm import IlSnap
+from programs.programs.ks.pe.spm import KsSnap
+from programs.programs.ma.pe.spm import MaSnap
+from programs.programs.nc.pe.spm import NcSnap
+from programs.programs.tx.pe.spm import TxSnap
+from programs.programs.wa.pe.spm import WaSnap
+
+FIXTURE_DIR = settings.BASE_DIR / "validations" / "management" / "commands" / "import_validations" / "data"
+
+
+@dataclass(frozen=True)
+class SnapParityState:
+    state_code: str  # "co" -- WhiteLabel.code, Program white_label
+    state_name: str  # "Colorado" -- WhiteLabel.name
+    postal_code: str  # "CO" -- WhiteLabel.state_code
+    old_calculator_cls: type
+    new_calculator_key: str  # snap_factory registration key, e.g. "co_snap"
+
+    @property
+    def fixture_path(self) -> Path:
+        return FIXTURE_DIR / f"{self.state_code}_snap.json"
+
+
+SNAP_PARITY_STATES: list[SnapParityState] = [
+    SnapParityState("co", "Colorado", "CO", CoSnap, "co_snap"),
+    SnapParityState("wa", "Washington", "WA", WaSnap, "wa_snap"),
+    SnapParityState("tx", "Texas", "TX", TxSnap, "tx_snap"),
+    SnapParityState("nc", "North Carolina", "NC", NcSnap, "nc_snap"),
+    SnapParityState("ma", "Massachusetts", "MA", MaSnap, "ma_snap"),
+    SnapParityState("ks", "Kansas", "KS", KsSnap, "ks_snap"),
+    SnapParityState("il", "Illinois", "IL", IlSnap, "il_snap"),
+]
+
+
+def build_snap_parity_cases() -> tuple[list[tuple[SnapParityState, dict]], list[str]]:
+    """One (state, raw_scenario_dict) case per scenario found in each state's
+    real fixture file -- the fixture is the sole source of truth for which
+    scenarios exist, so there's no separate list to fall out of sync with it
+    (D-015's original concern, now structurally impossible instead of
+    hand-maintained). Every failure mode here raises loudly at call time
+    (test_snap_parity.py calls this at module-import time, so a bad manifest
+    entry fails collection for the whole file) rather than silently
+    producing zero cases for a state."""
+    cases: list[tuple[SnapParityState, dict]] = []
+    ids: list[str] = []
+
+    for entry in SNAP_PARITY_STATES:
+        try:
+            snap_factory.get(entry.new_calculator_key)
+        except KeyError:
+            raise AssertionError(
+                f"{entry.state_code}: '{entry.new_calculator_key}' is not registered in "
+                f"snap_factory (available: {sorted(snap_factory.as_dict())}) -- "
+                "snap_registration.py wiring is stale or this manifest entry has a typo."
+            )
+
+        if not entry.fixture_path.exists():
+            raise AssertionError(f"{entry.state_code}: fixture file not found: {entry.fixture_path}")
+
+        raw_scenarios = json.loads(entry.fixture_path.read_text())
+        if not raw_scenarios:
+            raise AssertionError(f"{entry.state_code}: {entry.fixture_path} has zero scenarios")
+
+        seen_keys: set[str] = set()
+        for raw in raw_scenarios:
+            key = raw["scenario_key"]
+            if key in seen_keys:
+                raise AssertionError(f"{entry.state_code}: duplicate scenario_key {key!r} in {entry.fixture_path}")
+            seen_keys.add(key)
+            cases.append((entry, raw))
+            ids.append(f"{entry.state_code}-{key}")
+
+    return cases, ids

--- a/programs/programs/factories/tests/tanf_parity_manifest.py
+++ b/programs/programs/factories/tests/tanf_parity_manifest.py
@@ -1,0 +1,109 @@
+"""
+Per-state manifest for the TANF parity harness -- same generalized shape as
+snap_parity_manifest.py (DECISIONS.md D-017) from day one, not the
+pre-D-017 per-state-file approach SNAP started with. Reusing D-017's
+already-proven mechanism here (rather than hand-copying test_snap_parity.py
+into a near-duplicate test_tanf_parity.py) is a direct application of an
+already-settled pattern, not a new design decision.
+
+**Deliberately not unified with snap_parity_manifest.py into one
+cross-program harness yet.** D-017 itself only generalized *across states*
+after three real per-state files (CO/WA/TX) proved the duplication was
+real, not before -- generalizing speculatively from one example was exactly
+what D-002/D-008 already warn against. TANF is only the second program
+overall; unifying across *programs* now would be generalizing from a
+single data point the same way. Revisit once a third program's parity
+harness is being built, with two real examples (SNAP, TANF) to generalize
+from instead of one.
+
+TX is the first state registered -- see tanf_registration.py's docstring
+for why it's the safest first pick (pure pass-through, no countable-income
+override to litigate, unlike CO/IL/NC per D-020). Remaining states (no
+bespoke TanfCalculator needed; MA is a real out-of-scope exception; which
+other real states to add, and in what order, is a separate, later
+decision).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from django.conf import settings
+
+from programs.programs.factories.tanf_registration import tanf_factory
+from programs.programs.tx.pe.spm import TxTanf
+from programs.programs.wa.pe.spm import WaTanf
+
+FIXTURE_DIR = settings.BASE_DIR / "validations" / "management" / "commands" / "import_validations" / "data"
+
+
+@dataclass(frozen=True)
+class TanfParityState:
+    state_code: str  # "co" -- WhiteLabel.code, Program white_label
+    state_name: str  # "Colorado" -- WhiteLabel.name
+    postal_code: str  # "CO" -- WhiteLabel.state_code
+    old_calculator_cls: type
+    new_calculator_key: str  # tanf_factory registration key, e.g. "co_tanf"
+
+    @property
+    def fixture_path(self) -> Path:
+        return FIXTURE_DIR / f"{self.state_code}_tanf.json"
+
+
+TANF_PARITY_STATES: list[TanfParityState] = [
+    TanfParityState(
+        state_code="tx",
+        state_name="Texas",
+        postal_code="TX",
+        old_calculator_cls=TxTanf,
+        new_calculator_key="tx_tanf",
+    ),
+    TanfParityState(
+        state_code="wa",
+        state_name="Washington",
+        postal_code="WA",
+        old_calculator_cls=WaTanf,
+        new_calculator_key="wa_tanf",
+    ),
+]
+
+
+def build_tanf_parity_cases() -> tuple[list[tuple[TanfParityState, dict]], list[str]]:
+    """Identical mechanism to build_snap_parity_cases() -- see
+    snap_parity_manifest.py's docstring for the full reasoning (fixture is
+    the sole source of scenario truth; every failure mode raises loudly at
+    module-import time). Returns ([], []) with zero states registered,
+    which pytest.mark.parametrize collects as zero test cases, not an
+    error -- confirmed before treating this scaffold as done."""
+    cases: list[tuple[TanfParityState, dict]] = []
+    ids: list[str] = []
+
+    for entry in TANF_PARITY_STATES:
+        try:
+            tanf_factory.get(entry.new_calculator_key)
+        except KeyError:
+            raise AssertionError(
+                f"{entry.state_code}: '{entry.new_calculator_key}' is not registered in "
+                f"tanf_factory (available: {sorted(tanf_factory.as_dict())}) -- "
+                "tanf_registration.py wiring is stale or this manifest entry has a typo."
+            )
+
+        if not entry.fixture_path.exists():
+            raise AssertionError(f"{entry.state_code}: fixture file not found: {entry.fixture_path}")
+
+        raw_scenarios = json.loads(entry.fixture_path.read_text())
+        if not raw_scenarios:
+            raise AssertionError(f"{entry.state_code}: {entry.fixture_path} has zero scenarios")
+
+        seen_keys: set[str] = set()
+        for raw in raw_scenarios:
+            key = raw["scenario_key"]
+            if key in seen_keys:
+                raise AssertionError(f"{entry.state_code}: duplicate scenario_key {key!r} in {entry.fixture_path}")
+            seen_keys.add(key)
+            cases.append((entry, raw))
+            ids.append(f"{entry.state_code}-{key}")
+
+    return cases, ids

--- a/programs/programs/factories/tests/test_calculator_factory.py
+++ b/programs/programs/factories/tests/test_calculator_factory.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from programs.programs.config.loader import ConfigLayer
+from programs.programs.factories.calculator_factory import CalculatorFactory, DuplicateRegistrationError
+from programs.util import Dependencies
+
+
+def make_config(program="p"):
+    return ConfigLayer(program=program, state="s", pe_name="x", pe_entity="spm_unit", pe_period_month=None)
+
+
+class TestCalculatorFactory(SimpleTestCase):
+    def test_registered_callable_accepts_exactly_the_real_call_site_signature(self):
+        factory = CalculatorFactory()
+        config = make_config()
+        Calc = factory.register("p", config)
+
+        screen = SimpleNamespace()
+        program = SimpleNamespace()
+        # Matches screener/views.py:424's real call: Calculator(screen, program, missing_dependencies) --
+        # 3 positional args, nothing else. config/benefit_data must already be bound.
+        instance = Calc(screen, program, Dependencies())
+
+        self.assertIs(instance.config, config)
+        self.assertIsNone(instance.benefit_data)
+
+    def test_get_returns_the_registered_callable(self):
+        factory = CalculatorFactory()
+        config = make_config()
+        Calc = factory.register("p", config)
+
+        self.assertIs(factory.get("p"), Calc)
+
+    def test_as_dict_is_mergeable_like_a_per_state_calculator_dict(self):
+        factory = CalculatorFactory()
+        factory.register("p1", make_config("p1"))
+        factory.register("p2", make_config("p2"))
+
+        merged = {**factory.as_dict(), "existing_program": object}
+
+        self.assertEqual(set(merged.keys()), {"p1", "p2", "existing_program"})
+
+    def test_duplicate_registration_raises(self):
+        factory = CalculatorFactory()
+        config = make_config()
+        factory.register("p", config)
+
+        with self.assertRaises(DuplicateRegistrationError):
+            factory.register("p", config)

--- a/programs/programs/factories/tests/test_coexistence.py
+++ b/programs/programs/factories/tests/test_coexistence.py
@@ -1,0 +1,88 @@
+"""
+Phase 3 item 3: confirm old and new calculators can coexist and be called
+interchangeably by the existing orchestration layer. Mixes the real TxSnap
+(programs/programs/tx/pe/spm.py, already used as a fixture in
+programs/programs/policyengine/tests/test_pe_input.py) with the fabricated
+ZzToyProgram (toy_registration.py) through the *unmodified*
+pe_input()/all_eligibility() functions -- no changes to policy_engine.py,
+registry.py, or views.py.
+"""
+
+from django.test import TestCase
+
+from programs.models import FederalPoveryLimit, Program
+from programs.programs.factories.tests.toy_registration import ZzToyProgram
+from programs.programs.policyengine.policy_engine import all_eligibility, pe_input
+from programs.programs.tx.pe.spm import TxSnap
+from programs.util import Dependencies
+from screener.models import HouseholdMember, Screen, WhiteLabel
+
+
+class CoexistenceTestBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Texas", code="tx", state_code="TX")
+        cls.fpl_year = FederalPoveryLimit.objects.create(year="2024", period="2024")
+
+    def setUp(self):
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Travis County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(
+            screen=self.screen,
+            relationship="headOfHousehold",
+            age=35,
+            disabled=False,
+            student=False,
+        )
+
+        self.program = Program.objects.new_program(white_label="tx", name_abbreviated="tx_snap")
+        self.program.year = self.fpl_year
+        self.program.save()
+
+        self.missing_dependencies = Dependencies()
+        self.old_calculator = TxSnap(self.screen, self.program, self.missing_dependencies)
+        self.new_calculator = ZzToyProgram(self.screen, self.program, self.missing_dependencies)
+
+
+class TestPeInputMixesOldAndNewCalculators(CoexistenceTestBase):
+    def test_old_and_new_calculator_both_contribute_to_the_request(self):
+        result = pe_input(self.screen, [self.old_calculator, self.new_calculator])
+
+        people = result["household"]["people"][str(self.head.id)]
+        spm_unit = result["household"]["spm_units"]["spm_unit"]
+
+        self.assertIn("age", people)  # TxSnap's real dependency
+        self.assertIn("is_full_time_college_student", people)  # toy's additional_input
+        self.assertIn("snap", spm_unit)  # TxSnap's output field
+        self.assertIn("zz_toy_value", spm_unit)  # toy's output field
+
+
+class TestAllEligibilityMixesOldAndNewCalculators(CoexistenceTestBase):
+    class StubSim:
+        def __init__(self, data):
+            self.data = data
+
+        def value(self, unit, sub_unit, variable, period):
+            return self.data[(unit, sub_unit, variable, period)]
+
+    def test_both_calculators_produce_independently_correct_mergeable_eligibility(self):
+        sim = self.StubSim(
+            {
+                ("spm_units", "spm_unit", "snap", "2024-01"): 300.0,
+                ("spm_units", "spm_unit", "zz_toy_value", "2024"): 150.0,
+            }
+        )
+
+        results = all_eligibility(sim, {"tx_snap": self.old_calculator, "zz_toy_program": self.new_calculator})
+
+        self.assertIn("tx_snap", results)
+        self.assertIn("zz_toy_program", results)
+        self.assertTrue(results["tx_snap"].eligible)
+        self.assertEqual(results["tx_snap"].household_value, 300 * 12)  # Snap.household_value()'s real *12
+        self.assertTrue(results["zz_toy_program"].eligible)
+        self.assertEqual(results["zz_toy_program"].household_value, 150)

--- a/programs/programs/factories/tests/test_snap_parity.py
+++ b/programs/programs/factories/tests/test_snap_parity.py
@@ -1,0 +1,145 @@
+"""
+SNAP parallel-verification harness (ROADMAP.md Phase 4, DECISIONS.md D-017):
+compares each state's real old calculator (CoSnap/WaSnap/TxSnap, ...)
+against the new SnapCalculator (programs/programs/calculators/snap.py,
+D-013) household values for the same real households, for every state and
+scenario in snap_parity_manifest.py.
+
+Generalizes what used to be three separate, ~95%-identical hand-copied test
+files (one per state) into a single parameterized mechanism -- see
+snap_parity_manifest.py's docstring for why the manifest itself can't be
+pure JSON, and DECISIONS.md D-017 for the full ADR (ids as "state-scenario_key"
+make cross-state VCR cassette collision, D-016's bug, structurally
+impossible rather than a naming convention to remember; the fixture file is
+the sole source of truth for which scenarios exist, so there's no separate
+expected-count list to keep in sync, D-015's original concern).
+
+Calls the real calc_pe_eligibility() entry point directly (not a hand-rolled
+pe_input()/all_eligibility() reimplementation) -- reproduces its own
+can_calc() gate for free and guarantees both calculators share exactly one
+already-constructed Sim (D-014's precondition). pe_engines is patched to
+[DockerApiSim] for the duration of each test, per D-003 (DockerApiSim is
+policyengine/tests/test_integration.py's own definition, imported rather
+than redefined a fourth time).
+
+resolve_unpinned_comparable_version is mocked to a fixed, cited constant
+(D-017 point 3) -- SNAP's SnapJobTrainingStudentDependency is version-gated
+(min_pe_version=(1,752,0)), so every SNAP request triggers a live,
+uncached-per-process call to PolicyEngine's real hosted /versions/us
+endpoint when unmocked. That call caused a real, confirmed transient
+failure while recording TX's cassettes (RISKS.md Phase 4). Mocking to a
+fixed version clears that floor deterministically without changing which
+inputs get sent (verified against all three states' pre-refactor,
+already-recorded cassette bodies -- see D-017).
+
+Run: pytest -m integration programs/programs/factories/tests/test_snap_parity.py
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from programs.models import FederalPoveryLimit, Program
+from programs.programs.factories.snap_registration import snap_factory
+from programs.programs.factories.tests.snap_parity_manifest import (
+    SnapParityState,
+    build_snap_parity_cases,
+)
+from programs.programs.policyengine.policy_engine import calc_pe_eligibility
+from programs.programs.policyengine.tests.test_integration import DockerApiSim
+from screener.models import WhiteLabel
+from screener.serializers import ScreenSerializer
+
+SNAP_PARITY_CASES, SNAP_PARITY_IDS = build_snap_parity_cases()
+
+# PolicyEngine's actual resolved "current" at CO's original recording time
+# (from that cassette's recorded /versions/us response: {"current":"1.755.0", ...}).
+# Clears SnapJobTrainingStudentDependency's (1, 752, 0) floor, matching what
+# CO/WA/TX's already-recorded, already-reviewed cassettes actually sent (D-017).
+RESOLVED_COMPARABLE_VERSION = (1, 755, 0)
+
+
+@pytest.fixture(autouse=True)
+def _mock_pe_version_resolution():
+    with patch(
+        "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version",
+        return_value=RESOLVED_COMPARABLE_VERSION,
+    ):
+        yield
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+@pytest.mark.parametrize("case", SNAP_PARITY_CASES, ids=SNAP_PARITY_IDS)
+def test_snap_parity(case: tuple[SnapParityState, dict]):
+    entry, raw = case
+    scenario_key = raw["scenario_key"]
+    notes = raw["notes"]
+
+    fpl_year = FederalPoveryLimit.objects.create(year="2024", period="2024")
+    WhiteLabel.objects.create(name=entry.state_name, code=entry.state_code, state_code=entry.postal_code)
+
+    screen = ScreenSerializer(data={**raw["household"], "is_test": True})
+    screen.is_valid(raise_exception=True)
+    screen = screen.save()
+
+    program_key = entry.new_calculator_key
+    program = Program.objects.new_program(white_label=entry.state_code, name_abbreviated=program_key)
+    program.year = fpl_year
+    program.save()
+
+    missing_dependencies = screen.missing_fields()
+
+    old_calc = entry.old_calculator_cls(screen, program, missing_dependencies)
+    new_calc = snap_factory.get(program_key)(screen, program, missing_dependencies)
+
+    old_key = program_key
+    new_key = f"{program_key}_new"
+
+    with patch("programs.programs.policyengine.policy_engine.pe_engines", [DockerApiSim]):
+        result = calc_pe_eligibility(screen, {old_key: old_calc, new_key: new_calc})
+
+    eligibility = result["eligibility"]
+
+    if not eligibility:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            "calc_pe_eligibility() returned no eligibility results at all for either "
+            "calculator -- most likely the PolicyEngine Docker container is unreachable "
+            "(calc_pe_eligibility swallows the underlying exception and returns an empty "
+            "result rather than raising). Confirm the container is running before treating "
+            "this as a real parity mismatch."
+        )
+
+    missing_sides = {old_key, new_key} - eligibility.keys()
+    if missing_sides:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            f"can_calc()-divergence: {sorted(missing_sides)} missing from calc_pe_eligibility()'s "
+            f"result (old_calc.can_calc()={old_calc.can_calc()}, "
+            f"new_calc.can_calc()={new_calc.can_calc()}). old and new must agree on whether "
+            "they have enough data to calculate at all, not just on the resulting value."
+        )
+
+    old_eligibility = eligibility[old_key]
+    new_eligibility = eligibility[new_key]
+
+    print(
+        f"[{entry.state_code}:{scenario_key}] household_value -- "
+        f"old ({entry.old_calculator_cls.__name__})={old_eligibility.household_value} "
+        f"new (ConfigurableCalculator)={new_eligibility.household_value}"
+    )
+
+    if old_eligibility.eligible != new_eligibility.eligible:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            f"eligibility-boolean mismatch: old={old_eligibility.eligible} "
+            f"new={new_eligibility.eligible}"
+        )
+
+    if old_eligibility.household_value != new_eligibility.household_value:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            f"dollar-value mismatch (D-014 exact match, no tolerance): "
+            f"old={old_eligibility.household_value} new={new_eligibility.household_value}"
+        )

--- a/programs/programs/factories/tests/test_snap_registration.py
+++ b/programs/programs/factories/tests/test_snap_registration.py
@@ -1,0 +1,65 @@
+"""
+Real (non-fictional) counterpart to test_coexistence.py's toy-registration
+check: confirms co_snap_config actually loads through snap_registration.py
+and CoSnapCalculator produces the correct household value end-to-end
+through calc() -- a same-input/same-output micro-check against federal
+Snap.household_value()'s real cast-then-multiply-by-12 math
+(federal/pe/spm.py:42-43), not the full parallel-verification harness
+(DECISIONS.md D-013; that's still gated on the not-yet-made tolerance-
+threshold decision).
+"""
+
+from django.test import TestCase
+
+from programs.models import FederalPoveryLimit, Program
+from programs.programs.factories.snap_registration import CoSnapCalculator, co_snap_config
+from programs.programs.policyengine.calculators.dependencies.household import CoStateCodeDependency
+from programs.util import Dependencies
+from screener.models import HouseholdMember, Screen, WhiteLabel
+
+
+class StubSim:
+    def __init__(self, data):
+        self.data = data
+
+    def value(self, unit, sub_unit, variable, period):
+        return self.data[(unit, sub_unit, variable, period)]
+
+
+class TestCoSnapConfigLoadsCorrectly(TestCase):
+    def test_co_snap_config_extends_federal_and_appends_co_state_code(self):
+        self.assertEqual(co_snap_config.state, "co")
+        self.assertEqual(co_snap_config.pe_period_month, "01")
+        self.assertIn(CoStateCodeDependency, co_snap_config.pe_inputs)
+
+
+class TestCoSnapCalculatorHouseholdValue(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Colorado", code="co", state_code="CO")
+        cls.fpl_year = FederalPoveryLimit.objects.create(year="2024", period="2024")
+
+    def test_calc_produces_the_same_annualized_value_as_real_snap_household_value(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="80202",
+            county="Denver County",
+            household_size=1,
+            completed=False,
+        )
+        HouseholdMember.objects.create(
+            screen=screen, relationship="headOfHousehold", age=35, disabled=False, student=False
+        )
+        program = Program.objects.new_program(white_label="co", name_abbreviated="co_snap")
+        program.year = self.fpl_year
+        program.save()
+
+        calculator = CoSnapCalculator(screen, program, Dependencies())
+        # Same real Docker-cassette value used in test_snap_calculator.py --
+        # int(279.59998) * 12 == 3348, not int(279.59998 * 12) == 3355.
+        calculator.set_engine(StubSim({("spm_units", "spm_unit", "snap", "2024-01"): 279.59998}))
+
+        eligibility = calculator.calc()
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(eligibility.household_value, 3348)

--- a/programs/programs/factories/tests/test_tanf_parity.py
+++ b/programs/programs/factories/tests/test_tanf_parity.py
@@ -1,0 +1,138 @@
+"""
+TANF parallel-verification harness -- same mechanism as
+test_snap_parity.py (ROADMAP.md Phase 4, DECISIONS.md D-017), reused
+directly for TANF rather than hand-copied and adapted, since the
+comparison logic itself (D-014's three-category check: can_calc()
+divergence, eligibility-boolean divergence, exact dollar-value match) is
+already fully generic -- nothing about it is SNAP-specific. See
+tanf_parity_manifest.py's docstring for why this stays a separate file
+from test_snap_parity.py rather than unifying the two into one
+cross-program harness (not yet -- only the second program, same
+wait-for-real-evidence reasoning D-017 itself used across states).
+
+Unlike test_snap_parity.py, states register directly against the generic
+ConfigurableCalculator, not a bespoke *Calculator subclass -- see
+tanf_registration.py's docstring for the direct code-comparison proof that
+none is needed.
+
+resolve_unpinned_comparable_version is mocked here too, precautionarily --
+federal Tanf's own two inputs (AgeDependency, FullTimeCollegeStudentDependency)
+are not version-gated today (checked directly), so this mock isn't yet
+proven necessary the way it was for SNAP's SnapJobTrainingStudentDependency.
+Included anyway since it costs nothing against zero currently-registered
+states and removes a known class of flakiness (RISKS.md Phase 4) for
+whichever future state's dependencies turn out to be version-gated --
+re-verify against that state's actual request body before trusting it,
+exactly as D-017 did for SNAP, not assumed safe by analogy alone.
+
+Run: pytest -m integration programs/programs/factories/tests/test_tanf_parity.py
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from programs.models import FederalPoveryLimit, Program
+from programs.programs.factories.tanf_registration import tanf_factory
+from programs.programs.factories.tests.tanf_parity_manifest import (
+    TanfParityState,
+    build_tanf_parity_cases,
+)
+from programs.programs.policyengine.policy_engine import calc_pe_eligibility
+from programs.programs.policyengine.tests.test_integration import DockerApiSim
+from screener.models import WhiteLabel
+from screener.serializers import ScreenSerializer
+
+TANF_PARITY_CASES, TANF_PARITY_IDS = build_tanf_parity_cases()
+
+# Same cited constant as test_snap_parity.py (D-017) -- PolicyEngine's actual
+# resolved "current" at CO SNAP's original recording time. Reused for
+# consistency; re-verify against a real recorded /versions/us response if
+# this ever needs to change independently of SNAP's value.
+RESOLVED_COMPARABLE_VERSION = (1, 755, 0)
+
+
+@pytest.fixture(autouse=True)
+def _mock_pe_version_resolution():
+    with patch(
+        "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version",
+        return_value=RESOLVED_COMPARABLE_VERSION,
+    ):
+        yield
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+@pytest.mark.parametrize("case", TANF_PARITY_CASES, ids=TANF_PARITY_IDS)
+def test_tanf_parity(case: tuple[TanfParityState, dict]):
+    entry, raw = case
+    scenario_key = raw["scenario_key"]
+    notes = raw["notes"]
+
+    fpl_year = FederalPoveryLimit.objects.create(year="2024", period="2024")
+    WhiteLabel.objects.create(name=entry.state_name, code=entry.state_code, state_code=entry.postal_code)
+
+    screen = ScreenSerializer(data={**raw["household"], "is_test": True})
+    screen.is_valid(raise_exception=True)
+    screen = screen.save()
+
+    program_key = entry.new_calculator_key
+    program = Program.objects.new_program(white_label=entry.state_code, name_abbreviated=program_key)
+    program.year = fpl_year
+    program.save()
+
+    missing_dependencies = screen.missing_fields()
+
+    old_calc = entry.old_calculator_cls(screen, program, missing_dependencies)
+    new_calc = tanf_factory.get(program_key)(screen, program, missing_dependencies)
+
+    old_key = program_key
+    new_key = f"{program_key}_new"
+
+    with patch("programs.programs.policyengine.policy_engine.pe_engines", [DockerApiSim]):
+        result = calc_pe_eligibility(screen, {old_key: old_calc, new_key: new_calc})
+
+    eligibility = result["eligibility"]
+
+    if not eligibility:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            "calc_pe_eligibility() returned no eligibility results at all for either "
+            "calculator -- most likely the PolicyEngine Docker container is unreachable "
+            "(calc_pe_eligibility swallows the underlying exception and returns an empty "
+            "result rather than raising). Confirm the container is running before treating "
+            "this as a real parity mismatch."
+        )
+
+    missing_sides = {old_key, new_key} - eligibility.keys()
+    if missing_sides:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            f"can_calc()-divergence: {sorted(missing_sides)} missing from calc_pe_eligibility()'s "
+            f"result (old_calc.can_calc()={old_calc.can_calc()}, "
+            f"new_calc.can_calc()={new_calc.can_calc()}). old and new must agree on whether "
+            "they have enough data to calculate at all, not just on the resulting value."
+        )
+
+    old_eligibility = eligibility[old_key]
+    new_eligibility = eligibility[new_key]
+
+    print(
+        f"[{entry.state_code}:{scenario_key}] household_value -- "
+        f"old ({entry.old_calculator_cls.__name__})={old_eligibility.household_value} "
+        f"new (ConfigurableCalculator)={new_eligibility.household_value}"
+    )
+
+    if old_eligibility.eligible != new_eligibility.eligible:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            f"eligibility-boolean mismatch: old={old_eligibility.eligible} "
+            f"new={new_eligibility.eligible}"
+        )
+
+    if old_eligibility.household_value != new_eligibility.household_value:
+        pytest.fail(
+            f"[{entry.state_code}:{scenario_key}] {notes}\n"
+            f"dollar-value mismatch (D-014 exact match, no tolerance): "
+            f"old={old_eligibility.household_value} new={new_eligibility.household_value}"
+        )

--- a/programs/programs/factories/tests/test_tanf_registration.py
+++ b/programs/programs/factories/tests/test_tanf_registration.py
@@ -1,0 +1,156 @@
+"""
+Real (non-fictional) check that the production tanf_federal.json
+(programs/programs/config/data/tanf_federal.json), tx_tanf_config.json, and
+wa_tanf_config.json load correctly through tanf_registration.py, and that
+TxTanfCalculator/WaTanfCalculator produce the correct household value
+end-to-end through calc() -- the TANF-side counterpart to
+test_snap_registration.py's CoSnap-specific same-input/same-output
+micro-check, against federal Tanf.household_value()'s real
+cast-with-no-period-split math (PolicyEngineCalulator's plain
+`int(self.get_variable())` default -- see D-019 for why no *12 conversion
+applies here, unlike SNAP).
+"""
+
+from django.test import SimpleTestCase, TestCase
+
+from programs.models import FederalPoveryLimit, Program
+from programs.programs.factories.tanf_registration import (
+    TxTanfCalculator,
+    WaTanfCalculator,
+    tanf_factory,
+    tanf_federal_config,
+    tx_tanf_config,
+    wa_tanf_config,
+)
+from programs.programs.policyengine.calculators.dependencies.household import (
+    TxStateCodeDependency,
+    WaStateCodeDependency,
+)
+from programs.programs.policyengine.calculators.dependencies.member import (
+    AgeDependency,
+    FullTimeCollegeStudentDependency,
+    PregnancyDependency,
+)
+from programs.programs.policyengine.calculators.dependencies.spm import WaShowAllCashAssistanceProgramsDependency
+from programs.util import Dependencies
+from screener.models import HouseholdMember, Screen, WhiteLabel
+
+
+class StubSim:
+    def __init__(self, data):
+        self.data = data
+
+    def value(self, unit, sub_unit, variable, period):
+        return self.data[(unit, sub_unit, variable, period)]
+
+
+class TestTanfFederalConfigLoadsCorrectly(SimpleTestCase):
+    def test_federal_config_matches_federal_tanf_pe_inputs(self):
+        self.assertEqual(tanf_federal_config.program, "tanf")
+        self.assertEqual(tanf_federal_config.state, "federal")
+        self.assertEqual(tanf_federal_config.pe_name, "tanf")
+        self.assertEqual(tanf_federal_config.pe_entity, "spm_unit")
+        self.assertIsNone(tanf_federal_config.pe_period_month)
+        # Matches federal/pe/spm.py's Tanf.pe_inputs exactly (2 entries, no
+        # state-code -- this is the federal base, extended per-state later).
+        self.assertEqual(tanf_federal_config.pe_inputs, [AgeDependency, FullTimeCollegeStudentDependency])
+
+
+class TestTxTanfConfigLoadsCorrectly(SimpleTestCase):
+    def test_tx_tanf_config_extends_federal_and_appends_tx_state_code(self):
+        self.assertEqual(tx_tanf_config.state, "tx")
+        self.assertEqual(tx_tanf_config.pe_name, "tx_tanf")
+        self.assertIsNone(tx_tanf_config.pe_period_month)
+        self.assertIn(TxStateCodeDependency, tx_tanf_config.pe_inputs)
+
+
+class TestWaTanfConfigLoadsCorrectly(SimpleTestCase):
+    def test_wa_tanf_config_extends_federal_and_appends_wa_specific_inputs(self):
+        self.assertEqual(wa_tanf_config.state, "wa")
+        self.assertEqual(wa_tanf_config.pe_name, "wa_tanf")
+        self.assertIsNone(wa_tanf_config.pe_period_month)
+        self.assertIn(WaStateCodeDependency, wa_tanf_config.pe_inputs)
+        # WaTanf's real pe_inputs list is longer than TxTanf's -- wa_tanf's
+        # PolicyEngine formula needs more inputs, not more calculator logic
+        # (see tanf_registration.py's docstring).
+        self.assertIn(PregnancyDependency, wa_tanf_config.pe_inputs)
+        self.assertIn(WaShowAllCashAssistanceProgramsDependency, wa_tanf_config.pe_inputs)
+
+
+class TestTanfFactoryHasTxAndWaRegistered(SimpleTestCase):
+    def test_tx_and_wa_tanf_are_the_only_states_registered_so_far(self):
+        # Documents the current, deliberate state (tanf_registration.py's
+        # docstring) as an executable assertion, not just a comment -- this
+        # test should start failing the moment a third state IS registered,
+        # which is the correct signal to update it, not a bug.
+        self.assertEqual(
+            tanf_factory.as_dict(),
+            {"tx_tanf": TxTanfCalculator, "wa_tanf": WaTanfCalculator},
+        )
+
+
+class TestTxTanfCalculatorHouseholdValue(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Texas", code="tx", state_code="TX")
+        cls.fpl_year = FederalPoveryLimit.objects.create(year="2024", period="2024")
+
+    def test_calc_produces_the_same_value_as_real_tanf_household_value(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="79901",
+            county="El Paso County",
+            household_size=2,
+            completed=False,
+        )
+        HouseholdMember.objects.create(
+            screen=screen, relationship="headOfHousehold", age=30, disabled=False, student=False
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=8, disabled=False, student=False)
+        program = Program.objects.new_program(white_label="tx", name_abbreviated="tx_tanf")
+        program.year = self.fpl_year
+        program.save()
+
+        calculator = TxTanfCalculator(screen, program, Dependencies())
+        # No *12 conversion, unlike SNAP -- federal Tanf never overrides
+        # household_value()/pe_output_period (D-019), so the raw PolicyEngine
+        # value is read as-is.
+        calculator.set_engine(StubSim({("spm_units", "spm_unit", "tx_tanf", "2024"): 275.0}))
+
+        eligibility = calculator.calc()
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(eligibility.household_value, 275)
+
+
+class TestWaTanfCalculatorHouseholdValue(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Washington", code="wa", state_code="WA")
+        cls.fpl_year = FederalPoveryLimit.objects.create(year="2024", period="2024")
+
+    def test_calc_produces_the_same_value_as_real_tanf_household_value(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="99201",
+            county="Spokane County",
+            household_size=2,
+            household_assets=0,
+            completed=False,
+        )
+        HouseholdMember.objects.create(
+            screen=screen, relationship="headOfHousehold", age=34, disabled=False, student=False
+        )
+        HouseholdMember.objects.create(screen=screen, relationship="child", age=5, disabled=False, student=False)
+        program = Program.objects.new_program(white_label="wa", name_abbreviated="wa_tanf")
+        program.year = self.fpl_year
+        program.save()
+
+        calculator = WaTanfCalculator(screen, program, Dependencies())
+        # No *12 conversion, unlike SNAP -- same reasoning as TxTanf above.
+        calculator.set_engine(StubSim({("spm_units", "spm_unit", "wa_tanf", "2024"): 470.0}))
+
+        eligibility = calculator.calc()
+
+        self.assertTrue(eligibility.eligible)
+        self.assertEqual(eligibility.household_value, 470)

--- a/programs/programs/factories/tests/toy_registration.py
+++ b/programs/programs/factories/tests/toy_registration.py
@@ -1,0 +1,32 @@
+"""
+Test-only registration proving CalculatorFactory + ConfigurableCalculator
+slot into the real orchestration layer exactly like a real state's
+pe/__init__.py would -- imported BY the tests below, not a test itself.
+
+Deliberately fabricated program identity ("zz_toy_program"/state "zz", PE
+field "zz_toy_value") -- see the plan's Context section for why this is a
+different kind of artifact than the throwaway SnapCalculator D-010 ruled
+out: nothing here will ever be built for real in a later phase, and it
+proves orchestration coexistence, not SNAP parity.
+"""
+
+from programs.programs.config.loader import load_config_layer
+from programs.programs.factories.calculator_factory import CalculatorFactory
+
+_TOY_CONFIG_DICT = {
+    "program": "zz_toy_program",
+    "state": "zz",
+    "pe_name": "zz_toy_value",
+    "pe_entity": "spm_unit",
+    "state_dependency": None,
+    "extends": None,
+    "additional_inputs": ["FullTimeCollegeStudentDependency"],
+    "pe_period_month": None,
+}
+
+toy_config = load_config_layer(_TOY_CONFIG_DICT)
+
+factory = CalculatorFactory()
+ZzToyProgram = factory.register("zz_toy_program", toy_config)
+
+zz_toy_calculators = factory.as_dict()  # shaped exactly like co_spm_calculators

--- a/programs/programs/policyengine/client.py
+++ b/programs/programs/policyengine/client.py
@@ -1,0 +1,35 @@
+from typing import Any, Optional
+from .engines import Sim
+
+
+class PolicyEngineClient:
+    """
+    Thin wrapper around an already-constructed Sim, per RFC 0003
+    (rfcs/0003-program-calc-refactor/README.md). Does not construct or own
+    a Sim -- wrapping an existing instance never triggers a second PE API
+    call, since Sim.__init__ is the only place that call happens.
+
+    Only get_spm_value casts to int: SPM-level PE values in this codebase
+    are always currency (see DECISIONS.md D-009). get_member_value and
+    get_household_value return the raw value uncast, since their real
+    analogs (get_member_variable, get_member_dependency_value) are used for
+    non-numeric values too (e.g. medicaid_category/chip_category strings
+    used as dict keys) -- casting those would break on a value that was
+    never meant to be numeric. get_spm_value also takes an optional period
+    override (see DECISIONS.md D-013) -- SNAP's real value is monthly, not
+    at self.period's annual period, so SnapCalculator needs to read at a
+    different period than every other pure-pass-through program.
+    """
+
+    def __init__(self, sim: Sim, period: str):
+        self.sim = sim
+        self.period = period
+
+    def get_member_value(self, member_id: int, variable: str) -> Any:
+        return self.sim.value("people", str(member_id), variable, self.period)
+
+    def get_spm_value(self, variable: str, period: Optional[str] = None) -> int:
+        return int(self.sim.value("spm_units", "spm_unit", variable, period if period is not None else self.period))
+
+    def get_household_value(self, category: str, sub_category: str, variable: str) -> Any:
+        return self.sim.value(category, sub_category, variable, self.period)

--- a/programs/programs/policyengine/tests/cassettes/test_get_household_value_reads_arbitrary_category_uncast.yaml
+++ b/programs/programs/policyengine/tests/cassettes/test_get_household_value_reads_arbitrary_category_uncast.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"you": {"age": {"2024": 30}, "employment_income":
+      {"2024": 20000}}}, "families": {"your family": {"members": ["you"]}}, "spm_units":
+      {"spm_unit": {"members": ["you"], "snap": {"2024": null}}}, "tax_units": {"your
+      tax unit": {"members": ["you"]}}, "households": {"your household": {"members":
+      ["you"], "state_name": {"2024": "CO"}}}, "marital_units": {"your marital unit":
+      {"members": ["you"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"you": {"age":
+        {"2024": 30}, "employment_income": {"2024": 20000}}}, "families": {"your family":
+        {"members": ["you"]}}, "spm_units": {"spm_unit": {"members": ["you"], "snap":
+        {"2024": 279.59998}}}, "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {"2024":
+        "CO"}}}, "marital_units": {"your marital unit": {"members": ["you"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jul 2026 07:07:07 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - cf63ea80-763f-49ec-a8d6-8f2ed2a2f814
+      traceparent:
+      - 00-5886c545364bf8ea15f9f3a661a365ef-515289d62a60fe1b-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/policyengine/tests/cassettes/test_get_member_value_reads_person_level_value.yaml
+++ b/programs/programs/policyengine/tests/cassettes/test_get_member_value_reads_person_level_value.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"you": {"age": {"2024": 30}, "employment_income":
+      {"2024": 20000}}}, "families": {"your family": {"members": ["you"]}}, "spm_units":
+      {"spm_unit": {"members": ["you"], "snap": {"2024": null}}}, "tax_units": {"your
+      tax unit": {"members": ["you"]}}, "households": {"your household": {"members":
+      ["you"], "state_name": {"2024": "CO"}}}, "marital_units": {"your marital unit":
+      {"members": ["you"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"you": {"age":
+        {"2024": 30}, "employment_income": {"2024": 20000}}}, "families": {"your family":
+        {"members": ["you"]}}, "spm_units": {"spm_unit": {"members": ["you"], "snap":
+        {"2024": 279.59998}}}, "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {"2024":
+        "CO"}}}, "marital_units": {"your marital unit": {"members": ["you"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jul 2026 07:07:08 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - e1b25928-17df-40d7-b6ad-b2b5a4cde466
+      traceparent:
+      - 00-3d20267716db429f5d2fd611b92e777e-436bde7bbaca4bf3-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/policyengine/tests/cassettes/test_get_spm_value_casts_currency_to_int.yaml
+++ b/programs/programs/policyengine/tests/cassettes/test_get_spm_value_casts_currency_to_int.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"household": {"people": {"you": {"age": {"2024": 30}, "employment_income":
+      {"2024": 20000}}}, "families": {"your family": {"members": ["you"]}}, "spm_units":
+      {"spm_unit": {"members": ["you"], "snap": {"2024": null}}}, "tax_units": {"your
+      tax unit": {"members": ["you"]}}, "households": {"your household": {"members":
+      ["you"], "state_name": {"2024": "CO"}}}, "marital_units": {"your marital unit":
+      {"members": ["you"]}}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: http://localhost:8080/us/calculate
+  response:
+    body:
+      string: '{"status": "ok", "message": null, "result": {"people": {"you": {"age":
+        {"2024": 30}, "employment_income": {"2024": 20000}}}, "families": {"your family":
+        {"members": ["you"]}}, "spm_units": {"spm_unit": {"members": ["you"], "snap":
+        {"2024": 279.59998}}}, "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {"2024":
+        "CO"}}}, "marital_units": {"your marital unit": {"members": ["you"]}}}, "policyengine_bundle":
+        {"model_version": "1.755.0", "data_version": null, "dataset": null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 12 Jul 2026 07:07:09 GMT
+      Server:
+      - gunicorn
+      X-PolicyEngine-Request-Id:
+      - 1dc10ef3-f96c-4039-9e18-a404d37ae661
+      traceparent:
+      - 00-c427263a606c9a269c6230d5b2bc4fbd-2bddb35e8df78072-01
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/programs/programs/policyengine/tests/test_client.py
+++ b/programs/programs/policyengine/tests/test_client.py
@@ -1,0 +1,119 @@
+"""Unit tests for PolicyEngineClient (programs/programs/policyengine/client.py).
+
+Uses a stub Sim -- no network, no Docker required. See test_integration.py
+for tests against a real, recorded PolicyEngine response.
+"""
+
+from unittest.mock import patch
+from django.test import SimpleTestCase
+
+from programs.programs.policyengine.client import PolicyEngineClient
+from programs.programs.policyengine.engines import ApiSim
+
+
+class StubSim:
+    """Minimal Sim double: records every .value() call and returns canned values."""
+
+    def __init__(self, data=None):
+        self.data = data or {}
+        self.calls = []
+
+    def value(self, unit, sub_unit, variable, period):
+        self.calls.append((unit, sub_unit, variable, period))
+        return self.data[(unit, sub_unit, variable, period)]
+
+    def members(self, unit, sub_unit):
+        raise NotImplementedError
+
+
+class TestGetMemberValue(SimpleTestCase):
+    def test_reads_people_category_uncast(self):
+        sim = StubSim({("people", "1", "medicaid_category", "2024"): "ADULT"})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_member_value(1, "medicaid_category"), "ADULT")
+        self.assertEqual(sim.calls, [("people", "1", "medicaid_category", "2024")])
+
+    def test_does_not_cast_numeric_strings_that_are_not_currency(self):
+        # e.g. a FIPS county code -- would silently corrupt if cast to int.
+        sim = StubSim({("people", "1", "county_fips", "2024"): "08031"})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_member_value(1, "county_fips"), "08031")
+
+
+class TestGetSpmValue(SimpleTestCase):
+    def test_casts_to_int_truncating(self):
+        sim = StubSim({("spm_units", "spm_unit", "snap", "2024"): 279.59998})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_spm_value("snap"), 279)
+        self.assertEqual(sim.calls, [("spm_units", "spm_unit", "snap", "2024")])
+
+    def test_period_override_reads_at_the_given_period_not_self_period(self):
+        # SNAP's real value lives at the monthly pe_output_period ("2024-01"),
+        # not the annual self.period ("2024") -- see DECISIONS.md D-013.
+        sim = StubSim({("spm_units", "spm_unit", "snap", "2024-01"): 279.59998})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_spm_value("snap", period="2024-01"), 279)
+        self.assertEqual(sim.calls, [("spm_units", "spm_unit", "snap", "2024-01")])
+
+    def test_no_period_override_still_defaults_to_self_period(self):
+        sim = StubSim({("spm_units", "spm_unit", "snap", "2024"): 279.59998})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_spm_value("snap", period=None), 279)
+        self.assertEqual(sim.calls, [("spm_units", "spm_unit", "snap", "2024")])
+
+
+class TestGetHouseholdValue(SimpleTestCase):
+    def test_reads_arbitrary_category_uncast(self):
+        sim = StubSim({("households", "your household", "state_name", "2024"): "CO"})
+        client = PolicyEngineClient(sim, "2024")
+
+        self.assertEqual(client.get_household_value("households", "your household", "state_name"), "CO")
+        self.assertEqual(sim.calls, [("households", "your household", "state_name", "2024")])
+
+    def test_reads_tax_unit_category(self):
+        sim = StubSim({("tax_units", "your tax unit", "eitc", "2024"): 1500.4})
+        client = PolicyEngineClient(sim, "2024")
+
+        # Uncast on purpose (see DECISIONS.md D-009) -- caller casts if it needs to.
+        self.assertEqual(client.get_household_value("tax_units", "your tax unit", "eitc"), 1500.4)
+
+
+class TestWrappingExistingSimDoesNotTriggerASecondApiCall(SimpleTestCase):
+    """RFC 0003's own open question: does the client cause a second live PE call?"""
+
+    def test_constructing_the_client_makes_no_http_call(self):
+        with patch("requests.post") as mock_post:
+            sim = StubSim({("spm_units", "spm_unit", "snap", "2024"): 100})
+            PolicyEngineClient(sim, "2024")
+
+            mock_post.assert_not_called()
+
+    def test_multiple_getter_calls_reuse_the_same_sim_construction(self):
+        # ApiSim.__init__ is where the one real HTTP call happens (engines.py:43).
+        # Construct exactly one ApiSim, then call every client getter several times --
+        # the mocked requests.post call count must stay at 1 throughout.
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.raise_for_status.return_value = None
+            mock_post.return_value.json.return_value = {
+                "result": {
+                    "people": {"1": {"age": {"2024": 30}}},
+                    "spm_units": {"spm_unit": {"snap": {"2024": 279.6}}},
+                    "households": {"your household": {"state_name": {"2024": "CO"}}},
+                }
+            }
+
+            sim = ApiSim({"household": {}})
+            self.assertEqual(mock_post.call_count, 1)
+
+            client = PolicyEngineClient(sim, "2024")
+            for _ in range(3):
+                client.get_member_value(1, "age")
+                client.get_spm_value("snap")
+                client.get_household_value("households", "your household", "state_name")
+
+            self.assertEqual(mock_post.call_count, 1)

--- a/programs/programs/policyengine/tests/test_integration.py
+++ b/programs/programs/policyengine/tests/test_integration.py
@@ -1,0 +1,60 @@
+"""Integration tests for PolicyEngineClient against a real, recorded PolicyEngine
+response (per RFC 0008: "Use vcrpy fixtures for PolicyEngine calls").
+
+Follows the repo's existing VCR convention exactly (see
+integrations/clients/hud_income_limits/tests/test_integration.py and the
+auto_vcr fixture in the root conftest.py). Cassettes live in
+tests/cassettes/<test_name>.yaml, generated once against the local
+self-hosted PolicyEngine Docker container (see RISKS.md/DECISIONS.md D-003 --
+never the real hosted API), then replayed with zero live dependency.
+
+Run: pytest -m integration programs/programs/policyengine/tests/test_integration.py
+"""
+
+import pytest
+from django.test import SimpleTestCase
+
+from programs.programs.policyengine.client import PolicyEngineClient
+from programs.programs.policyengine.engines import ApiSim
+
+PERIOD = "2024"
+
+HOUSEHOLD_PAYLOAD = {
+    "household": {
+        "people": {"you": {"age": {PERIOD: 30}, "employment_income": {PERIOD: 20000}}},
+        "families": {"your family": {"members": ["you"]}},
+        "spm_units": {"spm_unit": {"members": ["you"], "snap": {PERIOD: None}}},
+        "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {"your household": {"members": ["you"], "state_name": {PERIOD: "CO"}}},
+        "marital_units": {"your marital unit": {"members": ["you"]}},
+    }
+}
+
+
+class DockerApiSim(ApiSim):
+    """Test-only Sim pointed at the local self-hosted Docker container instead of
+    PolicyEngine's real hosted API -- keeps faith with D-003 while still recording
+    a genuine response. Defined here only; engines.py is not touched."""
+
+    pe_url = "http://localhost:8080/us/calculate"
+
+
+@pytest.mark.integration
+class TestPolicyEngineClientAgainstRealResponse(SimpleTestCase):
+    def setUp(self):
+        self.sim = DockerApiSim(HOUSEHOLD_PAYLOAD)
+        self.client = PolicyEngineClient(self.sim, PERIOD)
+
+    def test_get_member_value_reads_person_level_value(self):
+        self.assertEqual(self.client.get_member_value("you", "age"), 30)
+
+    def test_get_spm_value_casts_currency_to_int(self):
+        # Real recorded value is a float (e.g. 279.59998); get_spm_value truncates.
+        value = self.client.get_spm_value("snap")
+        self.assertIsInstance(value, int)
+        self.assertGreater(value, 0)
+
+    def test_get_household_value_reads_arbitrary_category_uncast(self):
+        # state_name is a real non-numeric value on a category other than spm/people --
+        # confirms the method is genuinely generic, and returns it uncast.
+        self.assertEqual(self.client.get_household_value("households", "your household", "state_name"), "CO")

--- a/schemas/config_layer.schema.json
+++ b/schemas/config_layer.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://myfriendben.org/schemas/config-layer-v1.json",
+  "title": "Program config layer",
+  "description": "Wires a state's program to a PolicyEngine variable. Depth constraint (not expressible in this schema, enforced at runtime/CI instead): a config whose 'extends' is non-null must point to a config whose own 'extends' is null -- one level only, no chains, no cycles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "program",
+    "state",
+    "pe_name",
+    "pe_entity",
+    "state_dependency",
+    "extends",
+    "additional_inputs",
+    "pe_period_month"
+  ],
+  "properties": {
+    "program": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string",
+      "description": "Use \"federal\" as the sentinel for a base config that other configs extend."
+    },
+    "pe_name": {
+      "type": "string",
+      "description": "The PolicyEngine variable name, e.g. 'snap', 'co_tanf'."
+    },
+    "pe_entity": {
+      "type": "string",
+      "enum": ["spm_unit", "tax_unit", "person", "household", "family", "marital_unit"]
+    },
+    "state_dependency": {
+      "type": ["string", "null"],
+      "description": "The one state-code dependency class, e.g. CoStateCodeDependency. Null for federal-only configs."
+    },
+    "extends": {
+      "type": ["string", "null"],
+      "description": "The 'program' name of the base config this one extends, e.g. 'snap'. Null if fully self-contained."
+    },
+    "additional_inputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Dependency class names beyond extends's base (or the complete list if extends is null). Does not include state_dependency."
+    },
+    "pe_period_month": {
+      "type": ["string", "null"],
+      "description": "Default null (use pe_period as-is). Only federal SNAP sets this today, to '01'."
+    }
+  }
+}

--- a/schemas/data_layer.schema.json
+++ b/schemas/data_layer.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://myfriendben.org/schemas/data-layer-v1.json",
+  "title": "Benefit amount data layer",
+  "description": "Benefit amount tables for in-kind programs PolicyEngine does not compute a dollar value for (e.g. Medicaid, WIC). Not needed for pure cash pass-through programs (SNAP/TANF) — see PATTERNS.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["program", "state", "category_amounts", "source"],
+  "properties": {
+    "program": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "category_amounts": {
+      "type": "object",
+      "description": "Maps a category key (e.g. ADULT, INFANT) to a monthly dollar amount. No fixed key enum here deliberately — different programs use different taxonomies (Medicaid's 11 keys, WIC's 6).",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "Required, not optional — see DECISIONS.md D-005. Distinguishes a real citation from an honest gap, rather than relying on free-text convention alone.",
+      "additionalProperties": false,
+      "required": ["status", "citation"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["cited", "unsourced", "guessed"]
+        },
+        "citation": {
+          "type": ["string", "null"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "cited" } }
+          },
+          "then": {
+            "properties": { "citation": { "type": "string", "minLength": 1 } }
+          },
+          "else": {
+            "properties": { "citation": { "type": "null" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/examples/co_snap_config.json
+++ b/schemas/examples/co_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "co",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "CoStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/snap_federal.json
+++ b/schemas/examples/snap_federal.json
@@ -1,0 +1,33 @@
+{
+  "program": "snap",
+  "state": "federal",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": null,
+  "extends": null,
+  "additional_inputs": [
+    "SnapUnearnedIncomeDependency",
+    "SnapEarnedIncomeDependency",
+    "SnapAssetsDependency",
+    "SnapChildSupportDependency",
+    "PropertyTaxExpenseDependency",
+    "AgeDependency",
+    "MedicalExpenseDependency",
+    "IsDisabledDependency",
+    "SnapEmergencyAllotmentDependency",
+    "HousingCostDependency",
+    "HasPhoneExpenseDependency",
+    "HasHeatingCoolingExpenseDependency",
+    "HeatingCoolingExpenseDependency",
+    "ChildCareDependency",
+    "WaterExpenseDependency",
+    "PhoneExpenseDependency",
+    "HoaFeesExpenseDependency",
+    "HomeownersInsuranceExpenseDependency",
+    "FullTimeCollegeStudentDependency",
+    "PartTimeCollegeStudentDependency",
+    "SnapWorkExceptionDependency",
+    "SnapJobTrainingStudentDependency"
+  ],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/tx_snap_config.json
+++ b/schemas/examples/tx_snap_config.json
@@ -1,0 +1,10 @@
+{
+  "program": "snap",
+  "state": "tx",
+  "pe_name": "snap",
+  "pe_entity": "spm_unit",
+  "state_dependency": "TxStateCodeDependency",
+  "extends": "snap",
+  "additional_inputs": [],
+  "pe_period_month": "01"
+}

--- a/schemas/examples/wic_co.json
+++ b/schemas/examples/wic_co.json
@@ -1,0 +1,16 @@
+{
+  "program": "wic",
+  "state": "co",
+  "category_amounts": {
+    "NONE": 0,
+    "INFANT": 130,
+    "CHILD": 79,
+    "PREGNANT": 104,
+    "POSTPARTUM": 88,
+    "BREASTFEEDING": 121
+  },
+  "source": {
+    "status": "unsourced",
+    "citation": null
+  }
+}

--- a/schemas/examples/wic_nc.json
+++ b/schemas/examples/wic_nc.json
@@ -1,0 +1,16 @@
+{
+  "program": "wic",
+  "state": "nc",
+  "category_amounts": {
+    "NONE": 0,
+    "INFANT": 60,
+    "CHILD": 60,
+    "PREGNANT": 60,
+    "POSTPARTUM": 60,
+    "BREASTFEEDING": 60
+  },
+  "source": {
+    "status": "guessed",
+    "citation": null
+  }
+}

--- a/validations/management/commands/import_validations/data/co_snap.json
+++ b/validations/management/commands/import_validations/data/co_snap.json
@@ -1,0 +1,227 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "CO SNAP - Single Adult, Low Wage Income - Clearly Eligible. Used by the CO SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015) to compare old CoSnap vs new SnapCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "co",
+      "household_size": 1,
+      "zipcode": "80202",
+      "county": "Denver County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1994,
+          "age": 30,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 900.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+        
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "co_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "CO SNAP - Single Adult, High Wage Income - Should NOT Be Eligible. Used by the CO SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015) to compare old CoSnap vs new SnapCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "co",
+      "household_size": 1,
+      "zipcode": "80202",
+      "county": "Denver County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1994,
+          "age": 30,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 4200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "co_snap",
+      "eligible": false
+    }
+  },
+  {
+    "scenario_key": "household_size_edge",
+    "notes": "CO SNAP - Family of Four, Two Working Adults and Two Children - Household Size Edge Case. Exercises pe_input()'s per-member loop with multiple HouseholdMembers. Used by the CO SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015).",
+    "household": {
+      "white_label": "co",
+      "household_size": 4,
+      "zipcode": "80903",
+      "county": "El Paso County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 3,
+          "birth_year": 1989,
+          "age": 35,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 9,
+          "birth_year": 1991,
+          "age": 33,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 1,
+          "birth_year": 2016,
+          "age": 10,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 7,
+          "birth_year": 2019,
+          "age": 6,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 1500.0, "frequency": "monthly" },
+        { "type": "childcare", "amount": 400.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "co_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "non_integer_income",
+    "notes": "CO SNAP - Single Adult, Deliberately Odd Monthly Income - Stresses Cast/Rounding Behavior. Income chosen so the real PolicyEngine-computed monthly SNAP value is unlikely to land on a whole dollar amount, exercising the same cast-then-multiply-by-12 order D-013's 279.59998 fixture correction was written to catch, now through a real end-to-end PolicyEngine computation instead of a stubbed value. Used by the CO SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015).",
+    "household": {
+      "white_label": "co",
+      "household_size": 1,
+      "zipcode": "80301",
+      "county": "Boulder County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 11,
+          "birth_year": 1984,
+          "age": 40,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 1137.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 700.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "co_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "elderly_member",
+    "notes": "CO SNAP - Single Elderly Adult, Social Security Income - Federal Elderly Deduction Path. Exercises SNAP's real elderly-specific handling (age 60+), independent of WA's BBCE specifics -- CO has no BBCE net-income waiver, this scenario stresses the federal elderly pathway instead. Used by the CO SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015).",
+    "household": {
+      "white_label": "co",
+      "household_size": 1,
+      "zipcode": "80202",
+      "county": "Denver County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 2,
+          "birth_year": 1958,
+          "age": 67,
+          "disabled": false,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "sSRetirement",
+              "amount": 1200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "medicare": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 900.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "co_snap",
+      "eligible": true
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/il_snap.json
+++ b/validations/management/commands/import_validations/data/il_snap.json
@@ -1,0 +1,242 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "IL Basic Food (SNAP) - Single Adult, Income Well Below Federal 130% FPL Gross Test - Clearly Eligible. Own household (Chicago, own income), not copied from any other state's fixture.",
+    "household": {
+      "white_label": "il",
+      "household_size": 1,
+      "zipcode": "60601",
+      "county": "Cook County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 2,
+          "birth_year": 1988,
+          "age": 38,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 900.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "il_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "IL Basic Food (SNAP) - Single Adult, Gross Income Above IL's 165% FPL BBCE Ceiling - Should NOT Be Eligible. Income of $3,200/mo for HH=1 exceeds both the federal 130% FPL test and IL's own 165% FPL BBCE gross ceiling (IDHS MR #15.23 / PA 099-0170), so no categorical-eligibility path applies either.",
+    "household": {
+      "white_label": "il",
+      "household_size": 1,
+      "zipcode": "62701",
+      "county": "Sangamon County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 8,
+          "birth_year": 1985,
+          "age": 40,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 3200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "il_snap",
+      "eligible": false
+    }
+  },
+  {
+    "scenario_key": "household_size_edge",
+    "notes": "IL Basic Food (SNAP) - Household of 5, Moderate Income - Tests Household-Size Scaling. Own household (Rockford, own ages/income) distinct from any other state's household_size_edge scenario.",
+    "household": {
+      "white_label": "il",
+      "household_size": 5,
+      "zipcode": "61101",
+      "county": "Winnebago County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 11,
+          "birth_year": 1982,
+          "age": 43,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2600.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 5,
+          "birth_year": 1984,
+          "age": 42,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 1,
+          "birth_year": 2012,
+          "age": 14,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 6,
+          "birth_year": 2015,
+          "age": 11,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 10,
+          "birth_year": 2019,
+          "age": 6,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "il_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "elderly_member",
+    "notes": "IL Basic Food (SNAP) - Elderly Individual (Age 68), Fixed Income - Tests the AgeDependency/elderly-related deduction path. Own household (Peoria, own age/income), not copied from any other state's elderly_member scenario.",
+    "household": {
+      "white_label": "il",
+      "household_size": 1,
+      "zipcode": "61602",
+      "county": "Peoria County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 4,
+          "birth_year": 1958,
+          "age": 68,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "socialSecurity",
+              "amount": 1150.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "medicare": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "il_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "bbce_net_income_waiver",
+    "notes": "IL Basic Food (SNAP) - BBCE Stress Test - Gross Income Between Federal 130% and IL's 165% FPL Ceiling, Net Income Above 100% FPL - Expected Eligible Under Full Waiver. Own household (Chicago, single parent + 1 child), designed per DECISIONS.md D-022's IL BBCE research: PolicyEngine's real gov/hhs/tanf/non_cash/income_limit/gross.yaml sets IL's BBCE gross ceiling at 165% FPL (IDHS MR #15.23 / PA 099-0170), net_applies/non_hheod.yaml waives the net income test for IL, and asset_limit.yaml sets IL's asset limit to .inf -- a full gross+net+asset waiver, the same shape as WA/NC/TX, not MA's partial (gross-only) pattern. Gross $2,500/mo for HH=2 falls between the federal 130% FPL gross test (~$2,214/mo for HH=2) and IL's 165% FPL BBCE ceiling (~$2,811/mo); net income after standard/earned-income deductions is expected to land above the 100% FPL net-income limit (~$1,703/mo for HH=2), which would deny eligibility under the ordinary net income test but not under IL's full waiver.",
+    "household": {
+      "white_label": "il",
+      "household_size": 2,
+      "zipcode": "60601",
+      "county": "Cook County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 2,
+          "birth_year": 1988,
+          "age": 38,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2500.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 12,
+          "birth_year": 2016,
+          "age": 9,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "il_snap",
+      "eligible": true
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/ks_snap.json
+++ b/validations/management/commands/import_validations/data/ks_snap.json
@@ -1,0 +1,176 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "KS Food Assistance (SNAP) - Single Adult, Low Wage Income - Clearly Eligible. Kansas is one of only 7 states that has NOT adopted broad-based categorical eligibility (CBPP, 'Over 40 States Use Broad-Based Categorical Eligibility', cbpp.org/charts/over-40-states-use-broad-based-categorical-eligibility) -- KsSnap (ks/pe/spm.py) is confirmed pure pass-through with no state-specific waiver comparable to WA's/NC's BBCE mechanism, so scenarios reuse the same generic shapes CO's/TX's do rather than adding a state-specific stress case (same reasoning as TX). No independently-sourced expected dollar value exists for KS. Used by the generalized SNAP parity harness (DECISIONS.md D-017).",
+    "household": {
+      "white_label": "ks",
+      "household_size": 1,
+      "zipcode": "67202",
+      "county": "Sedgwick County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 3,
+          "birth_year": 1999,
+          "age": 27,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 850.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "ks_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "KS Food Assistance (SNAP) - Single Adult, High Wage Income - Should NOT Be Eligible. Kansas applies the strict federal 130% FPL gross income test with no BBCE expansion (CBPP chart, cbpp.org/charts/over-40-states-use-broad-based-categorical-eligibility). Used by the generalized SNAP parity harness (DECISIONS.md D-017).",
+    "household": {
+      "white_label": "ks",
+      "household_size": 1,
+      "zipcode": "66603",
+      "county": "Shawnee County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 11,
+          "birth_year": 1992,
+          "age": 33,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 3900.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "ks_snap",
+      "eligible": false
+    }
+  },
+  {
+    "scenario_key": "household_size_edge",
+    "notes": "KS Food Assistance (SNAP) - Single Working Parent, Two Children - Household Size Edge Case. Exercises pe_input()'s per-member loop with multiple HouseholdMembers, independently composed (single parent + 2 kids, not TX's two-parent family of 4). Used by the generalized SNAP parity harness (DECISIONS.md D-017). No independently-sourced expected dollar value exists for KS.",
+    "household": {
+      "white_label": "ks",
+      "household_size": 3,
+      "zipcode": "66204",
+      "county": "Johnson County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 5,
+          "birth_year": 1990,
+          "age": 36,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 1900.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 8,
+          "birth_year": 2015,
+          "age": 10,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 2,
+          "birth_year": 2019,
+          "age": 7,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 1100.0, "frequency": "monthly" },
+        { "type": "childcare", "amount": 350.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "ks_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "elderly_member",
+    "notes": "KS Food Assistance (SNAP) - Single Elderly Adult, Social Security Income - Federal Elderly Deduction Path. Exercises SNAP's real elderly-specific handling (age 60+), independent of any state-specific mechanism -- KS has no BBCE (CBPP chart). Used by the generalized SNAP parity harness (DECISIONS.md D-017). No independently-sourced expected dollar value exists for KS.",
+    "household": {
+      "white_label": "ks",
+      "household_size": 1,
+      "zipcode": "66101",
+      "county": "Wyandotte County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 4,
+          "birth_year": 1954,
+          "age": 71,
+          "disabled": false,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "sSRetirement",
+              "amount": 1100.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "medicare": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 800.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "ks_snap",
+      "eligible": true
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/ma_snap.json
+++ b/validations/management/commands/import_validations/data/ma_snap.json
@@ -1,0 +1,219 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "MA Supplemental Nutrition Assistance Program (SNAP) - Single Adult, Low Wage Income - Clearly Eligible. No independently-sourced expected dollar value exists for MA -- checked git history first, confirmed no prior MA SNAP work predates this project. Used by the generalized SNAP parity harness (DECISIONS.md D-017) to compare old MaSnap vs new SnapCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "ma",
+      "household_size": 1,
+      "zipcode": "02118",
+      "county": "Suffolk County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 7,
+          "birth_year": 1997,
+          "age": 29,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 850.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "ma_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "MA Supplemental Nutrition Assistance Program (SNAP) - Single Adult, High Wage Income Well Above the 200% FPL BBCE Ceiling - Should NOT Be Eligible. Massachusetts uses broad-based categorical eligibility (BBCE) at 200% FPL gross income, the maximum allowed under federal rules (106 CMR 364.976, 'Gross Monthly Categorical Eligibility Income Standards', mass.gov/doc/gross-monthly-categorical-eligibility-income-standards-as-referenced-at-106-cmr-364976/download) -- this income is chosen well above even that elevated ceiling so the household fails regardless of BBCE. Used by the generalized SNAP parity harness (DECISIONS.md D-017).",
+    "household": {
+      "white_label": "ma",
+      "household_size": 1,
+      "zipcode": "01608",
+      "county": "Worcester County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 10,
+          "birth_year": 1995,
+          "age": 31,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 3900.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "ma_snap",
+      "eligible": false
+    }
+  },
+  {
+    "scenario_key": "household_size_edge",
+    "notes": "MA Supplemental Nutrition Assistance Program (SNAP) - Two Working Adults, One Child - Household Size Edge Case. Exercises pe_input()'s per-member loop with multiple HouseholdMembers, independently composed (own MA city/incomes/ages, not copied from CO/WA/TX/NC's equivalent scenario). Used by the generalized SNAP parity harness (DECISIONS.md D-017). No independently-sourced expected dollar value exists for MA.",
+    "household": {
+      "white_label": "ma",
+      "household_size": 3,
+      "zipcode": "01103",
+      "county": "Hampden County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1987,
+          "age": 39,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 1950.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 12,
+          "birth_year": 1989,
+          "age": 36,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 600.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 3,
+          "birth_year": 2018,
+          "age": 8,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 1350.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "ma_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "elderly_member",
+    "notes": "MA Supplemental Nutrition Assistance Program (SNAP) - Single Elderly Adult, Social Security Income - Federal Elderly Deduction Path. Exercises SNAP's real elderly-specific handling (age 60+), independent of MA's own BBCE mechanism, with MA-specific location/age/amounts (not copied from another state's elderly_member scenario). Used by the generalized SNAP parity harness (DECISIONS.md D-017). No independently-sourced expected dollar value exists for MA.",
+    "household": {
+      "white_label": "ma",
+      "household_size": 1,
+      "zipcode": "01852",
+      "county": "Middlesex County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 1,
+          "birth_year": 1955,
+          "age": 70,
+          "disabled": false,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "sSRetirement",
+              "amount": 1000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "medicare": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 950.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "ma_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "ma_bbce_categorical_net_income_exemption",
+    "notes": "MA Supplemental Nutrition Assistance Program (SNAP) - MA's Own State-Specific BBCE Mechanism Regression Test - Gross Income Passes MA's 200% FPL BBCE Ceiling; Net Income Would Fail the Standard 100% FPL Test But Is Irrelevant. Went in with a narrower hypothesis, corrected after seeing the real recorded response -- worth stating both, since the correction is the actual finding. 106 CMR 364.976 ('Gross Monthly Categorical Eligibility Income Standards', mass.gov/doc/gross-monthly-categorical-eligibility-income-standards-as-referenced-at-106-cmr-364976/download) sets MA's broad-based categorical eligibility gross-income ceiling at 200% FPL. A secondary plain-language source (Massachusetts Legal Help, '68. Is there a gross income test for SNAP?', masslegalhelp.org/public-benefits-ssi/snap-food-benefits/68-there-gross-income-test-snap) reads as though the net income test still applies to the general population regardless of BBCE status, which was the original hypothesis this scenario was built to test -- gross wage income ($2,000/mo) chosen comfortably above the standard federal 130% FPL gross test but below MA's 200% FPL BBCE ceiling, with net income after standard SNAP deductions (~$1,400/mo, above the ~$1,255/mo 100% FPL net limit for FFY2024 HH=1) landing well past the net threshold. The actual Docker-recorded response returned a real, non-zero $23.28/mo benefit (the federal SNAP minimum allotment) -- the same value NC's expanded-cat-elig scenario returned last session for an analogous gross-passes/net-would-fail household -- meaning PolicyEngine implements MA's BBCE as a full categorical exemption from *both* the gross and net income tests, the same mechanism as WA's net_applies=false waiver and NC's Section 220.05.A.2 exemption, not the narrower gross-only reading the secondary source suggested. Most likely explanation: BBCE works by granting categorical eligibility via a token non-cash TANF-funded service, and federal categorical eligibility (7 CFR 273.2(j)) exempts a household from standard gross AND net income tests by definition -- the secondary source's caveat likely describes households processed outside that categorical path, not the common case PolicyEngine models here. Not independently re-verified beyond this one household; flagged as the actual, corrected finding rather than silently editing away the wrong hypothesis. No independently-sourced expected dollar value exists for MA. Used by the generalized SNAP parity harness (DECISIONS.md D-017).",
+    "household": {
+      "white_label": "ma",
+      "household_size": 1,
+      "zipcode": "02139",
+      "county": "Middlesex County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 9,
+          "birth_year": 1991,
+          "age": 34,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "ma_snap",
+      "eligible": true
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/nc_snap.json
+++ b/validations/management/commands/import_validations/data/nc_snap.json
@@ -1,0 +1,219 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "NC Food and Nutrition Services (SNAP) - Single Adult, Low Wage Income - Clearly Eligible. No independently-sourced expected dollar value exists for NC (unlike WA's value:864, traced to real commit 9a8019fd) -- no nc_snap.json or NC SNAP research predates this project (confirmed via git log search). Used by the generalized SNAP parity harness (DECISIONS.md D-017) to compare old NcSnap vs new SnapCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "nc",
+      "household_size": 1,
+      "zipcode": "27601",
+      "county": "Wake County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 4,
+          "birth_year": 1998,
+          "age": 28,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 980.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "nc_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "NC Food and Nutrition Services (SNAP) - Single Adult, High Wage Income Above 200% FPL Expanded Categorical Eligibility Threshold - Should NOT Be Eligible. $3,350/mo exceeds the 200% FPL gross income limit for HH=1 (~$2,608/mo, NC FNS Manual Section 220.02.E.2), so the household fails both expanded categorical eligibility and the standard gross income test. No independently-sourced expected dollar value exists for NC. Used by the generalized SNAP parity harness (DECISIONS.md D-017).",
+    "household": {
+      "white_label": "nc",
+      "household_size": 1,
+      "zipcode": "27601",
+      "county": "Wake County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 4,
+          "birth_year": 1998,
+          "age": 28,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 3350.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "nc_snap",
+      "eligible": false
+    }
+  },
+  {
+    "scenario_key": "household_size_edge",
+    "notes": "NC Food and Nutrition Services (SNAP) - Three-Person Household, Two Working Adults and One Child - Household Size Edge Case. Exercises pe_input()'s per-member loop with multiple HouseholdMembers, independently composed (3 members, not CO's/TX's 4; different incomes/rent, no childcare expense). Used by the generalized SNAP parity harness (DECISIONS.md D-017). No independently-sourced expected dollar value exists for NC.",
+    "household": {
+      "white_label": "nc",
+      "household_size": 3,
+      "zipcode": "28202",
+      "county": "Mecklenburg County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 11,
+          "birth_year": 1985,
+          "age": 40,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2100.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 2,
+          "birth_year": 1988,
+          "age": 38,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 700.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 5,
+          "birth_year": 2017,
+          "age": 9,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 1200.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "nc_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "elderly_member",
+    "notes": "NC Food and Nutrition Services (SNAP) - Single Elderly Adult, Social Security Income - Federal Elderly Deduction Path. Exercises SNAP's real elderly-specific handling (age 60+), independent of any state-specific mechanism, with NC-specific location/ages/amounts (not copied from CO's/TX's elderly_member scenario). Used by the generalized SNAP parity harness (DECISIONS.md D-017). No independently-sourced expected dollar value exists for NC.",
+    "household": {
+      "white_label": "nc",
+      "household_size": 1,
+      "zipcode": "28801",
+      "county": "Buncombe County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 9,
+          "birth_year": 1957,
+          "age": 68,
+          "disabled": false,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "sSRetirement",
+              "amount": 1050.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "medicare": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 750.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "nc_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "nc_expanded_cat_elig_net_income",
+    "notes": "NC Food and Nutrition Services (SNAP) - Expanded (200%) Categorical Eligibility Regression Test - Gross Income Passes 200% FPL, Net Income Would Exceed 100% FPL But Is Irrelevant. NC's own state-specific BBCE-equivalent mechanism, independently researched (not copied from WA's spec/fixture): NC FNS Manual Section 220 'Categorical Eligibility' (Change #02-2024, effective 2024-10-01, ncdhhs.gov/providers/dhhs-policies-manuals-and-forms, FNS-220-Categorical-Eligibility-10.2024.pdf). Section 220.02.E ('Expanded (200%) Categorical Eligibility') grants categorical eligibility once gross household income is at or below the 200% FPL maximum allowable gross income limit (and 3 other non-income criteria are met). Section 220.05.A.2 then states categorically eligible households (including expanded 200% cat-elig) are 'exempt from the gross and net income limits test' -- i.e. once the 200% gross test passes, the net income test does not gate eligibility, the same practical effect as WA's net_applies=false waiver, independently sourced from NC's own manual rather than assumed to work the same way. Gross income ($2,350/mo) is below the 200% FPL limit (~$2,608/mo for HH=1); net income after standard SNAP deductions (~20% earned income deduction + standard deduction, roughly $1,616/mo) would exceed the 100% FPL limit (~$1,304/mo) if the net test applied -- this scenario exists specifically to confirm PolicyEngine implements NC's expanded-categorical net-income exemption the same way it implements WA's, empirically, not just by policy citation. No independently-sourced expected dollar value exists for NC. Used by the generalized SNAP parity harness (DECISIONS.md D-017).",
+    "household": {
+      "white_label": "nc",
+      "household_size": 1,
+      "zipcode": "27401",
+      "county": "Guilford County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 8,
+          "birth_year": 1990,
+          "age": 36,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2350.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "nc_snap",
+      "eligible": true
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/tx_snap.json
+++ b/validations/management/commands/import_validations/data/tx_snap.json
@@ -1,0 +1,188 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "TX SNAP - Single Adult, Low Wage Income - Clearly Eligible. Used by the TX SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015) to compare old TxSnap vs new SnapCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "tx",
+      "household_size": 1,
+      "zipcode": "79901",
+      "county": "El Paso County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1994,
+          "age": 30,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 900.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+        
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "tx_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "TX SNAP - Single Adult, High Wage Income - Should NOT Be Eligible. Used by the TX SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015) to compare old TxSnap vs new SnapCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "tx",
+      "household_size": 1,
+      "zipcode": "79901",
+      "county": "El Paso County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1994,
+          "age": 30,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 4200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "tx_snap",
+      "eligible": false
+    }
+  },
+  {
+    "scenario_key": "household_size_edge",
+    "notes": "TX SNAP - Family of Four, Two Working Adults and Two Children - Household Size Edge Case. Exercises pe_input()'s per-member loop with multiple HouseholdMembers. Used by the TX SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015).",
+    "household": {
+      "white_label": "tx",
+      "household_size": 4,
+      "zipcode": "75201",
+      "county": "Dallas County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 3,
+          "birth_year": 1989,
+          "age": 35,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "spouse",
+          "birth_month": 9,
+          "birth_year": 1991,
+          "age": 33,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 1,
+          "birth_year": 2016,
+          "age": 10,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 7,
+          "birth_year": 2019,
+          "age": 6,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 1500.0, "frequency": "monthly" },
+        { "type": "childcare", "amount": 400.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "tx_snap",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "elderly_member",
+    "notes": "TX SNAP - Single Elderly Adult, Social Security Income - Federal Elderly Deduction Path. Exercises SNAP's real elderly-specific handling (age 60+), independent of any state-specific mechanism -- TX SNAP has no state-specific waiver comparable to WA's BBCE (confirmed pure pass-through during the Phase 4 audit). Used by the TX SNAP parallel-verification harness (DECISIONS.md D-013/D-014/D-015).",
+    "household": {
+      "white_label": "tx",
+      "household_size": 1,
+      "zipcode": "78701",
+      "county": "Travis County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 2,
+          "birth_year": 1958,
+          "age": 67,
+          "disabled": false,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "sSRetirement",
+              "amount": 1200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "medicare": true
+          }
+        }
+      ],
+      "expenses": [
+        { "type": "rent", "amount": 900.0, "frequency": "monthly" }
+      ]
+    },
+    "expected_results": {
+      "program_name": "tx_snap",
+      "eligible": true
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/tx_tanf.json
+++ b/validations/management/commands/import_validations/data/tx_tanf.json
@@ -1,0 +1,98 @@
+[
+  {
+    "scenario_key": "clearly_eligible",
+    "notes": "TX TANF - Single Parent, 1 Qualifying Child, Low Wage Income - Clearly Eligible. Used by the TX TANF parallel-verification harness (DECISIONS.md D-019) to compare old TxTanf vs the new registered ConfigurableCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "tx",
+      "household_size": 2,
+      "zipcode": "79901",
+      "county": "El Paso County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1994,
+          "age": 30,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 4,
+          "birth_year": 2018,
+          "age": 8,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "tx_tanf",
+      "eligible": true
+    }
+  },
+  {
+    "scenario_key": "clearly_ineligible",
+    "notes": "TX TANF - Single Parent, 1 Qualifying Child, High Wage Income - Should NOT Be Eligible. Used by the TX TANF parallel-verification harness (DECISIONS.md D-019) to compare old TxTanf vs the new registered ConfigurableCalculator against a real PolicyEngine response.",
+    "household": {
+      "white_label": "tx",
+      "household_size": 2,
+      "zipcode": "79901",
+      "county": "El Paso County",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1994,
+          "age": 30,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 5000.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        },
+        {
+          "relationship": "child",
+          "birth_month": 4,
+          "birth_year": 2018,
+          "age": 8,
+          "has_income": false,
+          "income_streams": [],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "tx_tanf",
+      "eligible": false
+    }
+  }
+]

--- a/validations/management/commands/import_validations/data/wa_snap.json
+++ b/validations/management/commands/import_validations/data/wa_snap.json
@@ -1,5 +1,6 @@
 [
   {
+    "scenario_key": "clearly_eligible",
     "notes": "WA Basic Food (SNAP) - Single Adult, Income Well Below 200% FPL - Clearly Eligible",
     "household": {
       "white_label": "wa",
@@ -37,6 +38,7 @@
     }
   },
   {
+    "scenario_key": "clearly_ineligible",
     "notes": "WA Basic Food (SNAP) - Single Adult, Gross Income Above 200% FPL ($2,661/mo) - Should NOT Be Eligible. Income of $2,661/mo exceeds both the SNAP FY2026 threshold ($2,608/mo, based on 2025 FPL: $15,650/yr ÷ 12 × 2) and the upcoming SNAP FY2027 threshold ($2,660/mo, based on 2026 FPL: $15,960/yr ÷ 12 × 2, effective Oct 2026). Value chosen to remain robustly ineligible across the Oct 2026 FPL-year transition.",
     "household": {
       "white_label": "wa",
@@ -74,6 +76,7 @@
     }
   },
   {
+    "scenario_key": "pregnant_household_size",
     "notes": "WA Basic Food (SNAP) - Pregnant Woman Living Alone, Below Income Threshold - Should Be Eligible with HH Size 1. Patmanson correction: federal SNAP (WAC 388-408-0015) does NOT count unborn children as household members; pregnancy only affects the work requirement exemption. Original scenario 14 incorrectly treated household as size 2.",
     "household": {
       "white_label": "wa",
@@ -109,6 +112,43 @@
       "program_name": "wa_snap",
       "eligible": true,
       "value": 864
+    }
+  },
+  {
+    "scenario_key": "bbce_net_income_waiver",
+    "notes": "WA Basic Food (SNAP) - BBCE Regression Test - Net Income Above 100% FPL But Still Eligible. Gross income ($2,200/mo) is below the 200% FPL limit ($2,608/mo for HH=1), so the household is categorically eligible under WA's Broad-Based Categorical Eligibility. Net income after standard deductions (~$1,541/mo) would exceed the 100% FPL limit (~$1,304/mo), but this is irrelevant under WA BBCE -- PolicyEngine implements this via meets_tanf_non_cash_net_income_test with net_applies=false for WA (see wa/snap/spec.md Scenario 9, and DECISIONS.md's WA-audit finding that this waiver lives entirely inside PolicyEngine, not in WaSnap/WaSnapCalculator's Python). Added specifically for the CO SNAP parity harness's extension to WA (Phase 4) -- the 3 original scenarios never exercised this state-specific mechanism at all.",
+    "household": {
+      "white_label": "wa",
+      "household_size": 1,
+      "zipcode": "98101",
+      "county": "King",
+      "household_assets": 0.0,
+      "agree_to_tos": true,
+      "is_13_or_older": true,
+      "household_members": [
+        {
+          "relationship": "headOfHousehold",
+          "birth_month": 6,
+          "birth_year": 1992,
+          "age": 34,
+          "has_income": true,
+          "income_streams": [
+            {
+              "type": "wages",
+              "amount": 2200.0,
+              "frequency": "monthly"
+            }
+          ],
+          "insurance": {
+            "none": true
+          }
+        }
+      ],
+      "expenses": []
+    },
+    "expected_results": {
+      "program_name": "wa_snap",
+      "eligible": true
     }
   }
 ]

--- a/validations/management/commands/import_validations/data/wa_tanf.json
+++ b/validations/management/commands/import_validations/data/wa_tanf.json
@@ -1,5 +1,6 @@
 [
   {
+    "scenario_key": "clearly_eligible",
     "notes": "Scenario 1: Clearly eligible single parent with two young children. Income $800/month, assets $1,500, WA resident, not receiving TANF.",
     "household": {
       "white_label": "wa",
@@ -78,6 +79,7 @@
     }
   },
   {
+    "scenario_key": "minimally_eligible_boundary",
     "notes": "Scenario 2: Minimally eligible — single parent with one child (age 17, turns 18 in June 2026), income $521/month, assets exactly at $6,000 limit.",
     "household": {
       "white_label": "wa",
@@ -139,6 +141,7 @@
     }
   },
   {
+    "scenario_key": "clearly_ineligible",
     "notes": "Scenario 5: Single parent with two children, income $2,500/month — countable earned income after disregard ($1,000) exceeds 3-person payment standard ($706). Ineligible.",
     "household": {
       "white_label": "wa",


### PR DESCRIPTION
## Context & Motivation

Fourth (and, per the human's explicit scope call, final) PR in the RFC 0003
architecture-prototype series — see #1637 (JSON schemas), #1638
(`PolicyEngineClient`), #1639 (`CalculatorFactory` + `ConfigurableCalculator`
adapter). This PR is the pilot itself: SNAP and TANF, migrated end-to-end
onto the new composition-based architecture (data/config JSON + a shared,
mostly-generic calculator class + explicit factory registration), verified
side by side against every existing state's real, unmodified, already-shipped
calculator.

RFC 0003's own thesis is that a new state's PolicyEngine-backed program
addition should become close to a JSON-only change for the common (pure
pass-through) case. This PR is the evidence for that claim: 9 state/program
registrations (7 SNAP states, 2 TANF states) each added as one config JSON +
a short registration entry + a fixture, with the underlying calculator class
(`ConfigurableCalculator`, or `SnapCalculator` for SNAP's one-line
monthly-to-annual override) written once and shared across all of them.

## Changes Made

- **`SnapCalculator`** (`programs/programs/calculators/snap.py`) — the one
  piece of Phase 3's `ConfigurableCalculator` that needed a subclass at all:
  a single `household_value()` override reproducing federal SNAP's real
  monthly-value read + `*12` annualization (`federal/pe/spm.py`), with the
  cast-then-multiply order verified directly against that source rather
  than assumed.
- **Production config/data JSON** (`programs/programs/config/data/`):
  `snap_federal.json` + 7 state SNAP configs (CO, WA, TX, NC, MA, KS, IL);
  `tanf_federal.json` + 2 state TANF configs (TX, WA).
- **Factory registration** (`programs/programs/factories/snap_registration.py`,
  `tanf_registration.py`) — each new calculator registered through
  `CalculatorFactory` under its own key (`co_snap`, `wa_tanf`, ...),
  deliberately not yet wired into any state's real `pe/__init__.py`
  registry (this PR adds and verifies the new path; switching production
  traffic over is a separate, later step).
- **Full parallel-verification harness**
  (`programs/programs/factories/tests/test_snap_parity.py`,
  `test_tanf_parity.py`, and their per-program manifests) — a single
  parameterized mechanism (not one hand-copied test file per state) that
  runs each state's real, shipped calculator and its new registered
  replacement through the *same*, unmodified `calc_pe_eligibility()`
  entry point against one real PolicyEngine response, and asserts an exact
  match on eligibility and household dollar value. 37 real household
  scenarios total (32 SNAP + 5 TANF) across all 9 registrations, each
  fixture independently authored (own cities/incomes/ages, not copied
  between states) in MyFriendBen's own existing `test_case_schema.json`
  fixture convention.
- Several scenarios were deliberately built to stress each state's own
  real, independently-researched state-specific mechanism rather than only
  the generic golden-path case: WA/NC/MA/IL's differing broad-based
  categorical-eligibility (BBCE) implementations (WA/NC/IL exempt both the
  gross and net income tests once categorically eligible; MA's own BBCE
  raises only the gross ceiling, confirmed by an initial hypothesis that
  turned out to be wrong and was corrected before landing — see that
  scenario's own `notes` field), and TX/KS's confirmed lack of any BBCE
  mechanism at all.
- **Result: 37/37 scenarios pass** — old and new calculators produce
  identical eligibility booleans and exact-match dollar values for every
  state and scenario, verified against a real self-hosted PolicyEngine
  instance and replaying cleanly with that instance stopped (zero live
  dependency at test time).

## Testing

- Migrations to run: none.
- Configuration updates needed: none (new calculators are registered but
  not wired into production traffic).
- Environment variables/settings to add: none beyond what #1637-#1639
  already introduce (self-hosted PolicyEngine Docker for integration
  tests, no new hosted credentials).
- Manual testing steps:
  - `pytest -m integration programs/programs/factories/tests/test_snap_parity.py programs/programs/factories/tests/test_tanf_parity.py` —
    37/37 passing against `ghcr.io/policyengine/policyengine-household-api:current`
    run locally via Docker; re-verified replaying cleanly with the
    container stopped.
  - `pytest -m "not integration"` — full non-integration suite passes with
    zero regressions.
  - `black --check` clean on every new `.py` file; new JSON files
    validated with `python -m json.tool` (this codebase doesn't run
    `black` against `.json`).

## Deployment

- Post-deployment scripts needed: none.
- Production config updates: none — the new calculators are registered
  through `CalculatorFactory` but not yet substituted for any state's real
  `pe/__init__.py` registry entry, so this PR changes zero production
  behavior on its own.
- Admin updates needed: none.
- Notify team/users of: nothing user-facing changes.

## Notes for Reviewers

- **This PR's diff is cumulative with #1637/#1638/#1639**, which are still
  open (awaiting the `action_required` workflow-approval gate). Until
  those merge, this diff necessarily includes their files too. **This PR's
  own new contribution is:**
  `programs/programs/calculators/snap.py` (+tests),
  `programs/programs/config/data/*.json` (11 files),
  `programs/programs/factories/snap_registration.py`,
  `programs/programs/factories/tanf_registration.py`,
  `programs/programs/factories/tests/{snap,tanf}_parity_manifest.py`,
  `test_{snap,tanf}_parity.py`, `test_{snap,tanf}_registration.py`, their
  37 VCR cassettes, and the 9 validation fixtures under
  `validations/management/commands/import_validations/data/`
  (`co/tx/nc/ma/ks/il_snap.json`, `tx_tanf.json`, plus additive
  `scenario_key` fields on the two pre-existing `wa_snap.json`/
  `wa_tanf.json` files — no existing scenario data in either file was
  changed).
- **`wa_snap.json` and `wa_tanf.json` predate this branch** (real
  production validation fixtures, `9a8019fd` and `f367e38f` respectively) —
  this PR only adds a `scenario_key` field to each existing scenario
  (needed by the new parity harness to key its parameterized test cases)
  and, in `wa_snap.json`'s case, one net-new scenario added in an earlier
  session specifically to stress WA's BBCE net-income waiver. Nothing
  about any pre-existing scenario's household data or expected value was
  touched.
- **Known limitation, not fixed here:** the parity harness proves the new
  architecture agrees with each state's *existing* calculator against a
  live PolicyEngine response — it cannot, by construction, catch both
  sides having drifted together away from real-world ground truth. One
  concrete instance surfaced during this work: WA's original
  Playwright-QA'd fixture value (`864`, from `9a8019fd`) no longer matches
  either calculator's live output (`1104`), most likely due to real
  upstream PolicyEngine SNAP-parameter drift since that value was
  recorded — both the old and new calculators agree with each other, just
  not with the historical value. Not something this PR fixes or needs to;
  flagged for whoever owns re-baselining that fixture.
- Known limitations carried over from earlier PRs in this series: WA's own
  `net_applies=false`-style BBCE waiver (and its NC/MA/IL analogs) lives
  entirely inside PolicyEngine's own parameters, not in this codebase —
  confirmed by direct inspection, not assumed.
- Future considerations: wiring these registrations into each state's real
  `pe/__init__.py` (switching production traffic over) is a deliberate,
  separate next step, not part of this PR. Extending this same pattern to
  the remaining SNAP/TANF states not yet registered (e.g. CO/IL/NC's TANF
  calculators — see the separate, already-open #1640, which flags a
  pre-existing, unrelated accuracy question in those three states' TANF
  income-counting that's worth resolving before registering them here) and
  to Tier 2 programs is scoped as this prototype's next phase.
