### PR TITLE
MFB-1189 is_dependent() has no relationship test — unrelated members wrongly enter the tax unit (EITC understated)

### DIFF
--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -143,7 +143,10 @@ class ConfigurationData:
         },
         "domesticPartner": {"_label": "relationshipOptions.domesticPartner", "_default_message": "Domestic Partner"},
         "roommate": {"_label": "relationshipOptions.roommate", "_default_message": "Roommate"},
-        "relatedOther": {"_label": "relationshipOptions.relatedOther", "_default_message": "Related in some other way"},
+        "relatedOther": {
+            "_label": "relationshipOptions.relatedOther",
+            "_default_message": "Other relative (aunt, uncle, cousin, in-law, etc.)",
+        },
     }
 
     # Languages available for translation (add/remove as needed for your state)

--- a/programs/programs/policyengine/tests/test_qualifying_relative_units.py
+++ b/programs/programs/policyengine/tests/test_qualifying_relative_units.py
@@ -56,3 +56,39 @@ class TestQualifyingRelativeUnitSplitting(TestCase):
         self.assertIn(SECONDARY_TAX_UNIT, tax_units)
         self.assertIn(str(adult_child.id), tax_units[SECONDARY_TAX_UNIT]["members"])
         self.assertNotIn(str(adult_child.id), tax_units[MAIN_TAX_UNIT]["members"])
+
+    def test_unrelated_student_roommate_is_not_in_main_tax_unit(self):
+        """Path 1 regression: unrelated student roommate should remain outside main tax unit."""
+        roommate = HouseholdMember.objects.create(screen=self.screen, relationship="roommate", age=22, student=True)
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=roommate,
+            type="wages",
+            amount=3_000,
+            frequency="yearly",
+        )
+
+        result = pe_input(self.screen, [self.calc_class])
+        tax_units = result["household"]["tax_units"]
+
+        self.assertIn(SECONDARY_TAX_UNIT, tax_units)
+        self.assertIn(str(roommate.id), tax_units[SECONDARY_TAX_UNIT]["members"])
+        self.assertNotIn(str(roommate.id), tax_units[MAIN_TAX_UNIT]["members"])
+
+    def test_low_income_unrelated_housemate_is_not_in_main_tax_unit(self):
+        """Path 2 regression: low-income unrelated member should not be treated as dependent."""
+        housemate = HouseholdMember.objects.create(screen=self.screen, relationship="boyfriendOrGirlfriend", age=30)
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=housemate,
+            type="wages",
+            amount=1_000,
+            frequency="yearly",
+        )
+
+        result = pe_input(self.screen, [self.calc_class])
+        tax_units = result["household"]["tax_units"]
+
+        self.assertIn(SECONDARY_TAX_UNIT, tax_units)
+        self.assertIn(str(housemate.id), tax_units[SECONDARY_TAX_UNIT]["members"])
+        self.assertNotIn(str(housemate.id), tax_units[MAIN_TAX_UNIT]["members"])

--- a/screener/models.py
+++ b/screener/models.py
@@ -14,6 +14,31 @@ from .feature_flags import FeatureFlagConfig, WHITELABEL_FEATURE_FLAGS
 from .irs_parameters import get_qualifying_relative_threshold
 
 
+# Relationship values that are eligible for the dependent relationship checks
+# currently modeled in this method (qualifying-child proxy + qualifying-relative
+# proxy). NOTE:
+# - domesticPartner is intentionally excluded because it is treated as a
+#   spouse-equivalent in relationship_map()/is_spouse(), and therefore returns
+#   False early in is_dependent().
+# - roommate / boyfriendOrGirlfriend are intentionally excluded for the
+#   qualifying-relative path as a conservative proxy because we do not collect
+#   the full IRS non-relative tests (all-year residency + >50% support).
+DEPENDENT_ELIGIBLE_RELATIONSHIPS: frozenset[str] = frozenset(
+    {
+        "child",
+        "fosterChild",
+        "stepChild",
+        "grandChild",
+        "parent",
+        "stepParent",
+        "grandParent",
+        "sisterOrBrother",
+        "stepSisterOrBrother",
+        "relatedOther",
+    }
+)
+
+
 class WhiteLabel(models.Model):
     FEATURE_FLAGS: ClassVar[dict[str, FeatureFlagConfig]] = WHITELABEL_FEATURE_FLAGS
 
