### PR TITLE
MFB-986: Update TX Homestead Exemption benefit values

### DIFF
--- a/programs/programs/tx/hse/calculator.py
+++ b/programs/programs/tx/hse/calculator.py
@@ -18,11 +18,18 @@ class TxHse(ProgramCalculator):
     https://statutes.capitol.texas.gov/Docs/TX/htm/TX.11.htm#11.13
 
     Benefit amount:
-    - $800/year (estimated typical tax savings for a low-income TX homeowner
-      under the general homestead exemption)
-    - $1200/year for seniors (age 65+) or people with disabilities (estimated
+    - $1200/year (estimated typical school-tax savings for a TX homeowner under
+      the general homestead exemption)
+    - $1700/year for seniors (age 65+) or people with disabilities (estimated
       typical savings under the general + senior/disabled exemption combined)
-    Note: actual savings vary by taxing unit and appraised value.
+
+    These estimates approximate savings = exemption amount x school district tax
+    rate. The 2025 propositions set the school-tax homestead exemption at
+    $140,000 (standard) and $200,000 (senior/disabled). The senior/disabled
+    figure scales the base by the exemption ratio (200,000 / 140,000 ~= 1.43),
+    i.e. $1200 x 1.43 ~= $1700.
+    Note: actual savings vary by taxing unit and appraised value. For homes
+    worth less than the exemption, real savings are capped at home value x rate.
 
     Disability eligibility follows the SSA test (Texas Tax Code § 11.13):
     - Medically determinable physical or mental impairment (proxied by long_term_disability)
@@ -33,8 +40,8 @@ class TxHse(ProgramCalculator):
     Source: https://statutes.capitol.texas.gov/?tab=1&code=TX&chapter=TX.11&artSec=
     """
 
-    amount = 800
-    senior_disabled_amount = 1200
+    amount = 1200
+    senior_disabled_amount = 1700
     senior_age = 65
     blind_senior_age = 55
     dependencies: ClassVar[list[str]] = ["age"]

--- a/programs/programs/tx/hse/tests/test_tx_hse.py
+++ b/programs/programs/tx/hse/tests/test_tx_hse.py
@@ -6,9 +6,9 @@ Eligibility:
 - Texas residency is handled by the TX white label (not tested here)
 
 Benefit value:
-- $1200 if any household member is age 65+, has long_term_disability, has disabled
+- $1700 if any household member is age 65+, has long_term_disability, has disabled
   status (unable to work now or in the future), or is age 55+ and visually impaired
-- $800 otherwise
+- $1200 otherwise
 """
 
 from django.test import TestCase
@@ -58,11 +58,11 @@ class TestTxHseClassAttributes(TestCase):
         self.assertIn("tx_hse", tx_calculators)
         self.assertEqual(tx_calculators["tx_hse"], TxHse)
 
-    def test_base_amount_is_800(self):
-        self.assertEqual(TxHse.amount, 800)
+    def test_base_amount_is_1200(self):
+        self.assertEqual(TxHse.amount, 1200)
 
-    def test_senior_disabled_amount_is_1200(self):
-        self.assertEqual(TxHse.senior_disabled_amount, 1200)
+    def test_senior_disabled_amount_is_1700(self):
+        self.assertEqual(TxHse.senior_disabled_amount, 1700)
 
     def test_senior_age_is_65(self):
         self.assertEqual(TxHse.senior_age, 65)
@@ -85,79 +85,79 @@ class TestTxHseEligibility(TestCase):
 
 
 class TestTxHseValue(TestCase):
-    def test_non_senior_non_disabled_gets_800(self):
+    def test_non_senior_non_disabled_gets_1200(self):
         members = [make_member(age=40)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_member_age_65_gets_1200(self):
+    def test_member_age_65_gets_1700(self):
         members = [make_member(age=65)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_member_age_80_gets_1200(self):
+    def test_member_age_80_gets_1700(self):
         members = [make_member(age=80)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_member_age_64_gets_800(self):
+    def test_member_age_64_gets_1200(self):
         members = [make_member(age=64)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_disabled_member_gets_1200(self):
+    def test_disabled_member_gets_1700(self):
         members = [make_member(age=40, disabled=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_visually_impaired_age_55_gets_1200(self):
+    def test_visually_impaired_age_55_gets_1700(self):
         members = [make_member(age=55, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_visually_impaired_age_60_gets_1200(self):
+    def test_visually_impaired_age_60_gets_1700(self):
         members = [make_member(age=60, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_visually_impaired_under_55_gets_800(self):
+    def test_visually_impaired_under_55_gets_1200(self):
         members = [make_member(age=40, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_visually_impaired_age_54_gets_800(self):
+    def test_visually_impaired_age_54_gets_1200(self):
         members = [make_member(age=54, visually_impaired=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_long_term_disability_gets_1200(self):
+    def test_long_term_disability_gets_1700(self):
         members = [make_member(age=40, long_term_disability=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_mixed_household_with_senior_gets_1200(self):
+    def test_mixed_household_with_senior_gets_1700(self):
         members = [make_member(age=40), make_member(age=70)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
-    def test_mixed_household_no_senior_no_disability_gets_800(self):
+    def test_mixed_household_no_senior_no_disability_gets_1200(self):
         members = [make_member(age=30), make_member(age=50)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_zero_member_household_gets_800(self):
+    def test_zero_member_household_gets_1200(self):
         calc = make_calculator(members=[])
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
     def test_member_with_none_age_does_not_raise(self):
         members = [make_member(age=None)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 800)
+        self.assertEqual(calc.household_value(), 1200)
 
-    def test_senior_and_disabled_member_gets_1200(self):
+    def test_senior_and_disabled_member_gets_1700(self):
         members = [make_member(age=70, disabled=True)]
         calc = make_calculator(members=members)
-        self.assertEqual(calc.household_value(), 1200)
+        self.assertEqual(calc.household_value(), 1700)
 
 
 class TestTxHseCalc(TestCase):
@@ -165,15 +165,15 @@ class TestTxHseCalc(TestCase):
         calc = make_calculator(has_mortgage=True, members=[make_member(age=40)])
         e = calc.calc()
         self.assertTrue(e.eligible)
-        self.assertEqual(e.value, 800)
+        self.assertEqual(e.value, 1200)
 
     def test_calc_ineligible_without_mortgage(self):
         calc = make_calculator(has_mortgage=False, members=[make_member(age=40)])
         e = calc.calc()
         self.assertFalse(e.eligible)
 
-    def test_calc_eligible_senior_gets_1200(self):
+    def test_calc_eligible_senior_gets_1700(self):
         calc = make_calculator(has_mortgage=True, members=[make_member(age=65)])
         e = calc.calc()
         self.assertTrue(e.eligible)
-        self.assertEqual(e.value, 1200)
+        self.assertEqual(e.value, 1700)


### PR DESCRIPTION
## Context & Motivation

Partner feedback indicated the Texas Homestead Exemption (`tx_hse`) benefit estimate was too low and should be raised. The prior values (\$800 base / \$1,200 senior-disabled) predated the 2025 Texas propositions that increased the school-tax homestead exemption to \$140,000 (standard) and \$200,000 (senior/disabled).

The partner asserted the base should be \$1,200. Applying the same underlying assumption (savings ≈ exemption amount × school-district tax rate) to the larger senior/disabled exemption, the senior/disabled tier scales by the exemption ratio (\$200,000 / \$140,000 ≈ 1.43), giving \$1,200 × 1.43 ≈ \$1,700.

- Fixes MFB-986

## Changes Made

- `programs/programs/tx/hse/calculator.py`:
  - `amount` (base): **800 → 1200**
  - `senior_disabled_amount` (65+ / disabled): **1200 → 1700**
  - Updated docstring to document the new figures, the derivation (exemption × school-tax rate, senior tier scaled by the 200k/140k exemption ratio), and the home-value cap caveat.
- `programs/programs/tx/hse/tests/test_tx_hse.py`:
  - Updated module docstring, class-attribute assertions, and all value/calc assertions plus their method names to reflect 1200/1700.

## Testing

- Migrations to run: none
- Configuration updates needed: none (`tx_hse_initial_config.json` has `estimated_value: ""` and pulls the amount from the calculator)
- Environment variables/settings to add: none
- Manual testing steps:
  - `./venv/bin/python -m pytest programs/programs/tx/hse/tests/test_tx_hse.py` (27 tests, all passing)
  - Optionally, screen a TX homeowner (household with a mortgage expense) and confirm the returned value is \$1,200, or \$1,700 when a member is 65+ / disabled.

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- Notify team/users of: updated TX Homestead Exemption estimated values (\$1,200 base / \$1,700 senior-disabled)

## Notes for Reviewers

- Known limitations:
  - These remain flat point estimates. True savings = `min(home appraised value, exemption) × school-district tax rate`. We capture neither the home's appraised value nor the district rate, so for lower-income homeowners whose homes are worth less than the exemption, real savings are capped at home value × rate and the estimate may overstate.
  - The senior/disabled value is selected (not per-household calculated); it returns \$1,700 whenever any member qualifies via age 65+, `disabled`, `long_term_disability`, or visually impaired + age 55+.
- Future considerations:
  - Capturing the home's appraised value in the screener would turn this from an estimate into a real per-household calculation (with the rate pinned or looked up by district/zip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)