### PR TITLE
MFB-1418: remove vestigial help_bubble_always_open flag from CESN

### DIFF
--- a/configuration/white_labels/cesn.py
+++ b/configuration/white_labels/cesn.py
@@ -2188,7 +2188,6 @@ class CesnConfigurationData(ConfigurationData):
                 "dont_show_category_values",
                 "logo_landing_page_link",
                 "no_lets_get_started",
-                "help_bubble_always_open",
                 "small_header_language_dropdown",
             ]
         },


### PR DESCRIPTION
## Summary
Removes `help_bubble_always_open` from CESN's `uiOptions` in `configuration/white_labels/cesn.py`. This fixes the income "Frequency" help tooltip rendering permanently expanded (with no "?" toggle) for CESN users.

## Root cause
The shared `HelpButton` component (benefits-calculator) honors the `help_bubble_always_open` flag: when set, it force-opens the help text and hides the "?" toggle. CESN carries this flag.

The income-frequency tooltip used to toggle correctly. benefits-calculator #2154 (MFB-1306, "unify inline help tooltips") routed it through the shared `HelpButton` for the first time — previously it was a hand-rolled toggle that never saw the flag — newly subjecting it to `help_bubble_always_open`.

## Why remove the flag (rather than opt-out in FE)
The flag is now **vestigial** for CESN:
- The steps it was originally built for (`householdSize`, `alreadyHasBenefits`) no longer have inline help buttons.
- The only other current `HelpButton` (`household-assets`) is **not** in CESN's step directory (`zipcode → householdSize → householdData → energy steps → hasBenefits`).

So the flag's only live effect for CESN is the one permanently-expanded income-frequency block. Removing it restores normal toggle behavior with no other user-visible change.

## Deploy note
⚠️ This is white-label config data applied via `add_config`, not a migration. The release process runs `migrate` but **not** the config import, so this takes effect only after running:

```
python manage.py add_config cesn
```

## Related
Companion FE PR on the same ticket fixes a missing icon on the CESN utility-status step: MyFriendBen/benefits-calculator#2167

Linear: MFB-1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)