@@ -529,14 +554,18 @@ class HouseholdMember(models.Model):
         if is_tax_unit_head or is_tax_unit_spouse:
             return False
 
+        has_eligible_relationship = self.relationship in DEPENDENT_ELIGIBLE_RELATIONSHIPS
+
         # Path 1: Qualifying Child
-        is_qualifying_child = (self.age <= 18 or (self.student and self.age <= 23) or self.has_disability()) and (
+        is_qualifying_child = has_eligible_relationship and (
+            self.age <= 18 or (self.student and self.age <= 23) or self.has_disability()
+        ) and (
             self.calc_gross_income("yearly", ["all"]) <= self.screen.calc_gross_income("yearly", ["all"]) / 2
         )
 
         # Path 2: Qualifying Relative
         threshold = get_qualifying_relative_threshold(self.screen.get_reference_date().year)
-        is_qualifying_relative = self.calc_gross_income("yearly", ["all"]) < threshold
+        is_qualifying_relative = has_eligible_relationship and self.calc_gross_income("yearly", ["all"]) < threshold
 
         return is_qualifying_child or is_qualifying_relative
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from .feature_flags import FeatureFlagConfig, WHITELABEL_FEATURE_FLAGS
 from .irs_parameters import get_qualifying_relative_threshold
 
-
 # Relationship values that are eligible for the dependent relationship checks
 # currently modeled in this method (qualifying-child proxy + qualifying-relative
 # proxy). NOTE:

--- a/screener/models.py
+++ b/screener/models.py
@@ -557,10 +557,10 @@ class HouseholdMember(models.Model):
         has_eligible_relationship = self.relationship in DEPENDENT_ELIGIBLE_RELATIONSHIPS
 
         # Path 1: Qualifying Child
-        is_qualifying_child = has_eligible_relationship and (
-            self.age <= 18 or (self.student and self.age <= 23) or self.has_disability()
-        ) and (
-            self.calc_gross_income("yearly", ["all"]) <= self.screen.calc_gross_income("yearly", ["all"]) / 2
+        is_qualifying_child = (
+            has_eligible_relationship
+            and (self.age <= 18 or (self.student and self.age <= 23) or self.has_disability())
+            and (self.calc_gross_income("yearly", ["all"]) <= self.screen.calc_gross_income("yearly", ["all"]) / 2)
         )
 
         # Path 2: Qualifying Relative

--- a/screener/tests/test_is_dependent.py
+++ b/screener/tests/test_is_dependent.py
@@ -9,7 +9,6 @@ from screener.models import (
     WhiteLabel,
 )
 
-
 ALL_RELATIONSHIP_OPTIONS = set(ConfigurationData.relationship_options.keys())
 
 

--- a/screener/tests/test_is_dependent.py
+++ b/screener/tests/test_is_dependent.py
@@ -1,6 +1,16 @@
 from django.test import TestCase
-from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream
+from configuration.white_labels.base import ConfigurationData
 from screener.irs_parameters import get_qualifying_relative_threshold
+from screener.models import (
+    DEPENDENT_ELIGIBLE_RELATIONSHIPS,
+    HouseholdMember,
+    IncomeStream,
+    Screen,
+    WhiteLabel,
+)
+
+
+ALL_RELATIONSHIP_OPTIONS = set(ConfigurationData.relationship_options.keys())
 
 
 class TestIsDependent(TestCase):
@@ -8,89 +18,113 @@ class TestIsDependent(TestCase):
 
     def setUp(self):
         self.white_label = WhiteLabel.objects.create(name="Texas", code="tx", state_code="TX")
-        self.screen = Screen.objects.create(
+        self.screen = self._make_screen()
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=41)
+
+    def _make_screen(self):
+        return Screen.objects.create(
             white_label=self.white_label,
             completed=False,
         )
-        self.head = HouseholdMember.objects.create(
-            screen=self.screen,
-            relationship="headOfHousehold",
-            age=41,
+
+    def _add_yearly_income(self, member, amount, income_type="wages"):
+        IncomeStream.objects.create(
+            screen=member.screen,
+            household_member=member,
+            type=income_type,
+            amount=amount,
+            frequency="yearly",
         )
+
+    def _setup_path_1_household(self, relationship):
+        """Path 1 household: student under 24 with income low enough to pass ratio test."""
+        screen = self._make_screen()
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40)
+        member = HouseholdMember.objects.create(screen=screen, relationship=relationship, age=21, student=True)
+        self._add_yearly_income(head, 40_000)
+        self._add_yearly_income(member, 6_000)
+        return head, member
+
+    def _setup_path_2_household(self, relationship, income=1_000):
+        """Path 2 household: adult low-income member below qualifying-relative threshold."""
+        screen = self._make_screen()
+        HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=40)
+        member = HouseholdMember.objects.create(screen=screen, relationship=relationship, age=35, student=False)
+        self._add_yearly_income(member, income)
+        return member
 
     # Qualifying Child
 
     def test_qualifying_child_under_18(self):
         child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=7)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=self.head, type="wages", amount=40_000, frequency="yearly"
