### PR TITLE
MFB-1065: Update ks_lieap spec.md to 2026 FPL income caps

### DIFF
--- a/programs/programs/ks/lieap/spec.md
+++ b/programs/programs/ks/lieap/spec.md
@@ -14,7 +14,8 @@
    * Screener fields:
      * `household_size`
      * `calc_gross_income("yearly", ["all"])`
-   * Source: 42 U.S.C. § 8624(b)(2)(B) — quoted: *"households with incomes which do not exceed the greater of— (i) an amount equal to 150 percent of the poverty level for such State; or (ii) an amount equal to 60 percent of the State median income"*. Kansas DCF publishes the applicable dollar amounts directly (see scenarios below), tied to household size: *"The combined gross income (before deductions) of all persons living at the address may not exceed 150% of the federal poverty level."*
+   * Source: 42 U.S.C. § 8624(b)(2)(B) — quoted: *"households with incomes which do not exceed the greater of— (i) an amount equal to 150 percent of the poverty level for such State; or (ii) an amount equal to 60 percent of the State median income"*. Kansas DCF publishes dollar amounts tied to household size: *"The combined gross income (before deductions) of all persons living at the address may not exceed 150% of the federal poverty level."*
+   * **FPL year:** the calculator applies 150% of the **2026** federal poverty guidelines (config `year: 2026`). The 150% caps used in the scenarios below are computed from those guidelines, not from DCF's most-recent published season table (which was based on the 2025 guidelines). Caps: HH1 $23,940/yr ($1,995/mo), HH2 $32,460 ($2,705/mo), HH3 $40,980 ($3,415/mo), HH4 $49,500 ($4,125/mo), HH5 $58,020 ($4,835/mo).
    * Household definition: "household" means everyone living at the address, not just people on a lease or related by blood. This is how the screener's `household_size` field should be interpreted for this program — everyone at the address, not a tax-filing unit or family-relationship count.
 2. **Categorical eligibility: households with a member receiving TANF, SSI, or SNAP qualify regardless of income**
    * Screener fields:
@@ -96,7 +97,7 @@
 
 * **Location**: Enter ZIP code `66603`, Select county `Shawnee`
 * **Household**: Number of people: `1`
-* **Person 1**: Birth month/year: `March 1971` (age 55), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment/wages income: `$1,200` per month ($14,400/year — well below the $23,472/year (150% FPL) threshold DCF publishes for a household of 1: $1,956/month × 12)
+* **Person 1**: Birth month/year: `March 1971` (age 55), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment/wages income: `$1,200` per month ($14,400/year — well below the $23,940/year (150% FPL) threshold for a household of 1: $1,995/month × 12)
 * **Energy Costs**: Indicate household is responsible for home energy costs: `Yes`, Select heating fuel type if prompted (e.g., `Natural Gas`)
 * **Current Benefits**: No current benefits selected
 
@@ -106,7 +107,7 @@
 
 ### Scenario 2: Two-Person Household Near Income Ceiling - Barely Eligible
 
-**What we're checking**: Household with gross income just under DCF's published 150% FPL threshold for a 2-person household ($31,728/year = $2,644/month × 12)
+**What we're checking**: Household with gross income just under the 150% FPL threshold for a 2-person household ($32,460/year = $2,705/month × 12)
 **Expected**: Eligible, $680/year
 
 **Steps**:
