### PR TITLE
MFB-1325: Apply the FPP Policy Manual countable-income rules in the custom TX FPP calculator

### DIFF
--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -118,21 +118,19 @@ class TxFpp(ProgramCalculator):
         that table (an ``exclude`` list of the FPP-exempt income types) is a tracked
         follow-up, not implemented here.
         """
-        # Earned income counts only for adults (under-18 earnings are exempt). Members
-        # with no recorded age are not counted as adults.
+        # Adults only — under-18 (and unknown-age) earnings are exempt.
         adult_earned = sum(
             member.calc_gross_income("yearly", ["earned"])
             for member in self.screen.household_members.all()
             if member.age is not None and member.age >= self.child_age_threshold
         )
 
-        # Unearned income counts for all ages. Child support received is pulled out of
-        # the unearned bucket and re-added net of its (annualized) disregard.
+        # Child support received is pulled from the unearned bucket and re-added net of its
+        # annualized disregard.
         unearned = self.screen.calc_gross_income("yearly", ["unearned"], exclude=["childSupport"])
         child_support_received = self.screen.calc_gross_income("yearly", ["childSupport"])
         countable_child_support = max(0, child_support_received - self.child_support_received_disregard_monthly * 12)
 
-        # Child support paid is deducted.
         child_support_paid = self.screen.calc_expenses("yearly", ["childSupport"])
 
         return int(max(0, adult_earned + unearned + countable_child_support - child_support_paid))

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -59,6 +59,11 @@ class TxFpp(ProgramCalculator):
         "income_type",
         "income_amount",
         "income_frequency",
+        # _countable_income() reads the childSupport expense via calc_expenses(); declare the
+        # expense dependencies so an incomplete expense row makes can_calc() skip this program
+        # (DependencyError) instead of crashing calc_expenses() and 500-ing the whole request.
+        "expense_type",
+        "expense_amount",
         "household_size",
     ]
 

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -19,6 +19,11 @@ class TxFpp(ProgramCalculator):
       adjunctive income eligibility via enrollment in SNAP, WIC, or CHIP — applicant
       or their child (§4140). CHIP Perinatal, the 4th §4140 program, is not collected
       by the screener and is tracked as a data gap.
+      The income test uses a *countable* income that mirrors PolicyEngine's
+      gov.states.tx.fpp countable-income model at the version we serve (policyengine-us
+      1.768.1) — see ``_countable_income``. It is NOT a flat gross-income total; PE is
+      treated as the source of truth (not independently verified against 1 TAC §382.109
+      / the FPP Policy Manual). If PE changes its FPP countable-income logic, re-sync.
     - Not enrolled in (full) Medicaid (§4100). FPP serves those who earn too much for
       regular Medicaid. Emergency Medicaid recipients are classified as underinsured
       and remain eligible, so they are NOT excluded. Other coverage (employer, private,
@@ -38,9 +43,22 @@ class TxFpp(ProgramCalculator):
     max_age = 64
     fpl_percent = 2.5
     member_amount = 266.84
+
+    # Earnings of members below this age are exempt from countable income — mirrors
+    # PolicyEngine (1 TAC §382.109(3)(A); FPP Policy Manual 4140 treats 18-year-olds as
+    # adults). PE is treated as the source of truth here; not independently verified.
+    child_age_threshold = 18
+
+    # Monthly disregard applied to child support *received* before it counts as income —
+    # only the amount above this counts. $75/month per the Texas FPP Policy Manual
+    # (Definition of Income, Rev 24-2), mirroring PolicyEngine's
+    # gov.states.tx.fpp.income.child_support_disregard (unchanged since 2016-07-01).
+    child_support_received_disregard_monthly = 75
+
     dependencies: ClassVar[list[str]] = [
         "age",
         "insurance",
+        "income_type",
         "income_amount",
         "income_frequency",
         "household_size",
@@ -83,6 +101,40 @@ class TxFpp(ProgramCalculator):
             e.condition(True, messages.presumed_eligibility())
             return
 
-        gross_income = int(self.screen.calc_gross_income("yearly", ["all"]))
+        countable_income = self._countable_income()
         income_limit = int(self.fpl_percent * self.program.year.get_limit(self.screen.household_size))
-        e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+        e.condition(countable_income <= income_limit, messages.income(countable_income, income_limit))
+
+    def _countable_income(self) -> int:
+        """TX FPP countable income, mirroring PolicyEngine's gov.states.tx.fpp
+        (``tx_fpp_countable_income``) at the version we serve (policyengine-us 1.768.1).
+
+        Differs from a flat gross-income total in three ways (PE treated as source of
+        truth; not independently verified against 1 TAC §382.109 / the FPP Policy Manual):
+          - earnings of members under ``child_age_threshold`` are exempt,
+          - child support *paid* is deducted,
+          - child support *received* counts only above a monthly disregard.
+
+        The dependent-care deduction PE added in 1.771.2 (frontier) is intentionally NOT
+        applied — it is absent from the 1.768.1 model we serve.
+        """
+        # Earned income counts only for adults (under-18 earnings are exempt). Members
+        # with no recorded age are not counted as adults.
+        adult_earned = sum(
+            member.calc_gross_income("yearly", ["earned"])
+            for member in self.screen.household_members.all()
+            if member.age is not None and member.age >= self.child_age_threshold
+        )
+
+        # Unearned income counts for all ages. Child support received is pulled out of
+        # the unearned bucket and re-added net of its (annualized) disregard.
+        unearned = self.screen.calc_gross_income("yearly", ["unearned"], exclude=["childSupport"])
+        child_support_received = self.screen.calc_gross_income("yearly", ["childSupport"])
+        countable_child_support = max(
+            0, child_support_received - self.child_support_received_disregard_monthly * 12
+        )
+
+        # Child support paid is deducted.
+        child_support_paid = self.screen.calc_expenses("yearly", ["childSupport"])
+
+        return int(max(0, adult_earned + unearned + countable_child_support - child_support_paid))

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -130,9 +130,7 @@ class TxFpp(ProgramCalculator):
         # the unearned bucket and re-added net of its (annualized) disregard.
         unearned = self.screen.calc_gross_income("yearly", ["unearned"], exclude=["childSupport"])
         child_support_received = self.screen.calc_gross_income("yearly", ["childSupport"])
-        countable_child_support = max(
-            0, child_support_received - self.child_support_received_disregard_monthly * 12
-        )
+        countable_child_support = max(0, child_support_received - self.child_support_received_disregard_monthly * 12)
 
         # Child support paid is deducted.
         child_support_paid = self.screen.calc_expenses("yearly", ["childSupport"])

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -19,11 +19,9 @@ class TxFpp(ProgramCalculator):
       adjunctive income eligibility via enrollment in SNAP, WIC, or CHIP — applicant
       or their child (§4140). CHIP Perinatal, the 4th §4140 program, is not collected
       by the screener and is tracked as a data gap.
-      The income test uses a *countable* income that mirrors PolicyEngine's
-      gov.states.tx.fpp countable-income model at the version we serve (policyengine-us
-      1.768.1) — see ``_countable_income``. It is NOT a flat gross-income total; PE is
-      treated as the source of truth (not independently verified against 1 TAC §382.109
-      / the FPP Policy Manual). If PE changes its FPP countable-income logic, re-sync.
+      The income test uses a *countable* income (see ``_countable_income``), not a flat
+      gross-income total, per the FPP Policy Manual "Definition of Income" (Rev 24-2,
+      Oct. 15, 2024) and §4140. Re-check against the manual if it is revised.
     - Not enrolled in (full) Medicaid (§4100). FPP serves those who earn too much for
       regular Medicaid. Emergency Medicaid recipients are classified as underinsured
       and remain eligible, so they are NOT excluded. Other coverage (employer, private,
@@ -36,23 +34,23 @@ class TxFpp(ProgramCalculator):
     Benefit value:
     - $266.84/year per eligible participant — the average annual benefit value from the
       TX HHS Women's Health Programs Report FY2024 (total expenditures $78,705,897 ÷
-      294,954 clients served). Mirrors PolicyEngine's gov.states.tx.fpp.annual_benefit
-      parameter. The household total scales with the number of eligible members.
+      294,954 clients served). The household total scales with the number of eligible
+      members.
     """
 
     max_age = 64
     fpl_percent = 2.5
     member_amount = 266.84
 