-        )
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=child, type="wages", amount=6_000, frequency="yearly"
-        )
+        self._add_yearly_income(self.head, 40_000)
+        self._add_yearly_income(child, 6_000)
         self.assertTrue(child.is_dependent())
 
     def test_qualifying_child_student_under_24(self):
         student = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=21, student=True)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=self.head, type="wages", amount=40_000, frequency="yearly"
-        )
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=student, type="wages", amount=6_000, frequency="yearly"
-        )
+        self._add_yearly_income(self.head, 40_000)
+        self._add_yearly_income(student, 6_000)
         self.assertTrue(student.is_dependent())
 
     def test_qualifying_child_disabled(self):
         disabled_adult = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=30, disabled=True)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=self.head, type="wages", amount=40_000, frequency="yearly"
-        )
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=disabled_adult, type="wages", amount=6_000, frequency="yearly"
-        )
+        self._add_yearly_income(self.head, 40_000)
+        self._add_yearly_income(disabled_adult, 6_000)
         self.assertTrue(disabled_adult.is_dependent())
+
+    def test_relationship_gate_applies_to_path_1_for_all_configured_relationships(self):
+        for relationship in sorted(ALL_RELATIONSHIP_OPTIONS):
+            with self.subTest(path="qualifying_child", relationship=relationship):
+                _, member = self._setup_path_1_household(relationship)
+                expected = relationship in DEPENDENT_ELIGIBLE_RELATIONSHIPS
+                self.assertEqual(member.is_dependent(), expected)
 
     # Qualifying Relative
 
     def test_qualifying_relative_below_threshold(self):
         adult_child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=19, student=False)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=adult_child, type="wages", amount=1_000, frequency="yearly"
-        )
+        self._add_yearly_income(adult_child, 1_000)
         self.assertTrue(adult_child.is_dependent())
 
     def test_qualifying_relative_exactly_at_threshold(self):
         # IRS rule is "less than" — at threshold should NOT be a dependent
         threshold = get_qualifying_relative_threshold(self.screen.get_reference_date().year)
         adult_child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=19)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=adult_child, type="wages", amount=threshold, frequency="yearly"
-        )
+        self._add_yearly_income(adult_child, threshold)
         self.assertFalse(adult_child.is_dependent())
 
     def test_qualifying_relative_above_threshold(self):
         threshold = get_qualifying_relative_threshold(self.screen.get_reference_date().year)
         adult_child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=19)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=adult_child, type="wages", amount=threshold + 1, frequency="yearly"
-        )
+        self._add_yearly_income(adult_child, threshold + 1)
         self.assertFalse(adult_child.is_dependent())
 
     def test_elderly_parent_low_income(self):
         parent = HouseholdMember.objects.create(screen=self.screen, relationship="parent", age=70)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=parent, type="sSRetirement", amount=4_000, frequency="yearly"