@@ -114,64 +115,64 @@
 * **Location**: Enter ZIP code `66502`, Select county `Riley`
 * **Household**: Number of people: `2`
 * **Person 1**: Birth month/year: `January 1986` (age 40), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$1,500` per month
-* **Person 2**: Birth month/year: `March 1988` (age 38), Relationship: `Spouse`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$1,140` per month
+* **Person 2**: Birth month/year: `March 1988` (age 38), Relationship: `Spouse`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$1,200` per month
 * **Energy Costs**: Indicate household is responsible for home heating costs: `Yes`, Select heating fuel type if prompted (e.g., `Natural Gas`)
 
-**Why this matters**: Combined income is $2,640/month ($31,680/year) — $48/year under DCF's published $31,728 cap. Confirms the screener does not incorrectly reject households barely within the income limit.
+**Why this matters**: Combined income is $2,700/month ($32,400/year) — $60/year under the $32,460 cap. Confirms the screener does not incorrectly reject households barely within the income limit.
 
 ---
 
 ### Scenario 3: Three-Person Household Income Just Below 150% FPL - Barely Eligible
 
-**What we're checking**: A household of 3 with gross annual income just below DCF's published 150% FPL threshold ($39,972/year = $3,331/month × 12)
+**What we're checking**: A household of 3 with gross annual income just below the 150% FPL threshold ($40,980/year = $3,415/month × 12)
 **Expected**: Eligible, $680/year
 
 **Steps**:
 
 * **Location**: Enter ZIP code `66502`, Select county `Riley`
 * **Household**: Number of people: `3`
-* **Person 1**: Birth month/year: `March 1991` (age 35), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$3,320` per month
+* **Person 1**: Birth month/year: `March 1991` (age 35), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$3,400` per month
 * **Person 2**: Birth month/year: `September 1992` (age 33), Relationship: `Spouse`, U.S. citizen: `Yes`, Has income: `No`
 * **Person 3**: Birth month/year: `January 2021` (age 5), Relationship: `Child`, U.S. citizen: `Yes`, Has income: `No`
 * **Energy Costs**: Indicate the household is responsible for home energy costs: `Yes`, Select heating fuel type if prompted: `Natural Gas`
 
-**Why this matters**: Combined income is $3,320/month ($39,840/year) — $132/year under DCF's published $39,972 cap.
+**Why this matters**: Combined income is $3,400/month ($40,800/year) — $180/year under the $40,980 cap.
 
 ---
 
 ### Scenario 4: Four-Person Household Income Exactly at 150% FPL - Boundary Eligible
 
-**What we're checking**: A 4-person household whose gross monthly income equals exactly DCF's published cap ($4,019/month = $48,228/year)
+**What we're checking**: A 4-person household whose gross monthly income equals exactly the 150% FPL cap ($4,125/month = $49,500/year)
 **Expected**: Eligible, $680/year
 
 **Steps**:
 
 * **Location**: Enter ZIP code `66604`, Select county `Shawnee`
 * **Household**: Number of people: `4`
-* **Person 1**: Birth month/year: `March 1986` (age 40), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$3,019` monthly, No other income sources
+* **Person 1**: Birth month/year: `March 1986` (age 40), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$3,125` monthly, No other income sources
 * **Person 2**: Birth month/year: `September 1988` (age 37), Relationship: `Spouse`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$1,000` monthly, No other income sources
 * **Person 3**: Birth month/year: `January 2016` (age 10), Relationship: `Child`, U.S. citizen: `Yes`, Has income: `No`
 * **Person 4**: Birth month/year: `June 2019` (age 7), Relationship: `Child`, U.S. citizen: `Yes`, Has income: `No`
 * **Energy Costs**: Indicate household is responsible for home energy costs: `Yes`, Heating fuel type: `Natural gas`
 
-**Why this matters**: Combined monthly income ($3,019 + $1,000 = $4,019) exactly matches DCF's published monthly cap for a 4-person household. Tests that the comparison is inclusive (≤), not strictly less-than.
+**Why this matters**: Combined monthly income ($3,125 + $1,000 = $4,125) exactly matches the 150% FPL monthly cap for a 4-person household. Tests that the comparison is inclusive (≤), not strictly less-than.
 
 ---
 
 ### Scenario 5: Single Adult Income Just Above 150% FPL - Ineligible
 
-**What we're checking**: A single-person household with gross income just above DCF's published cap ($1,956/month) is correctly denied
+**What we're checking**: A single-person household with gross income just above the 150% FPL cap ($1,995/month) is correctly denied
 **Expected**: Not eligible
 
 **Steps**:
 
 * **Location**: Enter ZIP code `66502`, Select county `Riley`
 * **Household**: Number of people: `1`
