### PR TITLE
MFB-1340: Consolidate KS/WA "Education" program category into childcare

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_early_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_early_head_start_initial_config.json
@@ -2,7 +2,7 @@
     "white_label": {"code": "ks"},
     "program_category": {
         "external_name": "ks_child_care",
-        "name": "Child Care",
+        "name": "Child Care, Youth, and Education",
         "icon": "child_care"
     },
     "program": {

--- a/programs/management/commands/import_program_config_data/data/ks_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_head_start_initial_config.json
@@ -2,7 +2,7 @@
     "white_label": {"code": "ks"},
     "program_category": {
         "external_name": "ks_child_care",
-        "name": "Child Care",
+        "name": "Child Care, Youth, and Education",
         "icon": "child_care"
     },
     "program": {

--- a/programs/management/commands/import_program_config_data/data/ks_promise_act_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_promise_act_initial_config.json
@@ -3,9 +3,9 @@
     "code": "ks"
   },
   "program_category": {
-    "external_name": "ks_education",
-    "name": "Education",
-    "icon": "education"
+    "external_name": "ks_child_care",
+    "name": "Child Care, Youth, and Education",
+    "icon": "child_care"
   },
   "program": {
     "name_abbreviated": "ks_promise_act",

--- a/programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wsos_bas_initial_config.json
@@ -3,9 +3,9 @@
     "code": "wa"
   },
   "program_category": {
-    "external_name": "wa_education",
-    "name": "Education",
-    "icon": "education"
+    "external_name": "wa_child_care",
+    "name": "Child Care, Youth, and Education",
+    "icon": "child_care"
   },
   "program": {
     "name_abbreviated": "wa_wsos_bas",

--- a/programs/management/commands/import_program_config_data/data/wa_wsos_cts_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wsos_cts_initial_config.json
@@ -3,9 +3,9 @@
     "code": "wa"
   },
   "program_category": {
-    "external_name": "wa_education",
-    "name": "Education",
-    "icon": "education"
+    "external_name": "wa_child_care",
+    "name": "Child Care, Youth, and Education",
+    "icon": "child_care"
   },
   "program": {
     "name_abbreviated": "wa_wsos_cts",

--- a/programs/management/commands/import_program_config_data/data/wa_wsos_grd_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_wsos_grd_initial_config.json
@@ -3,9 +3,9 @@
     "code": "wa"
   },
   "program_category": {
-    "external_name": "wa_education",
-    "name": "Education",
-    "icon": "education"
+    "external_name": "wa_child_care",
+    "name": "Child Care, Youth, and Education",
+    "icon": "child_care"
   },
   "program": {
     "name_abbreviated": "wa_wsos_grd",

--- a/programs/migrations/0163_delete_ks_wa_education_categories.py
+++ b/programs/migrations/0163_delete_ks_wa_education_categories.py
@@ -1,0 +1,75 @@
+# Deletes the standalone "Education" program categories for KS and WA
+# (ks_education / wa_education) after their programs have been reassigned to the
+# shared childcare category ("Child Care, Youth, and Education") via the admin.
+#
+# Defensive: Program.category is on_delete=SET_NULL, so deleting a category that
+# still has programs would silently leave those programs uncategorized. This
+# migration therefore REFUSES to delete a category that still has programs
+# pointing at it — it raises, failing the release, so an operator can finish the
+# admin reassignment first and redeploy. It does NOT reassign programs itself
+# (that is done manually in each environment's admin).
+#
+# Also deletes each category's now-orphaned name/description Translation rows.
+#
+# Idempotent: silently skips a category that is already gone (e.g. deleted in a
+# prior environment/run) and skips white labels not present in the environment.
+#
+# Not reversible — deleted ProgramCategory / Translation rows cannot be safely
+# recreated automatically. Restore from a DB snapshot if a rollback is needed.
+
+from django.db import migrations
+
+# (white_label code, education category external_name)
+TARGETS = [
+    ("ks", "ks_education"),
+    ("wa", "wa_education"),
+]
+
+
+def delete_education_categories(apps, schema_editor):
+    ProgramCategory = apps.get_model("programs", "ProgramCategory")
+    Program = apps.get_model("programs", "Program")
+    Translation = apps.get_model("translations", "Translation")
+    WhiteLabel = apps.get_model("screener", "WhiteLabel")
+
+    for wl_code, external_name in TARGETS:
+        try:
+            wl = WhiteLabel.objects.get(code=wl_code)
+        except WhiteLabel.DoesNotExist:
+            continue  # tenant not present (e.g. test environments)
+
+        category = ProgramCategory.objects.filter(white_label=wl, external_name=external_name).first()
+        if category is None:
+            continue  # already deleted — idempotent no-op
+
+        linked = sorted(Program.objects.filter(category=category).values_list("name_abbreviated", flat=True))
+        if linked:
+            raise RuntimeError(
+                f"Refusing to delete program category '{external_name}' ({wl_code}): "
+                f"{len(linked)} program(s) still reference it: {', '.join(linked)}. "
+                f"Program.category is SET_NULL, so deleting now would leave them uncategorized. "
+                f"Reassign them to '{wl_code}_child_care' in the admin, then redeploy to re-run this migration."
+            )
+
+        # Capture the translation FKs before deleting the category (they are
+        # PROTECT-referenced by the category, so they must be deleted after it).
+        translation_ids = [tid for tid in (category.name_id, category.description_id) if tid]
+        category.delete()
+        Translation.objects.filter(id__in=translation_ids).delete()
+
+
+def reverse(apps, schema_editor):
+    raise NotImplementedError(
+        "Irreversible: deleted ProgramCategory and Translation rows. Restore from a DB snapshot if needed."
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0162_alter_program_base_program"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_education_categories, reverse),
+    ]


### PR DESCRIPTION
## Summary

The KS Promise Scholarship Act (`ks_promise_act`) and the WA State Opportunity Scholarship programs (`wa_wsos_bas` / `wa_wsos_cts` / `wa_wsos_grd`) were assigned to standalone **"Education"** program categories (`ks_education` / `wa_education`). No other white label splits Education out — **5 of 7** (CO, IL, MA, NC, WA) use a single **"Child Care, Youth, and Education"** category.

This PR (1) updates the config source of truth so those programs point at the childcare category, and (2) adds a migration to delete the now-orphaned Education categories.

## Changes

### 1. Config (`import_program_config_data/data/`)

| File | `program_category` before | after |
|---|---|---|
| `ks_promise_act` | `ks_education` / "Education" / `education` | `ks_child_care` / "Child Care, Youth, and Education" / `child_care` |
| `wa_wsos_bas` | `wa_education` / "Education" / `education` | `wa_child_care` / "Child Care, Youth, and Education" / `child_care` |
| `wa_wsos_cts` | `wa_education` / "Education" / `education` | `wa_child_care` / "Child Care, Youth, and Education" / `child_care` |
| `wa_wsos_grd` | `wa_education` / "Education" / `education` | `wa_child_care` / "Child Care, Youth, and Education" / `child_care` |
| `ks_head_start` | name "Child Care" | name "Child Care, Youth, and Education" |
| `ks_early_head_start` | name "Child Care" | name "Child Care, Youth, and Education" |

All configs creating `ks_child_care` / `wa_child_care` now agree on the name, so a fresh import is order-independent. After this change, no config references `ks_education` / `wa_education`.

### 2. Migration `0163_delete_ks_wa_education_categories` (delete-only, defensive)

Deletes the `ks_education` / `wa_education` `ProgramCategory` rows plus their now-orphaned `name`/`description` Translation rows.

`Program.category` is `on_delete=SET_NULL`, so deleting a category that still has programs would **silently** leave them uncategorized. The migration therefore **does not reassign** programs itself — it **raises** (failing the release, no data change) if any program still references the category, naming the offending programs. Idempotent (skips categories already gone / white labels not present); not reversible (restore from snapshot).

## ⚠️ Required deploy order (per environment)

Because the migration is delete-only, the programs must be reassigned in each environment's **admin before this PR is deployed there**:

1. Reassign — KS: `ks_promise_act` → `ks_child_care`; WA: `wa_wsos_bas` / `wa_wsos_cts` / `wa_wsos_grd` → `wa_child_care`.
2. (Optional, cosmetic) Rename the KS `ks_child_care` category to "Child Care, Youth, and Education" (WA already correct).

If step 1 hasn't been done in an environment, that environment's release will fail **by design** (safe — no programs orphaned). Do the admin reassignment in staging + prod first, then deploy.

## Testing

- `test_import_all_program_configs.py` + `test_import_program_config.py` — 15/15 pass.
- `ks/promise_act` + `wa/wsos_{bas,cts,grd}` program tests — 71/71 pass.
- Migration happy path (no linked programs): deletes categories + orphaned translations — verified locally.
- Migration defensive path (programs still linked): verified in a rolled-back transaction — raised `RuntimeError` naming `ks_promise_act`, no changes made.

## Related

- Frontend PR MyFriendBen/benefits-calculator#2158 (`education` → `graduation-cap` icon) was closed as no longer needed for this path (Education is being removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)