-        )
+        self._add_yearly_income(parent, 4_000, income_type="sSRetirement")
         self.assertTrue(parent.is_dependent())
+
+    def test_relationship_gate_applies_to_path_2_for_all_configured_relationships(self):
+        for relationship in sorted(ALL_RELATIONSHIP_OPTIONS):
+            with self.subTest(path="qualifying_relative", relationship=relationship):
+                member = self._setup_path_2_household(relationship, income=1_000)
+                expected = relationship in DEPENDENT_ELIGIBLE_RELATIONSHIPS
+                self.assertEqual(member.is_dependent(), expected)
 
     # Head and Spouse
 
     def test_spouse_is_never_dependent(self):
         spouse = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=39)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=spouse, type="wages", amount=0, frequency="yearly"
-        )
+        self._add_yearly_income(spouse, 0)
         self.assertFalse(spouse.is_dependent())
+
+    def test_domestic_partner_is_never_dependent_because_spouse_equivalent(self):
+        """Domestic partner is handled by spouse-pairing and should never enter dependent logic."""
+        partner = HouseholdMember.objects.create(screen=self.screen, relationship="domesticPartner", age=39)
+        self._add_yearly_income(partner, 0)
+        self.assertTrue(partner.is_spouse())
+        self.assertFalse(partner.is_dependent())
 
     def test_member_with_no_income(self):
         adult_child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=20)
@@ -100,9 +134,7 @@ class TestIsDependent(TestCase):
         """Adult child ($0) and elderly parent ($4k SS) are both qualifying relatives in the same household."""
         adult_child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=22, student=False)
         elderly_parent = HouseholdMember.objects.create(screen=self.screen, relationship="parent", age=72)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=elderly_parent, type="sSRetirement", amount=4_000, frequency="yearly"
-        )
+        self._add_yearly_income(elderly_parent, 4_000, income_type="sSRetirement")
 
         self.assertTrue(adult_child.is_dependent())
         self.assertTrue(elderly_parent.is_dependent())
@@ -115,41 +147,43 @@ class TestIsDependent(TestCase):
         child19 = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=19, student=False)
         child7 = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=7)
 
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=self.head, type="wages", amount=43_800, frequency="yearly"
-        )
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=spouse, type="wages", amount=18_000, frequency="yearly"
-        )
+        self._add_yearly_income(self.head, 43_800)
+        self._add_yearly_income(spouse, 18_000)
 
         self.assertTrue(child19.is_dependent())
         self.assertTrue(child7.is_dependent())
 
-        dependents = [m for m in self.screen.household_members.all() if m.is_dependent()]
+        dependents = [m for m in HouseholdMember.objects.filter(screen=self.screen) if m.is_dependent()]
         self.assertEqual(len(dependents), 2)
 
     # Other relatives and non-relatives
 
     def test_aunt_with_low_income(self):
         aunt = HouseholdMember.objects.create(screen=self.screen, relationship="relatedOther", age=50)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=aunt, type="wages", amount=2_000, frequency="yearly"
-        )
+        self._add_yearly_income(aunt, 2_000)
         self.assertTrue(aunt.is_dependent())
 
     def test_grandchild_low_income(self):
         grandchild = HouseholdMember.objects.create(screen=self.screen, relationship="grandChild", age=20)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=grandchild, type="wages", amount=1_000, frequency="yearly"
-        )
+        self._add_yearly_income(grandchild, 1_000)
         self.assertTrue(grandchild.is_dependent())
 
+    def test_two_student_roommates_do_not_trigger_path_1(self):
+        """Regression: unrelated student roommate must not be classified as dependent."""
+        _, roommate = self._setup_path_1_household("roommate")
+
+        self.assertFalse(roommate.is_dependent())
+        self.assertFalse(roommate.is_in_tax_unit())
+
+    def test_low_income_unrelated_housemate_does_not_trigger_path_2(self):
+        """Regression: low-income unrelated member must not pass qualifying-relative path."""
+        roommate = self._setup_path_2_household("roommate", income=1_000)
+
+        self.assertFalse(roommate.is_dependent())
+        self.assertFalse(roommate.is_in_tax_unit())
+
     def test_disabled_adult_above_qualifying_relative_threshold_still_dependent(self):
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=self.head, type="wages", amount=100_000, frequency="yearly"
-        )
+        self._add_yearly_income(self.head, 100_000)
         disabled_adult = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=30, disabled=True)