-* **Person 1**: Birth month/year: `March 1976` (age 50), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$1,970` per month (annualizes to $23,640/year, above the $23,472/year cap), No other income sources
+* **Person 1**: Birth month/year: `March 1976` (age 50), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$2,000` per month (annualizes to $24,000/year, above the $23,940/year cap), No other income sources
 * **Energy Costs**: Indicate household is responsible for home energy costs: `Yes`
 * **Current Benefits**: No current benefits selected
 
-**Why this matters**: $1,970/month is $14 above DCF's published $1,956 monthly cap for a 1-person household — a genuine "just above" test using the same authoritative threshold as Scenario 1.
+**Why this matters**: $2,000/month is $5 above the $1,995 monthly cap ($60/year above the $23,940 annual cap) for a 1-person household — a genuine "just above" test using the same 150% FPL threshold as Scenario 1.
 
 ---
 
@@ -265,7 +266,7 @@
 * **Energy Costs**: Indicate household is responsible for home energy costs: `Yes`, Heating fuel type: `Natural Gas`
 * **Current Benefits**: LIEAP currently receiving: `No`
 
-**Why this matters**: Combined income $3,600/month ($43,200/year) is well under DCF's 5-person cap ($4,706/month = $56,472/year). Confirms multi-earner, multi-child aggregation.
+**Why this matters**: Combined income $3,600/month ($43,200/year) is well under the 5-person cap ($4,835/month = $58,020/year). Confirms multi-earner, multi-child aggregation.
 
 ---
 