-    # Earnings of members below this age are exempt from countable income — mirrors
-    # PolicyEngine (1 TAC §382.109(3)(A); FPP Policy Manual 4140 treats 18-year-olds as
-    # adults). PE is treated as the source of truth here; not independently verified.
+    # Earnings of members below this age are exempt from countable income. The FPP
+    # Definition of Income (Rev 24-2) exempts a child's earned income; §4140 / 1 TAC
+    # §382.109 set the cutoff by treating 18-year-olds as adults (so under-18 is exempt).
     child_age_threshold = 18
 
     # Monthly disregard applied to child support *received* before it counts as income —
-    # only the amount above this counts. $75/month per the Texas FPP Policy Manual
-    # (Definition of Income, Rev 24-2), mirroring PolicyEngine's
-    # gov.states.tx.fpp.income.child_support_disregard (unchanged since 2016-07-01).
+    # only the amount above this counts. FPP Definition of Income (Rev 24-2): "Count
+    # income after deducting $75 from the total monthly child support payments the
+    # household receives."
     child_support_received_disregard_monthly = 75
 
     dependencies: ClassVar[list[str]] = [
@@ -106,17 +104,19 @@ class TxFpp(ProgramCalculator):
         e.condition(countable_income <= income_limit, messages.income(countable_income, income_limit))
 
     def _countable_income(self) -> int:
-        """TX FPP countable income, mirroring PolicyEngine's gov.states.tx.fpp
-        (``tx_fpp_countable_income``) at the version we serve (policyengine-us 1.768.1).
+        """TX FPP countable income per the FPP Policy Manual "Definition of Income"
+        (Rev 24-2, Oct. 15, 2024) and §4140.
 
-        Differs from a flat gross-income total in three ways (PE treated as source of
-        truth; not independently verified against 1 TAC §382.109 / the FPP Policy Manual):
-          - earnings of members under ``child_age_threshold`` are exempt,
-          - child support *paid* is deducted,
-          - child support *received* counts only above a monthly disregard.
+        Differs from a flat gross-income total in three ways:
+          - a child's earned income is exempt (members under ``child_age_threshold``),
+          - child support *paid* by a household member is deducted (§4140 Step 2),
+          - child support *received* counts only above the monthly disregard.
 
-        The dependent-care deduction PE added in 1.771.2 (frontier) is intentionally NOT
-        applied — it is absent from the 1.768.1 model we serve.
+        Known limitation: the manual's "Types of Income" table exempts several other
+        income types this method still counts via the broad "unearned" bucket — e.g. SSI,
+        TANF, dividends/interest, EITC, and various assistance payments. Fully honoring
+        that table (an ``exclude`` list of the FPP-exempt income types) is a tracked
+        follow-up, not implemented here.
         """
         # Earned income counts only for adults (under-18 earnings are exempt). Members
         # with no recorded age are not counted as adults.

--- a/programs/programs/tx/fpp/spec.md
+++ b/programs/programs/tx/fpp/spec.md
@@ -3,14 +3,13 @@
 - **Program:** Family Planning Program (FPP)
 - **State:** TX (`tx`)
 - **name_abbreviated:** `tx_fpp`
-- **Tickets:** MFB-1088 (custom migration), MFB-1325 (countable-income rules per FPP Policy Manual)
 - **Calculator:** `programs/programs/tx/fpp/calculator.py` (`TxFpp`)
 
 ## Background
 
 FPP is a state-funded HHSC program offering free or low-cost reproductive and preventive
 health care to Texans through age 64. It was previously screened via a PolicyEngine
-calculator (`tx_fpp_benefit`). MFB-1088 migrates it to a **custom calculator** so the
+calculator (`tx_fpp_benefit`). It has been migrated to a **custom calculator** so the
 §4140 adjunctive income bypass — which depends on MFB enrollment flags PolicyEngine cannot
 see — can be enforced directly, and so the §4100 insurance rule can be relaxed from the
 prior strict "no insurance" filter to a Medicaid-only exclusion.
@@ -64,14 +63,14 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
        clients still qualify if they have a confidentiality concern OR an annual deductible
        > 5% of annual income. The screener cannot capture those conditions, so insured
        (non-Medicaid) clients are included and the §4200 caveat is surfaced in the program
-       description copy (added in MFB-1014).
+       description copy.
 
 4. **Texas residency** (§4130) — handled automatically by the TX white label; not re-checked.
 
 5. **Citizenship / immigration status — not required** (§4130)
    - `legal_status_required` includes all six values (no restriction). Per §4130, Form 1065,
-     and TMPPM Vol. 2 §1.1, FPP is available regardless of immigration status. (Team decision
-     on MFB-1088 #3: relax the prior restrictive filter.)
+     and TMPPM Vol. 2 §1.1, FPP is available regardless of immigration status. (Team decision:
+     relax the prior restrictive filter.)
 
 ## Benefit Value
 

--- a/programs/programs/tx/fpp/spec.md
+++ b/programs/programs/tx/fpp/spec.md
@@ -3,7 +3,7 @@
 - **Program:** Family Planning Program (FPP)
 - **State:** TX (`tx`)
 - **name_abbreviated:** `tx_fpp`
-- **Ticket:** MFB-1088
+- **Tickets:** MFB-1088 (custom migration), MFB-1325 (income mirror of PolicyEngine)
 - **Calculator:** `programs/programs/tx/fpp/calculator.py` (`TxFpp`)
 
 ## Background
@@ -22,14 +22,32 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
    - No minimum age. HHSC states only "64 or younger"; this matches PolicyEngine's
      `tx_fpp_age_eligible` (upper bound only). Members with no recorded age are not counted.
 
-2. **Household income at or below 250% FPL** (§4130), **OR adjunctive income eligibility** (§4140)
-   - Screener fields: `calc_gross_income("yearly", ["all"])`, `household_size`, `program.year`
-   - Income limit = `2.5 × FPL(household_size)` for the program's FPL year (2026).
+2. **Countable income at or below 250% FPL** (§4130), **OR adjunctive income eligibility** (§4140)
+   - Income limit = `2.5 × FPL(household_size)` for the program's FPL year (2026)
+     (`self.program.year.get_limit(household_size)`).
+   - **Countable income is not a flat gross total** — it mirrors PolicyEngine's
+     `gov.states.tx.fpp` countable-income model at the version we serve (policyengine-us
+     **1.768.1**), computed in `_countable_income()`. PolicyEngine is treated as the source of
+     truth here (not independently verified against 1 TAC §382.109 / the FPP Policy Manual).
+     It is `adult_earned + unearned + countable_child_support − child_support_paid`, floored at 0:
+     - **adult_earned** — earned income (`wages`, `selfEmployment`) summed only for members
+       age ≥ 18. Under-18 earnings are **exempt** (`child_age_threshold = 18`).
+     - **unearned** — all unearned income *except* child support received.
+     - **countable_child_support** — `max(0, child_support_received − disregard)`. The disregard
+       is **$75/month** ($900/yr) per the Texas FPP Policy Manual (Definition of Income, Rev 24-2),
+       mirroring PolicyEngine's `gov.states.tx.fpp.income.child_support_disregard` (unchanged
+       since 2016-07-01). Received child support ("Child Support (Received)" income) at or under
+       $900/yr counts as $0.
+     - **child_support_paid** — the `childSupport` expense, **deducted**.
+     - *Not applied:* the dependent-care deduction PolicyEngine added in 1.771.2 (frontier),
+       which is absent from the 1.768.1 model we serve. Re-sync if PE changes this logic.
    - **§4140 bypass** — enrollment in any of the following makes the household income-eligible
-     regardless of the 250% FPL test:
-     - SNAP — `screen.has_benefit("snap")`
-     - WIC — `screen.has_benefit("wic")`
-     - CHIP (applicant or their child) — `screen.has_benefit("chp")`
+     regardless of the countable-income test:
+     - SNAP — `screen.has_benefit("tx_snap")`
+     - WIC — `screen.has_benefit("tx_wic")`
+     - CHIP (applicant or their child) — `screen.has_insurance_types(("chp",))` (per-member
+       insurance; `tx_chip` is a PE eligibility program, never a current-benefit tile, so
+       `has_benefit("tx_chip")` is always False)
      - ⚠️ *data gap:* CHIP Perinatal, the 4th §4140 program, is not collected by the screener.
 
 3. **Not enrolled in (full) Medicaid** (§4100)
@@ -63,8 +81,8 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
 | Criterion | Fields | Notes |
 |-----------|--------|-------|
 | Age ≤ 64 | `birth_year`, `birth_month` | per-member; None-safe |
-| Income ≤ 250% FPL | `calc_gross_income`, `household_size`, `program.year` | gross income, all types |
-| §4140 bypass | `has_benefit("snap")`, `has_benefit("wic")`, `has_benefit("chp")` | CHIP Perinatal not captured (gap) |
+| Countable income ≤ 250% FPL | per-member `calc_gross_income(["earned"])` (adults only), screen `["unearned"]` / `["childSupport"]`, `calc_expenses(["childSupport"])`, `household_size`, `program.year` | mirrors PE `tx_fpp` countable income (1.768.1); child-support-received disregard $75/mo |
+| §4140 bypass | `has_benefit("tx_snap")`, `has_benefit("tx_wic")`, `has_insurance_types(("chp",))` | CHIP Perinatal not captured (gap) |
 | Medicaid exclusion | `member.insurance.medicaid` | Emergency Medicaid excluded from match |
 
 ## Validation Scenarios
@@ -74,3 +92,8 @@ the eligible standard case, the age-64 upper boundary, age-65/70 ineligible, the
 insurance rule (employer-insured now eligible; full-Medicaid excluded; Emergency Medicaid
 eligible), the 250% FPL income ceiling, the §4140 adjunctive bypass (income over 250% FPL but
 on SNAP → eligible), and a multi-eligible-member household (value 533).
+
+The **countable-income** behaviors (under-18 earnings exempt, child support paid deducted,
+child support received $75/mo disregard) are covered by unit tests in
+`tx/fpp/tests/test_fpp.py::TestTxFppCountableIncome`; the validation JSON does not yet include
+cases for them and should be extended to cover them.

--- a/programs/programs/tx/fpp/spec.md
+++ b/programs/programs/tx/fpp/spec.md
@@ -3,7 +3,7 @@
 - **Program:** Family Planning Program (FPP)
 - **State:** TX (`tx`)
 - **name_abbreviated:** `tx_fpp`
-- **Tickets:** MFB-1088 (custom migration), MFB-1325 (income mirror of PolicyEngine)
+- **Tickets:** MFB-1088 (custom migration), MFB-1325 (countable-income rules per FPP Policy Manual)
 - **Calculator:** `programs/programs/tx/fpp/calculator.py` (`TxFpp`)
 
 ## Background
@@ -19,28 +19,33 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
 
 1. **Age 64 or younger** (§4130)
    - Screener fields: `birth_year` + `birth_month` (→ `member.age`)
-   - No minimum age. HHSC states only "64 or younger"; this matches PolicyEngine's
-     `tx_fpp_age_eligible` (upper bound only). Members with no recorded age are not counted.
+   - No minimum age — the FPP Policy Manual states only "64 or younger" (§4130, upper
+     bound only). Members with no recorded age are not counted.
 
 2. **Countable income at or below 250% FPL** (§4130), **OR adjunctive income eligibility** (§4140)
    - Income limit = `2.5 × FPL(household_size)` for the program's FPL year (2026)
      (`self.program.year.get_limit(household_size)`).
-   - **Countable income is not a flat gross total** — it mirrors PolicyEngine's
-     `gov.states.tx.fpp` countable-income model at the version we serve (policyengine-us
-     **1.768.1**), computed in `_countable_income()`. PolicyEngine is treated as the source of
-     truth here (not independently verified against 1 TAC §382.109 / the FPP Policy Manual).
-     It is `adult_earned + unearned + countable_child_support − child_support_paid`, floored at 0:
+   - **Countable income is not a flat gross total** — it follows the FPP Policy Manual
+     "Definition of Income" (Rev 24-2, Oct. 15, 2024) and §4140, computed in
+     `_countable_income()`. It is `adult_earned + unearned + countable_child_support −
+     child_support_paid`, floored at 0:
      - **adult_earned** — earned income (`wages`, `selfEmployment`) summed only for members
-       age ≥ 18. Under-18 earnings are **exempt** (`child_age_threshold = 18`).
-     - **unearned** — all unearned income *except* child support received.
-     - **countable_child_support** — `max(0, child_support_received − disregard)`. The disregard
-       is **$75/month** ($900/yr) per the Texas FPP Policy Manual (Definition of Income, Rev 24-2),
-       mirroring PolicyEngine's `gov.states.tx.fpp.income.child_support_disregard` (unchanged
-       since 2016-07-01). Received child support ("Child Support (Received)" income) at or under
-       $900/yr counts as $0.
-     - **child_support_paid** — the `childSupport` expense, **deducted**.
-     - *Not applied:* the dependent-care deduction PolicyEngine added in 1.771.2 (frontier),
-       which is absent from the 1.768.1 model we serve. Re-sync if PE changes this logic.
+       age ≥ 18. A child's earned income is **exempt** (`child_age_threshold = 18`, per §4140 /
+       1 TAC §382.109).
+     - **unearned** — unearned income *except* child support received (see the limitation below).
+     - **countable_child_support** — `max(0, child_support_received − disregard)`. Per the
+       Definition of Income: *"Count income after deducting **$75** from the total monthly child
+       support payments the household receives."* Received child support ("Child Support
+       (Received)") at or under $900/yr counts as $0.
+     - **child_support_paid** — legally obligated child support paid by a household member is
+       **deducted** (§4140 Step 2); read from the `childSupport` expense.
+   - ⚠️ **Known limitation — exempt income types not yet excluded.** The Definition of Income
+     "Types of Income" table marks several types **Exempt** that `_countable_income()` still
+     counts through the broad `unearned` bucket — notably **SSI**, **TANF**, **dividends/interest
+     (`investment`)**, **EITC**, and various assistance / adoption / foster-care / in-kind
+     payments. The `exclude=` argument on `calc_gross_income` supports fixing this (an
+     FPP-exempt income-type list); it is a tracked follow-up, not implemented here. Effect: the
+     calc over-counts income for a narrow set of households and can under-approve at the margin.
    - **§4140 bypass** — enrollment in any of the following makes the household income-eligible
      regardless of the countable-income test:
      - SNAP — `screen.has_benefit("tx_snap")`
@@ -72,7 +77,7 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
 
 - **$266.84 / year per eligible member** (annual). Source: TX HHS Women's Health Programs
   Report FY2024 — total expenditures $78,705,897 ÷ 294,954 clients served = $266.84 average
-  annual benefit per participant. Mirrors PolicyEngine's `gov.states.tx.fpp.annual_benefit`.
+  annual benefit per participant.
 - The household total is the sum across eligible members (e.g., two eligible members →
   `trunc(266.84 × 2) = 533`).
 
@@ -81,7 +86,7 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
 | Criterion | Fields | Notes |
 |-----------|--------|-------|
 | Age ≤ 64 | `birth_year`, `birth_month` | per-member; None-safe |
-| Countable income ≤ 250% FPL | per-member `calc_gross_income(["earned"])` (adults only), screen `["unearned"]` / `["childSupport"]`, `calc_expenses(["childSupport"])`, `household_size`, `program.year` | mirrors PE `tx_fpp` countable income (1.768.1); child-support-received disregard $75/mo |
+| Countable income ≤ 250% FPL | per-member `calc_gross_income(["earned"])` (adults only), screen `["unearned"]` / `["childSupport"]`, `calc_expenses(["childSupport"])`, `household_size`, `program.year` | per FPP Definition of Income (Rev 24-2) + §4140; $75/mo child-support-received disregard; exempt income types not yet excluded (see limitation) |
 | §4140 bypass | `has_benefit("tx_snap")`, `has_benefit("tx_wic")`, `has_insurance_types(("chp",))` | CHIP Perinatal not captured (gap) |
 | Medicaid exclusion | `member.insurance.medicaid` | Emergency Medicaid excluded from match |
 

--- a/programs/programs/tx/fpp/spec.md
+++ b/programs/programs/tx/fpp/spec.md
@@ -3,6 +3,7 @@
 - **Program:** Family Planning Program (FPP)
 - **State:** TX (`tx`)
 - **name_abbreviated:** `tx_fpp`
+- **Tickets:** MFB-1088 (custom-calculator migration), MFB-1325 (FPP Policy Manual countable-income rules)
 - **Calculator:** `programs/programs/tx/fpp/calculator.py` (`TxFpp`)
 
 ## Background
@@ -89,15 +90,57 @@ prior strict "no insurance" filter to a Medicaid-only exclusion.
 | §4140 bypass | `has_benefit("tx_snap")`, `has_benefit("tx_wic")`, `has_insurance_types(("chp",))` | CHIP Perinatal not captured (gap) |
 | Medicaid exclusion | `member.insurance.medicaid` | Emergency Medicaid excluded from match |
 
-## Validation Scenarios
+## Test Scenarios
 
-See `validations/management/commands/import_validations/data/tx_fpp.json`. Coverage includes:
-the eligible standard case, the age-64 upper boundary, age-65/70 ineligible, the Medicaid-only
-insurance rule (employer-insured now eligible; full-Medicaid excluded; Emergency Medicaid
-eligible), the 250% FPL income ceiling, the §4140 adjunctive bypass (income over 250% FPL but
-on SNAP → eligible), and a multi-eligible-member household (value 533).
+These scenarios document the logic implemented in `calculator.py` (the source of truth) and
+are the basis for the unit tests in `tx/fpp/tests/test_fpp.py`. The income limit is
+`2.5 × FPL(household_size)`; examples below use an FPL of $15,000 → limit **$37,500**.
 
-The **countable-income** behaviors (under-18 earnings exempt, child support paid deducted,
-child support received $75/mo disregard) are covered by unit tests in
-`tx/fpp/tests/test_fpp.py::TestTxFppCountableIncome`; the validation JSON does not yet include
-cases for them and should be extended to cover them.
+**Age / insurance — per member (`member_eligible`)**
+
+| Scenario | Expected |
+|----------|----------|
+| Age 64 (upper boundary) | eligible |
+| Age 65 | ineligible |
+| Age unknown (`None`) | ineligible |
+| Young child (no minimum age) | eligible |
+| Uninsured | eligible |
+| Full Medicaid | ineligible |
+| Emergency Medicaid | eligible (underinsured, §4100) |
+| Employer / private / CHIP coverage | eligible (§4200) |
+
+**Income — countable vs 250% FPL (`household_eligible` / `_countable_income`)**
+
+| Scenario | Countable income | Expected |
+|----------|------------------|----------|
+| Unearned $20k | $20,000 | eligible |
+| Unearned exactly at limit | $37,500 | eligible |
+| Unearned $37,501 | $37,501 | ineligible |
+| Adult $30k earned + minor $15k earned | $30,000 (minor exempt) | eligible |
+| Two adults $30k + $15k (age 18 = adult) | $45,000 | ineligible |
+| Unknown-age member's earnings | not counted (can't confirm 18+) | — |
+| Unearned $40k − $5k child support paid | $35,000 | eligible |
+| Unearned $28k + $10k child support received ($75/mo disregard) | $37,100 | eligible |
+| Child support received ≤ $900/yr | $0 (fully disregarded) | — |
+| Deductions exceed income | floored at $0 | — |
+| All components combined | adult earned + unearned + (received − disregard) − paid | — |
+
+**§4140 adjunctive bypass — waives the income test**
+
+| Scenario | Expected |
+|----------|----------|
+| Enrolled in SNAP (`tx_snap`) | eligible regardless of income |
+| Enrolled in WIC (`tx_wic`) | eligible regardless of income |
+| CHIP coverage (per-member insurance) | eligible regardless of income |
+| High income, no bypass | ineligible |
+| Bare `snap` / `wic` (legacy unprefixed name) | no bypass |
+| `tx_chip` as a current benefit | no bypass (PE program, never a benefit tile) |
+| Bypass, but the only member is full-Medicaid | ineligible (bypass waives income only) |
+
+**Benefit value**
+
+| Scenario | Expected |
+|----------|----------|
+| One eligible member | $266.84 |
+| Two eligible members | $533.68 (sum) |
+| Ineligible member (Medicaid / over-age) in household | excluded from value |

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -71,7 +71,7 @@ def make_calculator(
 
     benefits = set(current_benefits or [])
 
-    def _gross(freq, types, exclude=[]):
+    def _gross(freq, types, exclude=None):
         if "unearned" in types:
             return unearned
         if "childSupport" in types:

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -4,7 +4,12 @@ Unit tests for TxFpp (Texas Family Planning Program) custom calculator.
 Eligibility:
 - Age 64 or younger (no minimum age)
 - Not enrolled in full Medicaid (Emergency Medicaid and other coverage are OK)
-- Household income <= 250% FPL, OR §4140 adjunctive bypass (SNAP / WIC / CHIP)
+- Countable income <= 250% FPL, OR §4140 adjunctive bypass (SNAP / WIC / CHIP)
+
+Countable income mirrors PolicyEngine's gov.states.tx.fpp model at the version we serve
+(policyengine-us 1.768.1): under-18 earnings are exempt, child support paid is deducted,
+and child support received counts only above a monthly disregard. PE is treated as the
+source of truth (not verified against 1 TAC §382.109 / the FPP Policy Manual).
 
 Benefit value: $266.84/year per eligible member.
 """
@@ -17,8 +22,12 @@ from programs.programs.tx.fpp.calculator import TxFpp
 from programs.programs.calc import ProgramCalculator, Eligibility, MemberEligibility
 
 
-def make_member(age=30, medicaid=False, emergency_medicaid=False, employer=False, none=True):
-    """Mock a household member with an insurance object."""
+def make_member(age=30, medicaid=False, emergency_medicaid=False, employer=False, none=True, earned=0):
+    """Mock a household member with an insurance object and (optionally) earned income.
+
+    `earned` is what the member's own `calc_gross_income(..., ["earned"])` returns — used by
+    `_countable_income`, which exempts the earnings of members under `child_age_threshold`.
+    """
     member = Mock()
     member.age = age
 
@@ -31,46 +40,53 @@ def make_member(age=30, medicaid=False, emergency_medicaid=False, employer=False
     insurance = Mock()
     insurance.has_insurance_types = Mock(side_effect=lambda types: any(flags.get(t, False) for t in types))
     member.insurance = insurance
+    member.calc_gross_income = Mock(side_effect=lambda freq, types, exclude=[]: earned if "earned" in types else 0)
     return member
 
 
 def make_calculator(
     current_benefits=None,
     has_chp=False,
-    household_income=0,
+    unearned=0,
+    child_support_received=0,
+    child_support_paid=0,
     household_size=1,
     fpl_limit=15_000,
     members=None,
 ):
     """Create a TxFpp calculator with a mocked screen and program.
 
-    The §4140 adjunctive bypass reads enrollment the way a real screen exposes it:
-    SNAP/WIC from the CurrentBenefit join table via has_benefit(), and CHIP from
-    per-member insurance via has_insurance_types(("chp",)). The mocks below mirror
-    those methods rather than the legacy has_snap/has_wic/has_chp columns, which the
-    serializer no longer populates (MFB-720) — so a regression back to those dead
-    columns would fail these tests.
+    Income is modeled the way `_countable_income` reads it:
+      - per-member earned income via each member's `calc_gross_income(["earned"])`
+        (set with `make_member(earned=...)`),
+      - `unearned` — screen-level unearned income excluding child support,
+      - `child_support_received` — screen-level child support income,
+      - `child_support_paid` — screen-level `childSupport` expense.
 
-    Args:
-        current_benefits: name_abbreviated strings the household already receives,
-            as written to the CurrentBenefit join table — e.g. ["tx_snap", "tx_wic"].
-            Drives has_benefit(). Note tx_chip is never a current benefit (it's a
-            PolicyEngine eligibility program), so passing it here is a no-op; use
-            has_chp for CHIP.
-        has_chp: whether a household member has CHIP coverage — a per-member
-            insurance flag, read via has_insurance_types(("chp",)), not a current
-            benefit.
+    The §4140 adjunctive bypass reads enrollment as a real screen exposes it: SNAP/WIC from
+    the CurrentBenefit join table via has_benefit(), CHIP from per-member insurance via
+    has_insurance_types(("chp",)) — not the legacy has_snap/has_wic/has_chp columns.
     """
     mock_program = Mock()
     mock_program.year.get_limit.return_value = fpl_limit
 
     benefits = set(current_benefits or [])
 
+    def _gross(freq, types, exclude=[]):
+        if "unearned" in types:
+            return unearned
+        if "childSupport" in types:
+            return child_support_received
+        return 0
+
     mock_screen = Mock()
     mock_screen.has_benefit = Mock(side_effect=lambda name_abbreviated: name_abbreviated in benefits)
     mock_screen.has_insurance_types = Mock(side_effect=lambda types, strict=True: has_chp and "chp" in types)
     mock_screen.household_size = household_size
-    mock_screen.calc_gross_income = Mock(return_value=household_income)
+    mock_screen.calc_gross_income = Mock(side_effect=_gross)
+    mock_screen.calc_expenses = Mock(
+        side_effect=lambda freq, types: child_support_paid if "childSupport" in types else 0
+    )
     mock_screen.household_members.all = Mock(return_value=members if members is not None else [])
 
     mock_missing_deps = Mock()
@@ -102,6 +118,14 @@ class TestTxFppClassAttributes(TestCase):
 
     def test_member_amount_is_annual_benefit(self):
         self.assertAlmostEqual(TxFpp.member_amount, 266.84)
+
+    def test_child_age_threshold_is_18(self):
+        self.assertEqual(TxFpp.child_age_threshold, 18)
+
+    def test_child_support_disregard_is_75_monthly(self):
+        """Child-support-received disregard is $75/month (Texas FPP Policy Manual,
+        Definition of Income Rev 24-2; PE gov.states.tx.fpp.income.child_support_disregard)."""
+        self.assertEqual(TxFpp.child_support_received_disregard_monthly, 75)
 
 
 class TestTxFppMemberEligibility(TestCase):
@@ -142,34 +166,123 @@ class TestTxFppMemberEligibility(TestCase):
 
 
 class TestTxFppHouseholdIncome(TestCase):
-    """Income gate — 250% FPL with no adjunctive bypass."""
+    """Income gate — countable income vs 250% FPL, no adjunctive bypass."""
 
-    def _run(self, household_income, fpl_limit=15_000):
-        # fpl_percent=2.5, so income_limit = int(2.5 * fpl_limit)
-        calc = make_calculator(household_income=household_income, fpl_limit=fpl_limit)
+    def _run(self, unearned, fpl_limit=15_000):
+        # fpl_percent=2.5, so income_limit = int(2.5 * fpl_limit) = 37,500 at fpl_limit 15,000
+        calc = make_calculator(unearned=unearned, fpl_limit=fpl_limit)
         e = Eligibility()
         add_eligible_member(e, make_member(age=30))
         calc.household_eligible(e)
         return e.eligible
 
     def test_income_below_250_fpl_is_eligible(self):
-        self.assertTrue(self._run(household_income=20_000, fpl_limit=15_000))  # limit 37,500
+        self.assertTrue(self._run(unearned=20_000))  # limit 37,500
 
     def test_income_exactly_at_250_fpl_is_eligible(self):
-        self.assertTrue(self._run(household_income=37_500, fpl_limit=15_000))  # limit 37,500
+        self.assertTrue(self._run(unearned=37_500))
 
     def test_income_above_250_fpl_is_ineligible(self):
-        self.assertFalse(self._run(household_income=37_501, fpl_limit=15_000))  # limit 37,500
+        self.assertFalse(self._run(unearned=37_501))
+
+
+class TestTxFppCountableIncome(TestCase):
+    """The three ways countable income mirrors PolicyEngine (vs a flat gross total)."""
+
+    def _household_eligible(self, calc):
+        e = Eligibility()
+        add_eligible_member(e, make_member(age=30))
+        calc.household_eligible(e)
+        return e.eligible
+
+    def test_minor_earnings_are_exempt(self):
+        """A minor's earnings don't count; only the adult's $30k is countable (<= $37,500)."""
+        adult = make_member(age=40, earned=30_000)
+        minor = make_member(age=16, earned=15_000)  # would push total to $45k if counted
+        calc = make_calculator(fpl_limit=15_000, members=[adult, minor])
+        self.assertTrue(self._household_eligible(calc))
+        self.assertEqual(calc._countable_income(), 30_000)
+
+    def test_adult_earnings_are_counted(self):
+        """Members at/over 18 are adults — both earners count ($45k > $37,500)."""
+        a1 = make_member(age=40, earned=30_000)
+        a2 = make_member(age=18, earned=15_000)
+        calc = make_calculator(fpl_limit=15_000, members=[a1, a2])
+        self.assertFalse(self._household_eligible(calc))
+        self.assertEqual(calc._countable_income(), 45_000)
+
+    def test_child_support_paid_is_deducted(self):
+        """$40k unearned minus $5k child support paid = $35k countable (<= $37,500)."""
+        calc = make_calculator(unearned=40_000, child_support_paid=5_000, fpl_limit=15_000)
+        self.assertTrue(self._household_eligible(calc))
+        self.assertEqual(calc._countable_income(), 35_000)
+
+    def test_child_support_received_applies_75_monthly_disregard(self):
+        """$75/mo ($900/yr) is disregarded, so $10k received counts as $9,100:
+        $28k + $9,100 = $37,100 (<= $37,500), eligible."""
+        calc = make_calculator(unearned=28_000, child_support_received=10_000, fpl_limit=15_000)
+        self.assertTrue(self._household_eligible(calc))
+        self.assertEqual(calc._countable_income(), 37_100)
+
+    def test_child_support_received_below_disregard_fully_excluded(self):
+        """Received child support at or under the annual disregard counts as $0:
+        $600/yr (< $900 disregard) → fully excluded, so only the $37k unearned counts."""
+        calc = make_calculator(unearned=37_000, child_support_received=600, fpl_limit=15_000)
+        self.assertTrue(self._household_eligible(calc))
+        self.assertEqual(calc._countable_income(), 37_000)
+
+    def test_disregard_is_what_changes_the_result(self):
+        """Without the disregard the same household would be over the limit — confirms the
+        disregard drives the outcome. $28k + $10k = $38k > $37,500."""
+        calc = make_calculator(unearned=28_000, child_support_received=10_000, fpl_limit=15_000)
+        calc.child_support_received_disregard_monthly = 0
+        self.assertFalse(self._household_eligible(calc))
+        self.assertEqual(calc._countable_income(), 38_000)
+
+    def test_countable_income_floored_at_zero(self):
+        """Deductions cannot drive countable income negative."""
+        calc = make_calculator(unearned=1_000, child_support_paid=5_000, fpl_limit=15_000)
+        self.assertEqual(calc._countable_income(), 0)
+
+    def test_member_with_unknown_age_earnings_excluded(self):
+        """A member with no recorded age is not treated as an adult, so their earnings are
+        excluded (can't confirm they're 18+)."""
+        adult = make_member(age=40, earned=20_000)
+        unknown_age = make_member(age=None, earned=15_000)
+        calc = make_calculator(fpl_limit=15_000, members=[adult, unknown_age])
+        self.assertEqual(calc._countable_income(), 20_000)
+
+    def test_child_support_paid_and_received_combined(self):
+        """Both child-support branches apply together: $20k unearned + ($10k received −
+        $900 disregard) − $5k paid = $24,100."""
+        calc = make_calculator(
+            unearned=20_000, child_support_received=10_000, child_support_paid=5_000, fpl_limit=15_000
+        )
+        self.assertEqual(calc._countable_income(), 24_100)
+
+    def test_countable_income_combines_all_components(self):
+        """adult earned + unearned + disregarded child support − child support paid.
+        $18k adult earned + $10k unearned + ($5k received − $900) − $2k paid = $30,100."""
+        adult = make_member(age=30, earned=18_000)
+        minor = make_member(age=10, earned=9_999)  # exempt
+        calc = make_calculator(
+            unearned=10_000,
+            child_support_received=5_000,
+            child_support_paid=2_000,
+            fpl_limit=15_000,
+            members=[adult, minor],
+        )
+        self.assertEqual(calc._countable_income(), 30_100)
 
 
 class TestTxFppAdjunctiveBypass(TestCase):
     """§4140 — SNAP / WIC / CHIP enrollment bypasses the income test."""
 
-    def _run(self, current_benefits=None, has_chp=False, household_income=99_999, fpl_limit=15_000):
+    def _run(self, current_benefits=None, has_chp=False, unearned=99_999, fpl_limit=15_000):
         calc = make_calculator(
             current_benefits=current_benefits,
             has_chp=has_chp,
-            household_income=household_income,
+            unearned=unearned,
             fpl_limit=fpl_limit,
         )
         e = Eligibility()
@@ -189,6 +302,27 @@ class TestTxFppAdjunctiveBypass(TestCase):
     def test_no_bypass_and_high_income_is_ineligible(self):
         self.assertFalse(self._run())
 
+    def test_unprefixed_snap_does_not_bypass(self):
+        """Only the TX-scoped name bypasses. A bare "snap"/"wic" (e.g. a regression to the
+        legacy columns) must NOT trigger the §4140 bypass."""
+        self.assertFalse(self._run(current_benefits=["snap"]))
+
+    def test_unprefixed_wic_does_not_bypass(self):
+        self.assertFalse(self._run(current_benefits=["wic"]))
+
+    def test_tx_chip_current_benefit_does_not_bypass(self):
+        """CHIP bypass comes from per-member insurance (has_insurance_types), not a current
+        benefit — tx_chip is a PE eligibility program, never written to the join table."""
+        self.assertFalse(self._run(current_benefits=["tx_chip"]))
+
+    def test_bypass_does_not_rescue_household_with_no_eligible_member(self):
+        """The bypass only waives the income test. A household whose only member is
+        disqualified (full Medicaid) is still ineligible even while enrolled in SNAP."""
+        member = make_member(age=30, none=False, medicaid=True)
+        calc = make_calculator(current_benefits=["tx_snap"], unearned=99_999, members=[member])
+        e = calc.calc()
+        self.assertFalse(e.eligible)
+
 
 class TestTxFppValue(TestCase):
     """Benefit value — $266.84 per eligible member, summed across members."""
@@ -199,14 +333,14 @@ class TestTxFppValue(TestCase):
 
     def test_single_eligible_member_value(self):
         member = make_member(age=30)
-        calc = make_calculator(household_income=10_000, fpl_limit=15_000, members=[member])
+        calc = make_calculator(unearned=10_000, fpl_limit=15_000, members=[member])
         e = calc.calc()
         self.assertTrue(e.eligible)
         self.assertAlmostEqual(e.value, 266.84)
 
     def test_two_eligible_members_value_sums(self):
         members = [make_member(age=55), make_member(age=30)]
-        calc = make_calculator(household_income=20_000, fpl_limit=15_000, members=members)
+        calc = make_calculator(unearned=20_000, fpl_limit=15_000, members=members)
         e = calc.calc()
         self.assertTrue(e.eligible)
         self.assertAlmostEqual(e.value, 533.68)
@@ -215,7 +349,17 @@ class TestTxFppValue(TestCase):
         """A Medicaid member does not count; only the eligible member contributes value."""
         eligible = make_member(age=32, none=True)
         medicaid_member = make_member(age=8, none=False, medicaid=True)
-        calc = make_calculator(household_income=20_000, fpl_limit=15_000, members=[eligible, medicaid_member])
+        calc = make_calculator(unearned=20_000, fpl_limit=15_000, members=[eligible, medicaid_member])
+        e = calc.calc()
+        self.assertTrue(e.eligible)
+        self.assertAlmostEqual(e.value, 266.84)
+
+    def test_over_age_member_excluded_from_value(self):
+        """An over-64 member is not eligible and contributes no value; only the in-range
+        member counts."""
+        eligible = make_member(age=40, none=True)
+        over_age = make_member(age=70, none=True)
+        calc = make_calculator(unearned=20_000, fpl_limit=15_000, members=[eligible, over_age])
         e = calc.calc()
         self.assertTrue(e.eligible)
         self.assertAlmostEqual(e.value, 266.84)
@@ -226,12 +370,36 @@ class TestTxFppIntegration(TestCase):
 
     def test_over_age_household_is_ineligible(self):
         member = make_member(age=70)
-        calc = make_calculator(household_income=10_000, fpl_limit=15_000, members=[member])
+        calc = make_calculator(unearned=10_000, fpl_limit=15_000, members=[member])
         e = calc.calc()
         self.assertFalse(e.eligible)
 
     def test_over_income_no_bypass_is_ineligible(self):
         member = make_member(age=30)
-        calc = make_calculator(household_income=99_999, fpl_limit=15_000, members=[member])
+        calc = make_calculator(unearned=99_999, fpl_limit=15_000, members=[member])
+        e = calc.calc()
+        self.assertFalse(e.eligible)
+
+    def test_working_minor_household_eligible_end_to_end(self):
+        """The minor-earnings exemption flows through the full calc(): an adult earning
+        $30k plus a 16-year-old earning $15k is income-eligible ($30k countable <= $37,500,
+        the minor's earnings exempt). Both are eligible members (FPP has no minimum age),
+        so the household value is 2 × $266.84 — the exemption affects the income test, not
+        who counts as a beneficiary.
+        """
+        adult = make_member(age=40, earned=30_000, none=True)
+        minor = make_member(age=16, earned=15_000, none=True)
+        calc = make_calculator(fpl_limit=15_000, members=[adult, minor])
+        e = calc.calc()
+        self.assertTrue(e.eligible)
+        self.assertAlmostEqual(e.value, 533.68)
+
+    def test_working_minor_would_be_ineligible_if_counted(self):
+        """Control for the above: if the minor's $15k earnings counted, the $45k total would
+        exceed the $37,500 limit. Setting the threshold to 0 (no exemption) makes it so."""
+        adult = make_member(age=40, earned=30_000, none=True)
+        minor = make_member(age=16, earned=15_000, none=True)
+        calc = make_calculator(fpl_limit=15_000, members=[adult, minor])
+        calc.child_age_threshold = 0  # count everyone's earnings
         e = calc.calc()
         self.assertFalse(e.eligible)

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -72,8 +72,14 @@ def make_calculator(
     benefits = set(current_benefits or [])
 
     def _gross(freq, types, exclude=None):
+        exclude = exclude or []
         if "unearned" in types:
-            return unearned
+            # In the real model childSupport lives in the "unearned" bucket; only exclude=
+            # removes it. Mirror that here so dropping exclude=["childSupport"] in the
+            # calculator (a double-count regression) actually breaks these tests.
+            if "childSupport" in exclude:
+                return unearned
+            return unearned + child_support_received
         if "childSupport" in types:
             return child_support_received
         return 0
@@ -125,6 +131,13 @@ class TestTxFppClassAttributes(TestCase):
         """Child-support-received disregard is $75/month (Texas FPP Policy Manual,
         Definition of Income Rev 24-2; PE gov.states.tx.fpp.income.child_support_disregard)."""
         self.assertEqual(TxFpp.child_support_received_disregard_monthly, 75)
+
+    def test_declares_expense_dependencies(self):
+        """_countable_income() reads the childSupport expense, so the expense deps must be
+        declared — otherwise an incomplete expense row crashes calc_expenses() and 500s the
+        whole eligibility request instead of skipping this program via DependencyError."""
+        self.assertIn("expense_type", TxFpp.dependencies)
+        self.assertIn("expense_amount", TxFpp.dependencies)
 
 
 class TestTxFppMemberEligibility(TestCase):
@@ -273,6 +286,20 @@ class TestTxFppCountableIncome(TestCase):
             members=[adult, minor],
         )
         self.assertEqual(calc._countable_income(), 30_100)
+
+    def test_unearned_query_excludes_child_support(self):
+        """Regression guard against double-counting child support. In the real model
+        childSupport lives in the "unearned" bucket, so the unearned query MUST pass
+        exclude=["childSupport"] — it is re-added once, net of the disregard. If a future
+        edit drops the exclude, production would count child support twice. This pins the
+        call contract directly, independent of the mock's fidelity."""
+        calc = make_calculator(unearned=20_000, child_support_received=10_000, fpl_limit=15_000)
+        calc._countable_income()
+
+        unearned_calls = [c for c in calc.screen.calc_gross_income.call_args_list if "unearned" in c.args[1]]
+        self.assertTrue(unearned_calls, "expected an unearned-income query")
+        for c in unearned_calls:
+            self.assertEqual(c.kwargs.get("exclude"), ["childSupport"])
 
 
 class TestTxFppAdjunctiveBypass(TestCase):

--- a/programs/programs/tx/fpp/tests/test_fpp.py
+++ b/programs/programs/tx/fpp/tests/test_fpp.py
@@ -6,10 +6,9 @@ Eligibility:
 - Not enrolled in full Medicaid (Emergency Medicaid and other coverage are OK)
 - Countable income <= 250% FPL, OR §4140 adjunctive bypass (SNAP / WIC / CHIP)
 
-Countable income mirrors PolicyEngine's gov.states.tx.fpp model at the version we serve
-(policyengine-us 1.768.1): under-18 earnings are exempt, child support paid is deducted,
-and child support received counts only above a monthly disregard. PE is treated as the
-source of truth (not verified against 1 TAC §382.109 / the FPP Policy Manual).
+Countable income follows the FPP Policy Manual "Definition of Income" (Rev 24-2) and §4140:
+under-18 earnings are exempt, child support paid is deducted, and child support received
+counts only above a $75/month disregard.
 
 Benefit value: $266.84/year per eligible member.
 """
@@ -187,7 +186,8 @@ class TestTxFppHouseholdIncome(TestCase):
 
 
 class TestTxFppCountableIncome(TestCase):
-    """The three ways countable income mirrors PolicyEngine (vs a flat gross total)."""
+    """The three ways countable income differs from a flat gross total (per the FPP
+    Definition of Income)."""
 
     def _household_eligible(self, calc):
         e = Eligibility()


### PR DESCRIPTION
## Context & Motivation

- Linear: **MFB-1325** — https://linear.app/myfriendben/issue/MFB-1325 (auto-linked via the `david/mfb-1325` branch)
- Related PR: #1642 (MFB-1316) — the hybrid-PolicyEngine re-migration that was explored and set aside in favor of this approach

The custom TX FPP calculator (from MFB-1088) measured income as a flat `gross_income("all") ≤ 250% FPL`, which diverges from the FPP **Definition of Income**. This PR brings the calculator's income test in line with the **TX FPP Policy Manual** — "Definition of Income" (Rev 24-2, Oct. 15, 2024) and §4130/§4140 — which is the source of truth here. (PolicyEngine models the same rules and was the initial reference, but each rule below was verified against the manual directly.)

Note: no change was strictly *required* — the custom calc never calls PolicyEngine — so this is a deliberate **accuracy** improvement (the old flat total was stricter than the FPP policy), not a forced fix.

## Changes Made

- **`_countable_income()` helper** (`tx/fpp/calculator.py`) replacing the flat `gross_income("all")` test, per the FPP Definition of Income:
  - **a child's earned income is exempt** — earned income summed only for members age ≥ 18 (`child_age_threshold = 18`, per §4140 / 1 TAC §382.109; members with no recorded age are not treated as adults);
  - **child support paid deducted** — legally obligated child support paid by a household member (§4140 Step 2), from the `childSupport` expense;
  - **child support received disregard** — Definition of Income: *"Count income after deducting $75 from the total monthly child support payments the household receives"* → `max(0, received − $75/mo)`;
  - countable income floored at 0.
- New constants `child_age_threshold = 18` and `child_support_received_disregard_monthly = 75`.
- Added `"income_type"` to `dependencies` (the calc now branches on income type), plus `"expense_type"` / `"expense_amount"` (the calc reads the `childSupport` expense; declaring these makes an incomplete expense row skip the program via `DependencyError` instead of crashing `calc_expenses` — hardening against the raw API, which the frontend never triggers).
- **Unchanged/preserved:** age ≤ 64 (no minimum age, §4130), §4100 Medicaid-only exclusion, §4140 SNAP/WIC/CHIP adjunctive bypass, flat $266.84/eligible-member value (TX HHS Women's Health Programs Report FY2024).
- Expanded tests to **47** (`tx/fpp/tests/test_fpp.py`) and updated `tx/fpp/spec.md` (added ticket refs; replaced the deprecated "Validation Scenarios" section with a calculator-derived "Test Scenarios" section that the unit tests mirror).

## Testing

- Migrations to run: none (no model/schema changes)
- Configuration updates needed: none
- Environment variables/settings to add: none
- Manual testing steps:
  - `pytest programs/programs/tx/fpp/tests/test_fpp.py` → 47 passed
  - `pytest programs/programs/tx` → passed (full TX suite)
  - This calc does **not** call PolicyEngine, so unit tests are the primary signal. Optional end-to-end check: submit a TX screen with (a) a working under-18 member, (b) child support paid, and (c) child support received near the 250% FPL line, and confirm `tx_fpp` reflects the exemption/deduction/disregard.

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: TX FPP income eligibility now uses countable income per the FPP Definition of Income. A small set of near-250%-FPL TX households — those with a working minor, child support paid, or modest child support received — may now qualify where they previously didn't. These are accuracy corrections (the old flat-income test was stricter), not regressions.

## Notes for Reviewers

- Verification: each income rule in this PR was checked against the FPP Policy Manual (§4130, §4140, and the "Definition of Income" table, Rev 24-2) — not merely against PolicyEngine.
- **Known limitation (pre-existing, not introduced here):** the Definition of Income "Types of Income" table also marks several types **Exempt** that `_countable_income()` still counts via the broad `unearned` bucket — notably **SSI, TANF, dividends/interest (`investment`), EITC**, and various assistance/adoption/foster-care/in-kind payments. The `exclude=` argument on `calc_gross_income` supports fixing this (an FPP-exempt income-type list); it's a bounded follow-up, deliberately out of scope here. Effect: the calc over-counts income for a narrow set of households and can under-approve at the margin.
- Future considerations:
  - Address the exempt-income-types gap above (follow-up).
  - The §4140 adjunctive list in the manual is CHIP **Perinatal**/SNAP/WIC; we use regular CHIP insurance as a proxy (existing data gap, noted in the spec).
  - Re-check against the FPP Policy Manual if it's revised (current basis: Rev 24-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated FPP eligibility to use policy-defined countable income (earned/unearned, with floors applied).
  * Earned income is excluded for members below the configured age threshold.
  * Added child support rules: $75/month disregard for received and deduction for paid.
  * Updated adjunctive bypass behavior for TX-specific SNAP/WIC identifiers and CHIP handling.
* **Bug Fixes**
  * Corrected eligibility outcomes for edge cases involving unknown ages and child support aggregation.
  * Prevented bypass from incorrectly qualifying otherwise ineligible households.
* **Documentation**
  * Refreshed the TX FPP spec, field mappings, and benefit value wording.
* **Tests**
  * Expanded unit and end-to-end test coverage for countable-income components and bypass scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
