### PR TITLE
Delete orphaned KS/WA Education program categories

### DIFF
--- a/programs/migrations/0163_delete_ks_wa_education_categories.py
+++ b/programs/migrations/0163_delete_ks_wa_education_categories.py
@@ -1,0 +1,75 @@
+# Deletes the standalone "Education" program categories for KS and WA
+# (ks_education / wa_education) after their programs have been reassigned to the
+# shared childcare category ("Child Care, Youth, and Education") via the admin.
+#
+# Defensive: Program.category is on_delete=SET_NULL, so deleting a category that
+# still has programs would silently leave those programs uncategorized. This
+# migration therefore REFUSES to delete a category that still has programs
+# pointing at it — it raises, failing the release, so an operator can finish the
+# admin reassignment first and redeploy. It does NOT reassign programs itself
+# (that is done manually in each environment's admin).
+#
+# Also deletes each category's now-orphaned name/description Translation rows.
+#
+# Idempotent: silently skips a category that is already gone (e.g. deleted in a
+# prior environment/run) and skips white labels not present in the environment.
+#
+# Not reversible — deleted ProgramCategory / Translation rows cannot be safely
+# recreated automatically. Restore from a DB snapshot if a rollback is needed.
+
+from django.db import migrations
+
+# (white_label code, education category external_name)
+TARGETS = [
+    ("ks", "ks_education"),
+    ("wa", "wa_education"),
+]
+
+
+def delete_education_categories(apps, schema_editor):
+    ProgramCategory = apps.get_model("programs", "ProgramCategory")
+    Program = apps.get_model("programs", "Program")
+    Translation = apps.get_model("translations", "Translation")
+    WhiteLabel = apps.get_model("screener", "WhiteLabel")
+
+    for wl_code, external_name in TARGETS:
+        try:
+            wl = WhiteLabel.objects.get(code=wl_code)
+        except WhiteLabel.DoesNotExist:
+            continue  # tenant not present (e.g. test environments)
+
+        category = ProgramCategory.objects.filter(white_label=wl, external_name=external_name).first()
+        if category is None:
+            continue  # already deleted — idempotent no-op
+
+        linked = sorted(Program.objects.filter(category=category).values_list("name_abbreviated", flat=True))
+        if linked:
+            raise RuntimeError(
+                f"Refusing to delete program category '{external_name}' ({wl_code}): "
+                f"{len(linked)} program(s) still reference it: {', '.join(linked)}. "
+                f"Program.category is SET_NULL, so deleting now would leave them uncategorized. "
+                f"Reassign them to '{wl_code}_child_care' in the admin, then redeploy to re-run this migration."
+            )
+
+        # Capture the translation FKs before deleting the category (they are
+        # PROTECT-referenced by the category, so they must be deleted after it).
+        translation_ids = [tid for tid in (category.name_id, category.description_id) if tid]
+        category.delete()
+        Translation.objects.filter(id__in=translation_ids).delete()
+
+
+def reverse(apps, schema_editor):
+    raise NotImplementedError(
+        "Irreversible: deleted ProgramCategory and Translation rows. Restore from a DB snapshot if needed."
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0162_alter_program_base_program"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_education_categories, reverse),
+    ]


### PR DESCRIPTION
## Summary

Follow-up to #1647 (config consolidation). Adds migration `0163_delete_ks_wa_education_categories` that removes the standalone `ks_education` / `wa_education` `ProgramCategory` rows once their programs have been reassigned to the shared childcare category ("Child Care, Youth, and Education").

## Why a migration (not manual admin)

The categories must be deleted identically in local, staging, and prod. A data migration runs automatically on each deploy's `migrate` step, is idempotent, reviewable, and atomic — matching the `0157_consolidate_nc_categories` precedent.

## Defensive design

`Program.category` is `on_delete=SET_NULL`, so deleting a category that still has programs would **silently** leave those programs uncategorized (no error). To prevent that, the migration:

- **Raises** (failing the release) if any program still references the category, naming the offending programs, so an operator can finish the reassignment and redeploy.
- Deletes the category **and** its now-orphaned `name`/`description` Translation rows only when nothing references it.
- Is **idempotent**: skips a category already gone, and skips white labels not present in the environment (safe for test envs).
- Is **not reversible** (documented; restore from a DB snapshot if needed), same as `0157`.

## ⚠️ Deploy order (required)

Before this migration runs in a given environment, an admin must have:

1. Reassigned the programs to the childcare category — KS: `ks_promise_act` → `ks_child_care`; WA: `wa_wsos_bas` / `wa_wsos_cts` / `wa_wsos_grd` → `wa_child_care`.
2. (Optional, cosmetic) Renamed the KS `ks_child_care` category to "Child Care, Youth, and Education".

If step 1 hasn't been done in an environment, that environment's release will fail **by design** — no programs get orphaned. Do not merge/deploy this together with #1647; deploy it only after the admin reassignment is confirmed in each environment.

## Testing

- **Happy path** (no linked programs): migration applies and deletes the categories + orphaned translations. Verified locally — `ks_education`/`wa_education` gone, the four programs now on `*_child_care`.
- **Defensive path** (programs still linked): verified in a rolled-back transaction by re-linking `ks_promise_act` to a recreated `ks_education` and invoking the migration function — it raised `RuntimeError` naming `ks_promise_act` and made no changes.
- `python manage.py migrate programs --plan` recognizes the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)