@@ -296,7 +297,7 @@
 * **Household**: Number of people: `2`
 * **Person 1**: Birth month/year: `March 1985` (age 41), Relationship: `Head of Household`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$3,200`/month
 * **Person 2**: Birth month/year: `June 1987` (age 39), Relationship: `Spouse`, U.S. citizen: `Yes`, Has income: `Yes`, Employment income: `$0`/month
-* **Income total**: $3,200/month = $38,400/year — **above** DCF's $31,728/year (150% FPL) cap for a 2-person household
+* **Income total**: $3,200/month = $38,400/year — **above** the $32,460/year (150% FPL) cap for a 2-person household
 * **Energy Costs**: Indicate household is responsible for home energy costs: `Yes`
 * **Current Benefits**: Select that the household currently receives `SNAP` (Supplemental Nutrition Assistance Program)
 

--- a/programs/programs/ks/lieap/tests/test_ks_lieap.py
+++ b/programs/programs/ks/lieap/tests/test_ks_lieap.py
@@ -21,8 +21,9 @@ Not tested here (handled outside the calculator):
 Benefit value is a flat $680/year for every eligible household.
 
 The 100% FPL limits used below are chosen so that 1.5x equals the exact
-per-household-size 150% FPL dollar thresholds Kansas DCF publishes, so the
-"barely eligible" / "just above" boundary scenarios test the real cutoffs.
+per-household-size 150% FPL dollar thresholds from the 2026 federal poverty
+guidelines (the calculator's configured FPL year), so the "barely eligible" /
+"just above" boundary scenarios test the real cutoffs.
 """
 
 from django.test import TestCase
@@ -32,13 +33,14 @@ from programs.programs.ks import ks_calculators
 from programs.programs.ks.lieap.calculator import KsLieap
 from programs.programs.calc import ProgramCalculator, Eligibility
 
-# 100% FPL by household size such that 1.5x matches DCF's published 150% caps.
+# 100% FPL by household size such that 1.5x matches the 2026 150% FPL caps
+# (the calculator's configured FPL year; see spec.md Criterion 1).
 FPL_100 = {
-    1: 15_648,  # 1.5x = 23,472
-    2: 21_152,  # 1.5x = 31,728
-    3: 26_648,  # 1.5x = 39,972
-    4: 32_152,  # 1.5x = 48,228
-    5: 37_648,  # 1.5x = 56,472
+    1: 15_960,  # 1.5x = 23,940
+    2: 21_640,  # 1.5x = 32,460
+    3: 27_320,  # 1.5x = 40,980
+    4: 33_000,  # 1.5x = 49,500
+    5: 38_680,  # 1.5x = 58,020
 }
 
 
@@ -113,11 +115,11 @@ class TestKsLieapIncomeEligibility(TestCase):
         self.assertTrue(run_household_eligible(make_calculator(income=10_000, household_size=1)).eligible)
 
     def test_income_exactly_at_cap_is_eligible(self):
-        # inclusive comparison (<=): 1-person cap is 23,472
-        self.assertTrue(run_household_eligible(make_calculator(income=23_472, household_size=1)).eligible)
+        # inclusive comparison (<=): 1-person cap is 23,940
+        self.assertTrue(run_household_eligible(make_calculator(income=23_940, household_size=1)).eligible)
 
     def test_income_just_above_cap_is_ineligible(self):
-        self.assertFalse(run_household_eligible(make_calculator(income=23_473, household_size=1)).eligible)
+        self.assertFalse(run_household_eligible(make_calculator(income=23_941, household_size=1)).eligible)
 
     def test_income_pass_message_included(self):
         e = run_household_eligible(make_calculator(income=10_000, household_size=1))
@@ -204,22 +206,26 @@ class TestKsLieapScenarios(TestCase):
         self.assertEqual(e.value, 680)
 
     def test_scenario_2_two_person_near_ceiling(self):
-        e = self._calc(income=31_680, household_size=2)
+        # $2,700/mo = $32,400/yr, $60 under the 2-person cap ($32,460)
+        e = self._calc(income=32_400, household_size=2)
         self.assertTrue(e.eligible)
         self.assertEqual(e.value, 680)
 
     def test_scenario_3_three_person_just_below_cap(self):
-        e = self._calc(income=39_840, household_size=3)
+        # $3,400/mo = $40,800/yr, $180 under the 3-person cap ($40,980)
+        e = self._calc(income=40_800, household_size=3)
         self.assertTrue(e.eligible)
         self.assertEqual(e.value, 680)
 
     def test_scenario_4_four_person_exactly_at_cap(self):
-        e = self._calc(income=48_228, household_size=4)
+        # $4,125/mo = $49,500/yr, exactly the 4-person cap (inclusive <=)
+        e = self._calc(income=49_500, household_size=4)
         self.assertTrue(e.eligible)
         self.assertEqual(e.value, 680)
 
     def test_scenario_5_single_adult_just_above_cap(self):
-        e = self._calc(income=23_640, household_size=1)
+        # $2,000/mo = $24,000/yr, $60 over the 1-person cap ($23,940)
+        e = self._calc(income=24_000, household_size=1)
         self.assertFalse(e.eligible)
 
     def test_scenario_6_senior_social_security(self):
@@ -257,7 +263,7 @@ class TestKsLieapScenarios(TestCase):
         self.assertEqual(e.value, 680)
 
     def test_scenario_12_over_income_but_snap_categorical(self):
-        # $38,400/yr is above the 2-person cap ($31,728) but SNAP receipt qualifies
+        # $38,400/yr is above the 2-person cap ($32,460) but SNAP receipt qualifies
         e = self._calc(income=38_400, household_size=2, has_snap=True)
         self.assertTrue(e.eligible)
         self.assertEqual(e.value, 680)


### PR DESCRIPTION
## Context & Motivation

- Linear: **MFB-1065** — Add Kansas Low Income Energy Assistance Program (LIEAP)
- Related PR: #1649 (the `ks_lieap` calculator implementation this spec accompanies)

Staging API QA of `ks_lieap` surfaced one failing scenario: Scenario 5 ("single adult just above 150% FPL") returned **Eligible** instead of **Not eligible**. Root cause was **not** a calculator bug — it was a stale FPL year in `spec.md`. The spec's income caps were transcribed from Kansas DCF's most-recent published season income table, which is based on the **2025** federal poverty guidelines (the 2026 LIEAP season opened Jan 20, 2026, before the 2026 guidelines took effect). The calculator correctly applies **150% of the 2026 FPL** (config `year: 2026`), whose caps are higher. Scenario 5's income ($23,640/yr) landed between the two thresholds, so the calculator — correctly — returned Eligible.

Per team decision, the 2026 guidelines are correct, so the fix is to the spec (and its unit tests), not the calculator.

## Changes Made

- Updated `programs/programs/ks/lieap/spec.md` to use **2026** 150% FPL income caps (no calculator or config changes):
  - HH1 $23,940/yr ($1,995/mo), HH2 $32,460 ($2,705/mo), HH3 $40,980 ($3,415/mo), HH4 $49,500 ($4,125/mo), HH5 $58,020 ($4,835/mo).
- Added an explicit **FPL year** note under Criterion 1 documenting that caps derive from the 2026 guidelines (config `year: 2026`), not DCF's 2025-based season table.
- Re-anchored the boundary-scenario incomes to preserve each scenario's intent under the 2026 caps:
  - **S5** ("just above"): $1,970 → **$2,000/mo** ($24,000/yr, $60 over the $23,940 cap) → now correctly Not eligible.
  - **S4** ("exactly at cap"): $3,019 → **$3,125/mo** (total $4,125/mo = $49,500/yr, exactly the cap) → preserves the inclusive-≤ boundary test, still Eligible.
  - **S2** ($2,640 → **$2,700/mo**) and **S3** ($3,320 → **$3,400/mo**): kept just under the 2026 caps to preserve "barely eligible" intent.
- Refreshed the cited cap figures in S1, S10, and S12 to the 2026 values.
- Updated `programs/programs/ks/lieap/tests/test_ks_lieap.py` to match the spec (no calculator change):
  - Bumped the mocked 100% FPL limits (`FPL_100`) so `1.5×` equals the 2026 caps.
  - Boundary tests: exactly-at-cap $23,472→**$23,940** (eligible, inclusive ≤); just-above $23,473→**$23,941** (ineligible).
  - Per-scenario incomes realigned to the corrected spec: S2 **$32,400**, S3 **$40,800**, S4 **$49,500**, S5 **$24,000**; refreshed docstring and the S12 cap reference to the 2026 values.

## Testing

- Migrations to run: none (documentation + unit-test change).
- Configuration updates needed: none.
- Environment variables/settings to add: none.
- Manual testing steps:
  - Unit tests: `python manage.py test programs.programs.ks.lieap.tests.test_ks_lieap` → **36/36 pass**.
  - API QA suite re-run against staging after the change: **12/12 scenarios pass** (all eligibility outcomes + the flat $680 value match).
  - Boundary verification via the calculator's income message, e.g. S5 returns *"Household makes $24,000 per year which must be less than $23,940"* → Not eligible; S4 at exactly $49,500 → Eligible (inclusive ≤).
  - Full results: `qa/MFB-1065-ks_lieap-api-results.md`.

## Deployment

- Post-deployment scripts needed: none.
- Production config updates: none.
- Admin updates needed: none.
- Notify team/users of: nothing — spec/documentation and unit tests only; no runtime behavior change.

## Notes for Reviewers

- Known limitations:
  - The spec's income caps now track the calculator's configured FPL year (2026) rather than Kansas DCF's published season table. When the DCF season table and the FPL config year diverge again (state season tables lag the FPL year by ~1 year), boundary scenarios will need the same re-anchoring.
  - Monthly-vs-annual rounding matters at the boundary: a state's published monthly cap × 12 can sit a few dollars above the annualized FPL × 1.5. S4's income is set to the calculator's annualized cap exactly to keep the inclusive-≤ test valid.
  - The unit tests mock PolicyEngine's FPL limits (`FPL_100`), so they encode the 2026 caps directly rather than reading them from PE at runtime — they must be re-synced whenever the calculator's configured FPL year changes.
- Future considerations:
  - If the intent is ever to match DCF's published dollar thresholds exactly (rather than generic 150% FPL × current year), that would be a calculator change, not a spec change — out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kansas LIEAP income-limit references to use the 2026 federal poverty guidelines.
  * Clarified that eligibility caps are based on 150% of the 2026 guidelines.
  * Updated eligibility examples and test scenarios with revised household income thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