-        IncomeStream.objects.create(
-            screen=self.screen, household_member=disabled_adult, type="wages", amount=8_000, frequency="yearly"
-        )
+        self._add_yearly_income(disabled_adult, 8_000)
         self.assertTrue(disabled_adult.is_dependent())


### PR DESCRIPTION
## Context & Motivation

- Fixes #[MFB-1189](https://linear.app/myfriendben/issue/MFB-1189/is-dependent-has-no-relationship-test-unrelated-members-wrongly-enter)

## Changes Made
- Added relationship gating to [HouseholdMember.is_dependent()](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [models.py](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for both:
* qualifying-child path
* qualifying-relative path
- Introduced shared constant [DEPENDENT_ELIGIBLE_RELATIONSHIPS](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to avoid hardcoded branch-specific relationship checks.
- Explicitly excluded unrelated relationships ([roommate](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), boyfriendOrGirlfriend) from dependent eligibility.
- Updated dependent relationship set to align with IRS notes (including removing fosterParent from eligible set).
- Added/expanded tests in [test_is_dependent.py](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
* relationship coverage across both paths
* student roommate regression (Path 1)
* low-income unrelated housemate regression (Path 2)
* domestic partner behavior coverage
- Added tax-unit regression tests in [test_qualifying_relative_units.py](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ensure unrelated members stay out of [main_tax_unit](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
_ Updated relatedOther label text in [base.py](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for clearer UX intent:
"Other relative (aunt, uncle, cousin, in-law, etc.)"

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: no
- Configuration updates needed: yes
- Environment variables/settings to add: no
- Manual testing steps:

  1. Create a household with:
     - Head of household (`headOfHousehold`)
     - Optional spouse/domestic partner
     - Additional member with varying `relationship`, age/student/disability, and income.
  2. Verify `is_dependent()` behavior for both branches:
     - **Path 1 (qualifying child proxy)**: age/student/disability + income ratio
     - **Path 2 (qualifying relative proxy)**: below IRS threshold
  3. Confirm relationship gate is applied to **both** paths:
     - `roommate` and `boyfriendOrGirlfriend` should **not** be treated as dependents even if they satisfy income/age conditions.
  4. Generate PolicyEngine input and verify tax unit membership:
     - Unrelated members should be in `secondary_tax_unit` (not `main_tax_unit`).
  5. Confirm no regressions:
     - Legitimate relationships (`child`, `parent`, `sisterOrBrother`, `grandChild`, `relatedOther`, etc.) still behave as expected based on income/age criteria.

### Testing

#### Scenario 1: Two Student Roommates (Path 1 — qualifying child gate)
Unrelated student roommate must NOT be treated as head's dependent.
Screener input:
Field | Member 1 (Head) | Member 2 (Roommate)
-- | -- | --
Household Size | 2 |  
Relationship | (head, auto) | Roommate
Age | 30 | 22
Student | No | Yes (full-time)
Income | Wages, $20,000/yearly | Wages, $3,000/yearly

Scenario 1b (control — same but with "Child" relationship): Change Member 2's relationship from "Roommate" to "Child". Everything else identical. The child SHOULD be in the head's tax unit as a qualifying child. Compare EITC results — they should differ if the gate is working.
<img width="681" height="124" alt="image" src="https://github.com/user-attachments/assets/c1c1d13b-9281-43a1-aee7-7e1c373cc2cc" />

<img width="696" height="170" alt="image" src="https://github.com/user-attachments/assets/6ad851e5-7034-4f9c-9a6c-e5047f8df81b" />

---

#### Scenario 2 – Low-Income Partner (Qualifying Relative)
Screener input:
Field | Member 1 (Head) | Member 2 (Partner)
-- | -- | --
Household Size | 2 |  
Relationship | (head, auto) | Boyfriend/Girlfriend
Age | 35 | 30
Student | No | No
Income | Wages, $25,000/yearly | Wages, $1,000/yearly

<img width="681" height="123" alt="image" src="https://github.com/user-attachments/assets/eb84b1b9-79e9-4d5c-b1a5-8a5c177d8a96" />

#### Scenario 2b – Control
Change relationship to "Child" (age 30, $1k income). Now they SHOULD qualify as a qualifying relative and enter the head's tax unit. Results should differ.
<img width="762" height="236" alt="Screenshot 2026-07-23 132110" src="https://github.com/user-attachments/assets/44d7a6fa-e4dc-4ee2-8ff2-6728e6ff3351" />

---

#### Scenario 3 – Higher-Income Roommate (Regression)
- **Relationship:** Roommate
- **Income:** $18,000
- **Expected:** Excluded from the head's tax unit. EITC calculated correctly.

Screener input:
Field | Member 1 (Head) | Member 2 (Child) | Member 3 (Roommate)
-- | -- | -- | --
Household Size | 3 |   |  
Relationship | (head, auto) | Child | Roommate
Age | 35 | 8 | 22
Student | No | No | Yes
Income | Wages, $20,000/yearly | None | Wages, $18,000/yearly

<img width="690" height="165" alt="image" src="https://github.com/user-attachments/assets/d2fa4958-c564-4290-bd3c-5fcb1d113947" />

without roommate 

<img width="685" height="178" alt="image" src="https://github.com/user-attachments/assets/9ecb116c-968e-4ad6-9c0c-e80c73ff5e3a" />

---

#### Scenario 4 – Legitimate Dependents
Screener input:
Field | Head | Member 2 | Member 3
-- | -- | -- | --
Household Size | 3 |   |  
Relationship | (head) | Child | Parent
Age | 40 | 8 | 70
Student | No | No | No
Income | Wages, $40,000/yr | None | Social Security, $4,000/yr
<img width="684" height="120" alt="image" src="https://github.com/user-attachments/assets/e6dea442-fed7-4e41-bfa8-7e8de7ec6de8" />

Both child and parent should be in the head's tax unit. 
Child qualifies via Path 1 (age ≤ 18).
Parent qualifies via Path 2 (income $4k &lt; ~$5,300 threshold). 
EITC/CTC should reflect all three in the same tax unit

if change "Parent" to "Other relative (aunt, uncle, cousin, in-law, etc.)"
<img width="684" height="126" alt="image" src="https://github.com/user-attachments/assets/25db4f65-624b-460d-83d7-edbd97b22f00" />


---

#### Scenario 5 – Domestic Partner
Purpose: Domestic partner should pair with head as spouse, not enter dependent logic
Field | Head | Member 2
-- | -- | --
Household Size | 2 |  
Relationship | (head) | Domestic Partner
Age | 35 | 33
Income | Wages, $30,000/yr | None ($0)

<img width="689" height="125" alt="image" src="https://github.com/user-attachments/assets/32734d14-cd24-4888-a2c3-c8354c5b1275" />

Despite $0 income (which would easily pass the qualifying-relative threshold), the domestic partner should NOT be listed as a dependent
They should be treated as a spouse — results should show filing status as married/joint equivalent
Compare with a Scenario where Member 2 is "Spouse" — results should be identical

---

#### Scenario 6 – relatedOther Label (FE)
- **Expected:** Updated label displays **"Other relative (aunt, uncle, cousin, in-law, etc.)"**.

## Deployment

- Post-deployment scripts needed: no
- Production config updates: no
- Admin updates needed: yes,  `add_translations`
- Notify team/users of:  Superadmin access is needed to manually update this translation during deployment, since a saved value for relationshipOptions.relatedOther likely already exists in staging/production and may override the new code default.

## Notes for Reviewers


- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dependent eligibility now considers the household member’s relationship type, improving classification for qualifying children and relatives.
  - Unrelated roommates and housemates are correctly excluded from the primary tax unit when appropriate.

- **Updates**
  - Clarified the “Other relative” relationship option with examples such as aunt, uncle, cousin, and in-law.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->