### PR TITLE
MFB-1424: Make degraded eligibility runs visible — Sentry + missing_programs for HUD failures, calculator crashes, and malformed screen data

### DIFF
--- a/integrations/clients/hud_income_limits/__init__.py
+++ b/integrations/clients/hud_income_limits/__init__.py
@@ -1,3 +1,17 @@
-from .client import HudIncomeClient, HudIncomeClientError, hud_client, MtspAmiPercent, Section8AmiPercent
+from .client import (
+    HudIncomeClient,
+    HudIncomeClientError,
+    HudIncomeClientInputError,
+    hud_client,
+    MtspAmiPercent,
+    Section8AmiPercent,
+)
 
-__all__ = ["HudIncomeClient", "HudIncomeClientError", "hud_client", "MtspAmiPercent", "Section8AmiPercent"]
+__all__ = [
+    "HudIncomeClient",
+    "HudIncomeClientError",
+    "HudIncomeClientInputError",
+    "hud_client",
+    "MtspAmiPercent",
+    "Section8AmiPercent",
+]

--- a/integrations/clients/hud_income_limits/client.py
+++ b/integrations/clients/hud_income_limits/client.py
@@ -18,6 +18,12 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from django.core.cache import cache
 from integrations.external_api_status import report_external_api_failure, HUD
+
+# `DependencyError` is the eligibility loop's "skip this program" signal. Reaching into
+# programs/ from an integration client is a layering compromise, made deliberately: the
+# alternative is repeating the same translation in all seven HUD-backed calculators,
+# where forgetting it silently reintroduces an unjustified "not eligible".
+from programs.util import DependencyError
 from screener.models import Screen
 
 # Type alias for MTSP AMI percentage levels (Multifamily Tax Subsidy Project)
@@ -40,12 +46,21 @@ class HudIncomeClientInputError(HudIncomeClientError):
 
     Separate from the base class so `_report_hud_failure` does NOT treat these as HUD
     being unavailable — a 9-person household is ordinary screener data, not an outage,
-    and flagging it would fire a Sentry error and a frontend warning on every such
-    screen. Subclasses HudIncomeClientError so the existing `except HudIncomeClientError`
-    handlers in the HUD-backed calculators keep catching it unchanged.
+    and flagging it would fire a Sentry error and warn the user that an external service
+    failed when nothing external did.
+
+    It never escapes the client: `_report_hud_failure` translates it into a
+    `DependencyError` so the calling program is omitted from the results and the response
+    is flagged incomplete. Subclassing HudIncomeClientError keeps it catchable by the
+    calculators' existing handlers for any path that bypasses the decorator.
     """
 
     pass
+
+
+# Upstream response bodies land in exception messages; HUD serves HTML error pages, so
+# cap what we forward to Sentry.
+_ERROR_DETAIL_MAX_CHARS = 500
 
 
 def _report_hud_failure(method):
@@ -61,26 +76,38 @@ def _report_hud_failure(method):
     has to be recorded here — by the time the calculator swallows it, the fact that the
     number came from a failed lookup is gone.
 
-    Reports once per exception instance: `approximate_screen_mtsp_ami` calls
-    `get_screen_mtsp_ami` internally, and both are decorated.
+    Two failure classes, handled differently:
+
+    - `HudIncomeClientInputError` — the household is outside HUD's published tables
+      (>8 people, most often). Nothing failed, so no Sentry error; but we still have no
+      income limit, and letting the calculators' `except HudIncomeClientError` handlers
+      see it would turn "we can't evaluate this gate" into a definite "not eligible" we
+      can't justify. Translated to `DependencyError`, which the eligibility loop already
+      understands: the program is omitted rather than answered wrongly, and
+      `missing_programs` is set.
+    - everything else — a genuine HUD failure. Reported once per exception instance
+      (`approximate_screen_mtsp_ami` calls `get_screen_mtsp_ami`, and both are
+      decorated) and, via `report_external_api_failure`, once per service per run.
     """
 
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         try:
             return method(self, *args, **kwargs)
-        except HudIncomeClientInputError:
-            # Out-of-range arguments, not a HUD failure. Propagate untouched.
-            raise
+        except HudIncomeClientInputError as e:
+            raise DependencyError() from e
         except HudIncomeClientError as e:
             if not getattr(e, "_mfb_reported", False):
                 e._mfb_reported = True
                 report_external_api_failure(
                     HUD,
-                    f"HUD Income Limits lookup failed in {type(self).__name__}.{method.__name__}: {e}. "
-                    f"HUD-backed programs fall back to 'not eligible (income limit unknown)' "
-                    f"for this screen.",
+                    "HUD Income Limits lookup failed; HUD-backed programs fall back to "
+                    "'not eligible (income limit unknown)'.",
                     e,
+                    context={
+                        "method": f"{type(self).__name__}.{method.__name__}",
+                        "detail": str(e)[:_ERROR_DETAIL_MAX_CHARS],
+                    },
                 )
             raise
 
@@ -713,7 +740,9 @@ class HudIncomeClient:
             elif status_code == 429:
                 raise HudIncomeClientError("Rate limit exceeded. Please wait before making more requests.") from e
             else:
-                raise HudIncomeClientError(f"API request failed ({status_code}): {e.response.text}") from e
+                raise HudIncomeClientError(
+                    f"API request failed ({status_code}): {e.response.text[:_ERROR_DETAIL_MAX_CHARS]}"
+                ) from e
         except requests.exceptions.Timeout as e:
             raise HudIncomeClientError(
                 "Request timeout after multiple retries. The HUD API may be experiencing issues."

--- a/integrations/clients/hud_income_limits/client.py
+++ b/integrations/clients/hud_income_limits/client.py
@@ -10,13 +10,14 @@ Provides access to two HUD Income Limits datasets:
 API Documentation: https://www.huduser.gov/portal/dataset/fmr-api.html
 """
 
+import functools
 from typing import Union, Literal, Optional, cast, get_args
 from decouple import config
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from sentry_sdk import capture_exception
 from django.core.cache import cache
+from integrations.external_api_status import report_external_api_failure, HUD
 from screener.models import Screen
 
 # Type alias for MTSP AMI percentage levels (Multifamily Tax Subsidy Project)
@@ -30,6 +31,60 @@ class HudIncomeClientError(Exception):
     """Base exception for HUD Income Client errors"""
 
     pass
+
+
+class HudIncomeClientInputError(HudIncomeClientError):
+    """A lookup we never even attempted because the arguments were out of range
+    (household size outside HUD's 1-8 table, bedroom count outside 0-4, an AMI
+    percentage outside the MTSP range).
+
+    Separate from the base class so `_report_hud_failure` does NOT treat these as HUD
+    being unavailable — a 9-person household is ordinary screener data, not an outage,
+    and flagging it would fire a Sentry error and a frontend warning on every such
+    screen. Subclasses HudIncomeClientError so the existing `except HudIncomeClientError`
+    handlers in the HUD-backed calculators keep catching it unchanged.
+    """
+
+    pass
+
+
+def _report_hud_failure(method):
+    """Report any HUD lookup failure that means "we could not get a usable number from
+    HUD" — loud Sentry error plus the request-scoped flag that makes `missing_programs`
+    true and warns the frontend.
+
+    Applied at the public-method boundary rather than at each `raise` site so every
+    failure path is covered: transport errors from `_api_request`, an unrecognized
+    county from `_get_entity_id`, and a 200 response missing the field we need. The
+    HUD-backed calculators all catch HudIncomeClientError and degrade to "not eligible
+    (income limit unknown)", which is a real answer shown to the user, so the failure
+    has to be recorded here — by the time the calculator swallows it, the fact that the
+    number came from a failed lookup is gone.
+
+    Reports once per exception instance: `approximate_screen_mtsp_ami` calls
+    `get_screen_mtsp_ami` internally, and both are decorated.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except HudIncomeClientInputError:
+            # Out-of-range arguments, not a HUD failure. Propagate untouched.
+            raise
+        except HudIncomeClientError as e:
+            if not getattr(e, "_mfb_reported", False):
+                e._mfb_reported = True
+                report_external_api_failure(
+                    HUD,
+                    f"HUD Income Limits lookup failed in {type(self).__name__}.{method.__name__}: {e}. "
+                    f"HUD-backed programs fall back to 'not eligible (income limit unknown)' "
+                    f"for this screen.",
+                    e,
+                )
+            raise
+
+    return wrapper
 
 
 class HudIncomeClient:
@@ -145,6 +200,7 @@ class HudIncomeClient:
             self._headers = {"Authorization": f"Bearer {token}"}
         return self._headers
 
+    @_report_hud_failure
     def get_screen_mtsp_ami(
         self,
         screen: Screen,
@@ -214,6 +270,7 @@ class HudIncomeClient:
 
         return int(value)
 
+    @_report_hud_failure
     def get_screen_il_ami(
         self,
         screen,
@@ -312,7 +369,7 @@ class HudIncomeClient:
 
     def _validate_bedrooms(self, bedrooms: int) -> None:
         if bedrooms < 0 or bedrooms > 4:
-            raise HudIncomeClientError(f"Bedroom count must be 0-4, got {bedrooms}")
+            raise HudIncomeClientInputError(f"Bedroom count must be 0-4, got {bedrooms}")
 
     def _fetch_fmr_area_data(
         self,
@@ -368,6 +425,7 @@ class HudIncomeClient:
                 return int(value) if value is not None else None
         return None
 
+    @_report_hud_failure
     def get_screen_fmr(
         self,
         screen: Screen,
@@ -401,6 +459,7 @@ class HudIncomeClient:
         area_data = self._fetch_fmr_area_data(screen, year, county_override)
         return self._metro_fmr_value(area_data.get("basicdata", {}), bedrooms, county_override or screen.county)
 
+    @_report_hud_failure
     def get_screen_safmr(
         self,
         screen: Screen,
@@ -440,6 +499,7 @@ class HudIncomeClient:
             )
         return value
 
+    @_report_hud_failure
     def get_screen_payment_standard(
         self,
         screen: Screen,
@@ -484,6 +544,7 @@ class HudIncomeClient:
     # Derived from MtspAmiPercent so the two stay in sync automatically
     MTSP_THRESHOLDS: list[int] = sorted(int(p.rstrip("%")) for p in get_args(MtspAmiPercent))
 
+    @_report_hud_failure
     def approximate_screen_mtsp_ami(
         self,
         screen: Screen,
@@ -525,7 +586,7 @@ class HudIncomeClient:
         target_num = int(str(target_percent).rstrip("%"))
 
         if target_num < self.MTSP_THRESHOLDS[0] or target_num > self.MTSP_THRESHOLDS[-1]:
-            raise HudIncomeClientError(
+            raise HudIncomeClientInputError(
                 f"target_percent {target_percent} is outside the supported MTSP range "
                 f"[{self.MTSP_THRESHOLDS[0]}%, {self.MTSP_THRESHOLDS[-1]}%]"
             )
@@ -545,7 +606,7 @@ class HudIncomeClient:
     def _validate_household_size(self, household_size: int) -> None:
         """Validate household size is within HUD API bounds (1-8)."""
         if household_size < 1 or household_size > 8:
-            raise HudIncomeClientError("Household size must be between 1 and 8")
+            raise HudIncomeClientInputError("Household size must be between 1 and 8")
 
     def _fetch_cached_data(self, cache_key: str, endpoint: str, year: int) -> dict:
         """Fetch data from cache or API and cache the result."""
@@ -625,43 +686,44 @@ class HudIncomeClient:
         Raises:
             HudIncomeClientError: On authentication, authorization, or data errors
         """
+        # Every raise below chains the underlying requests exception with `from e`, so the
+        # single Sentry event reported by `_report_hud_failure` at the public-method
+        # boundary carries the full cause chain. Don't capture here as well — that would
+        # fire a duplicate event per failure.
         try:
             response = self._session.get(f"{self.BASE_URL}/{endpoint}", headers=self.headers, params=params, timeout=30)
             response.raise_for_status()
             try:
                 return response.json()
             except ValueError as e:
-                capture_exception(e)
                 raise HudIncomeClientError(f"Non-JSON response from HUD API ({endpoint}): {response.text[:200]}") from e
         except requests.exceptions.HTTPError as e:
-            capture_exception(e)
             status_code = e.response.status_code
             if status_code == 401:
-                raise HudIncomeClientError("Authentication failed. Check HUD_API_TOKEN is set and valid.")
+                raise HudIncomeClientError("Authentication failed. Check HUD_API_TOKEN is set and valid.") from e
             elif status_code == 403:
                 raise HudIncomeClientError(
                     "Access denied. Ensure your HUD API account is registered for both "
                     "FMR and Income Limits datasets at https://www.huduser.gov/hudapi/public/register"
-                )
+                ) from e
             elif status_code == 404:
                 raise HudIncomeClientError(
                     f"Data not found for endpoint: {endpoint}. " "Check that the state/county exists and year is valid."
-                )
+                ) from e
             elif status_code == 429:
-                raise HudIncomeClientError("Rate limit exceeded. Please wait before making more requests.")
+                raise HudIncomeClientError("Rate limit exceeded. Please wait before making more requests.") from e
             else:
-                raise HudIncomeClientError(f"API request failed ({status_code}): {e.response.text}")
+                raise HudIncomeClientError(f"API request failed ({status_code}): {e.response.text}") from e
         except requests.exceptions.Timeout as e:
-            capture_exception(e)
             raise HudIncomeClientError(
                 "Request timeout after multiple retries. The HUD API may be experiencing issues."
-            )
+            ) from e
         except requests.exceptions.ConnectionError as e:
-            capture_exception(e)
-            raise HudIncomeClientError("Connection failed. Please check your network connection or try again later.")
+            raise HudIncomeClientError(
+                "Connection failed. Please check your network connection or try again later."
+            ) from e
         except requests.exceptions.RequestException as e:
-            capture_exception(e)
-            raise HudIncomeClientError(f"Request failed: {str(e)}")
+            raise HudIncomeClientError(f"Request failed: {str(e)}") from e
 
 
 # Default client instance

--- a/integrations/clients/hud_income_limits/tests/test_client.py
+++ b/integrations/clients/hud_income_limits/tests/test_client.py
@@ -16,9 +16,11 @@ from django.core.cache import cache
 from integrations.clients.hud_income_limits.client import (
     HudIncomeClient,
     HudIncomeClientError,
+    HudIncomeClientInputError,
     MtspAmiPercent,
     Section8AmiPercent,
 )
+from integrations.external_api_status import HUD, get_external_api_failures, track_external_api_failures
 from screener.models import Screen, WhiteLabel
 
 
@@ -466,6 +468,76 @@ class TestHudIncomeClientValidation(HudClientTestBase):
 
             with self.assertRaisesRegex(HudIncomeClientError, r"HUD_API_TOKEN"):
                 _ = client.headers
+
+
+class TestHudFailureReporting(HudClientTestBase):
+    """A HUD lookup failure must be recorded as an external-API failure so the results
+    view can flag `missing_programs` — the HUD-backed calculators swallow
+    HudIncomeClientError and degrade to "not eligible (income limit unknown)", so this is
+    the only place the degradation is still visible."""
+
+    def test_transport_failure_records_hud(self) -> None:
+        client = HudIncomeClient(api_token="test_token")
+
+        with patch.object(client, "_api_request", side_effect=requests.exceptions.ConnectionError("no route")):
+            with track_external_api_failures():
+                with self.assertRaises(requests.exceptions.ConnectionError):
+                    client.get_screen_il_ami(self.screen, "80%", "2025")
+                # A raw requests error escaping _api_request isn't a HudIncomeClientError,
+                # so it is not reported here — the loop-level handler catches it instead.
+                self.assertEqual(get_external_api_failures(), [])
+
+    def test_hud_client_error_records_hud(self) -> None:
+        client = HudIncomeClient(api_token="test_token")
+
+        # A 200 response with no usable payload -> HudIncomeClientError from
+        # _validate_data_response, reported at the public-method boundary.
+        with self.mock_api_responses(client, self.mock_counties_response, {}):
+            with track_external_api_failures():
+                with self.assertRaises(HudIncomeClientError):
+                    client.get_screen_il_ami(self.screen, "80%", "2025")
+                self.assertEqual(get_external_api_failures(), [HUD])
+
+    def test_county_not_found_records_hud(self) -> None:
+        client = HudIncomeClient(api_token="test_token")
+        self.screen.county = "Nonexistent"
+
+        with self.mock_api_responses(client, self.mock_counties_response):
+            with track_external_api_failures():
+                with self.assertRaisesRegex(HudIncomeClientError, r"County not found"):
+                    client.get_screen_il_ami(self.screen, "80%", "2025")
+                self.assertEqual(get_external_api_failures(), [HUD])
+
+    def test_input_error_does_not_record_hud(self) -> None:
+        """A 9-person household is ordinary screener data, not a HUD outage — it must not
+        fire a Sentry error or warn the user that an external service failed."""
+        client = HudIncomeClient(api_token="test_token")
+        self.screen.household_size = 9
+
+        with track_external_api_failures():
+            with self.assertRaises(HudIncomeClientInputError):
+                client.get_screen_il_ami(self.screen, "80%", "2025")
+            self.assertEqual(get_external_api_failures(), [])
+
+    def test_bedroom_input_error_does_not_record_hud(self) -> None:
+        client = HudIncomeClient(api_token="test_token")
+
+        with track_external_api_failures():
+            with self.assertRaises(HudIncomeClientInputError):
+                client.get_screen_payment_standard(self.screen, 7, "2026")
+            self.assertEqual(get_external_api_failures(), [])
+
+    @patch("integrations.clients.hud_income_limits.client.report_external_api_failure")
+    def test_reports_once_through_nested_public_calls(self, mock_report) -> None:
+        """approximate_screen_mtsp_ami calls get_screen_mtsp_ami and both are decorated;
+        the failure should produce one report, not two."""
+        client = HudIncomeClient(api_token="test_token")
+
+        with self.mock_api_responses(client, self.mock_counties_response, {}):
+            with self.assertRaises(HudIncomeClientError):
+                client.approximate_screen_mtsp_ami(self.screen, "65%", "2025")
+
+        self.assertEqual(mock_report.call_count, 1)
 
 
 class TestHudIncomeClientCountyLookup(HudClientTestBase):

--- a/integrations/clients/hud_income_limits/tests/test_client.py
+++ b/integrations/clients/hud_income_limits/tests/test_client.py
@@ -21,6 +21,7 @@ from integrations.clients.hud_income_limits.client import (
     Section8AmiPercent,
 )
 from integrations.external_api_status import HUD, get_external_api_failures, track_external_api_failures
+from programs.util import DependencyError
 from screener.models import Screen, WhiteLabel
 
 
@@ -406,13 +407,14 @@ class TestHudIncomeClientApproximate(HudClientTestBase):
             self.assertEqual(result, 84120)
 
     def test_out_of_range_raises_error(self) -> None:
-        """Targets outside [20, 100] raise HudIncomeClientError."""
+        """Targets outside [20, 100] are out-of-range input -> DependencyError."""
         client = HudIncomeClient(api_token="test_token")
 
-        with self.assertRaisesRegex(HudIncomeClientError, r"outside the supported MTSP range"):
+        with self.assertRaises(DependencyError) as ctx:
             client.approximate_screen_mtsp_ami(self.screen, "10%", "2025")
+        self.assertIn("outside the supported MTSP range", str(ctx.exception.__cause__))
 
-        with self.assertRaisesRegex(HudIncomeClientError, r"outside the supported MTSP range"):
+        with self.assertRaises(DependencyError):
             client.approximate_screen_mtsp_ami(self.screen, "105%", "2025")
 
     def test_propagates_hud_api_error(self) -> None:
@@ -439,25 +441,31 @@ class TestHudIncomeClientValidation(HudClientTestBase):
     """Test shared validation logic across both endpoints."""
 
     def test_household_size_validation_too_small(self) -> None:
-        """Test that household size < 1 raises error for both endpoints."""
+        """Household size < 1 is out-of-range input, surfaced as DependencyError."""
         self.screen.household_size = 0
         client = HudIncomeClient(api_token="test_token")
 
-        with self.assertRaisesRegex(HudIncomeClientError, r"between 1 and 8"):
+        with self.assertRaises(DependencyError):
             client.get_screen_mtsp_ami(self.screen, "80%", "2025")
 
-        with self.assertRaisesRegex(HudIncomeClientError, r"between 1 and 8"):
+        with self.assertRaises(DependencyError):
             client.get_screen_il_ami(self.screen, "80%", "2025")
 
     def test_household_size_validation_too_large(self) -> None:
-        """Test that household size > 8 raises error for both endpoints."""
+        """HUD's tables stop at 8 people. A 9-person household is ordinary screener data,
+        so the public methods raise DependencyError — the eligibility loop omits the
+        program and flags the response, rather than the calculators turning "we have no
+        income limit" into a definite "not eligible"."""
         self.screen.household_size = 9
         client = HudIncomeClient(api_token="test_token")
 
-        with self.assertRaisesRegex(HudIncomeClientError, r"between 1 and 8"):
+        with self.assertRaises(DependencyError) as ctx:
             client.get_screen_mtsp_ami(self.screen, "80%", "2025")
+        # The originating reason is preserved on the cause chain for debugging.
+        self.assertIsInstance(ctx.exception.__cause__, HudIncomeClientInputError)
+        self.assertIn("between 1 and 8", str(ctx.exception.__cause__))
 
-        with self.assertRaisesRegex(HudIncomeClientError, r"between 1 and 8"):
+        with self.assertRaises(DependencyError):
             client.get_screen_il_ami(self.screen, "80%", "2025")
 
     def test_missing_api_token_raises_error(self) -> None:
@@ -515,7 +523,7 @@ class TestHudFailureReporting(HudClientTestBase):
         self.screen.household_size = 9
 
         with track_external_api_failures():
-            with self.assertRaises(HudIncomeClientInputError):
+            with self.assertRaises(DependencyError):
                 client.get_screen_il_ami(self.screen, "80%", "2025")
             self.assertEqual(get_external_api_failures(), [])
 
@@ -523,7 +531,7 @@ class TestHudFailureReporting(HudClientTestBase):
         client = HudIncomeClient(api_token="test_token")
 
         with track_external_api_failures():
-            with self.assertRaises(HudIncomeClientInputError):
+            with self.assertRaises(DependencyError):
                 client.get_screen_payment_standard(self.screen, 7, "2026")
             self.assertEqual(get_external_api_failures(), [])
 
@@ -538,6 +546,58 @@ class TestHudFailureReporting(HudClientTestBase):
                 client.approximate_screen_mtsp_ami(self.screen, "65%", "2025")
 
         self.assertEqual(mock_report.call_count, 1)
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_outage_reports_once_per_screen_not_once_per_lookup(self, mock_exc, mock_msg) -> None:
+        """One MA screen makes five HUD lookups across four calculators, each raising its
+        own exception. During an outage that used to be ten Sentry events per screen; the
+        per-run dedupe in report_external_api_failure makes it two."""
+        client = HudIncomeClient(api_token="test_token")
+
+        with track_external_api_failures():
+            for _ in range(5):
+                with self.mock_api_responses(client, self.mock_counties_response, {}):
+                    with self.assertRaises(HudIncomeClientError):
+                        client.get_screen_il_ami(self.screen, "80%", "2025")
+
+            self.assertEqual(get_external_api_failures(), [HUD])
+
+        self.assertEqual(mock_exc.call_count, 1)
+        self.assertEqual(mock_msg.call_count, 1)
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_report_uses_a_static_message_with_detail_in_context(self, mock_exc, mock_msg) -> None:
+        """The upstream error text must not reach the message body — Sentry groups
+        capture_message by its text, and HUD serves HTML error pages."""
+        client = HudIncomeClient(api_token="test_token")
+
+        with self.mock_api_responses(client, self.mock_counties_response, {}):
+            with track_external_api_failures():
+                with self.assertRaises(HudIncomeClientError):
+                    client.get_screen_il_ami(self.screen, "80%", "2025")
+
+        message = mock_msg.call_args.args[0]
+        self.assertNotIn("get_screen_il_ami", message)
+        context = mock_msg.call_args.kwargs["contexts"]["external_api"]
+        self.assertEqual(context["service"], HUD)
+        self.assertEqual(context["method"], "HudIncomeClient.get_screen_il_ami")
+        self.assertLessEqual(len(context["detail"]), 500)
+        self.assertEqual(mock_msg.call_args.kwargs["fingerprint"], ["external-api-failure", HUD])
+
+    def test_oversized_upstream_body_is_truncated_before_it_reaches_sentry(self) -> None:
+        """A 500 with a huge HTML body must not be pasted wholesale into the exception
+        message (which becomes the Sentry event title)."""
+        client = HudIncomeClient(api_token="test_token")
+        response = Mock(status_code=500, text="x" * 10_000)
+        http_error = requests.exceptions.HTTPError(response=response)
+
+        with patch.object(client._session, "get", side_effect=http_error):
+            with self.assertRaises(HudIncomeClientError) as ctx:
+                client._api_request("il/data/1234")
+
+        self.assertLess(len(str(ctx.exception)), 600)
 
 
 class TestHudIncomeClientCountyLookup(HudClientTestBase):
@@ -929,5 +989,6 @@ class TestHudIncomeClientFmrAndSafmr(HudClientTestBase):
 
     def test_invalid_bedrooms_raises(self) -> None:
         client = self._client()
-        with self.assertRaisesRegex(HudIncomeClientError, r"Bedroom count must be 0-4"):
+        with self.assertRaises(DependencyError) as ctx:
             client.get_screen_fmr(self.screen, 5, 2026)
+        self.assertIn("Bedroom count must be 0-4", str(ctx.exception.__cause__))

--- a/integrations/external_api_status.py
+++ b/integrations/external_api_status.py
@@ -9,6 +9,10 @@ Integrations record a failure with `record_external_api_failure(service_id)`; th
 results view wraps the eligibility computation in `track_external_api_failures()` and
 reads the collected ids with `get_external_api_failures()`.
 
+Most callers should use `report_external_api_failure(...)` instead, which both records
+the failure and surfaces it loudly in Sentry — the two things that always want to happen
+together when an integration degrades a results run.
+
 The collector is a `contextvars.ContextVar`, so it is isolated per request/thread and
 resets cleanly when the context manager exits. `record_...` is a no-op when no context
 is active, so deep integration code can call it unconditionally (safe from unit tests,
@@ -17,7 +21,9 @@ management commands, or code paths that don't wrap a tracking context).
 
 import contextvars
 from contextlib import contextmanager
-from typing import List
+from typing import List, Optional
+
+from sentry_sdk import capture_exception, capture_message
 
 # Stable service identifiers sent to the frontend. Extend as more integrations opt in.
 POLICY_ENGINE = "policy_engine"
@@ -60,3 +66,21 @@ def get_external_api_failures() -> List[str]:
     none / no active context)."""
     failures = _failures.get()
     return sorted(failures) if failures else []
+
+
+def report_external_api_failure(service_id: str, message: str, exception: Optional[BaseException] = None) -> None:
+    """Record an external-API failure AND surface it loudly in Sentry.
+
+    This is the canonical handling for "an integration we depend on failed, so this
+    results run is degraded": one Sentry error event for the exception (when there is
+    one) plus one for the human-readable context, then the request-scoped record that
+    makes `missing_programs` true and populates `external_api_failures` for the
+    frontend.
+
+    Callers that only want the flag (no Sentry noise) can use
+    `record_external_api_failure` directly.
+    """
+    if exception is not None:
+        capture_exception(exception, level="error")
+    capture_message(message, level="error")
+    record_external_api_failure(service_id)

--- a/integrations/external_api_status.py
+++ b/integrations/external_api_status.py
@@ -21,7 +21,7 @@ management commands, or code paths that don't wrap a tracking context).
 
 import contextvars
 from contextlib import contextmanager
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from sentry_sdk import capture_exception, capture_message
 
@@ -68,7 +68,12 @@ def get_external_api_failures() -> List[str]:
     return sorted(failures) if failures else []
 
 
-def report_external_api_failure(service_id: str, message: str, exception: Optional[BaseException] = None) -> None:
+def report_external_api_failure(
+    service_id: str,
+    message: str,
+    exception: Optional[BaseException] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> None:
     """Record an external-API failure AND surface it loudly in Sentry.
 
     This is the canonical handling for "an integration we depend on failed, so this
@@ -77,10 +82,30 @@ def report_external_api_failure(service_id: str, message: str, exception: Option
     makes `missing_programs` true and populates `external_api_failures` for the
     frontend.
 
+    Reports at most ONCE per service per tracking context. A single screen makes several
+    independent calls to the same integration (five HUD lookups across the MA
+    calculators, one PolicyEngine call per method), each raising its own exception, so
+    without this an outage produces a double-digit event count per screen while telling
+    us nothing the first event didn't. Subsequent failures for an already-reported
+    service are dropped silently — the flag is already set, and it is a set.
+
+    `message` must be a STATIC string: Sentry groups `capture_message` events by their
+    text, so interpolating a screen id or an upstream response body into it creates a
+    new issue per screen. Put that detail in `context` instead, which is attached to the
+    event as structured data. `fingerprint` is pinned to the service id for the same
+    reason.
+
     Callers that only want the flag (no Sentry noise) can use
     `record_external_api_failure` directly.
     """
+    if service_id in get_external_api_failures():
+        # Already reported for this run; the record is a set, so nothing left to do.
+        return
+
+    contexts = {"external_api": {"service": service_id, **(context or {})}}
+    fingerprint = ["external-api-failure", service_id]
+
     if exception is not None:
-        capture_exception(exception, level="error")
-    capture_message(message, level="error")
+        capture_exception(exception, level="error", contexts=contexts, fingerprint=fingerprint)
+    capture_message(message, level="error", contexts=contexts, fingerprint=fingerprint)
     record_external_api_failure(service_id)

--- a/integrations/tests.py
+++ b/integrations/tests.py
@@ -65,8 +65,18 @@ class TestReportExternalApiFailure(SimpleTestCase):
             report_external_api_failure(HUD, "HUD is down", boom)
             self.assertEqual(get_external_api_failures(), [HUD])
 
-        mock_capture_exception.assert_called_once_with(boom, level="error")
-        mock_capture_message.assert_called_once_with("HUD is down", level="error")
+        mock_capture_exception.assert_called_once_with(
+            boom,
+            level="error",
+            contexts={"external_api": {"service": HUD}},
+            fingerprint=["external-api-failure", HUD],
+        )
+        mock_capture_message.assert_called_once_with(
+            "HUD is down",
+            level="error",
+            contexts={"external_api": {"service": HUD}},
+            fingerprint=["external-api-failure", HUD],
+        )
 
     @patch("integrations.external_api_status.capture_message")
     @patch("integrations.external_api_status.capture_exception")
@@ -76,4 +86,62 @@ class TestReportExternalApiFailure(SimpleTestCase):
             self.assertEqual(get_external_api_failures(), [POLICY_ENGINE])
 
         mock_capture_exception.assert_not_called()
-        mock_capture_message.assert_called_once_with("no exception here", level="error")
+        mock_capture_message.assert_called_once_with(
+            "no exception here",
+            level="error",
+            contexts={"external_api": {"service": POLICY_ENGINE}},
+            fingerprint=["external-api-failure", POLICY_ENGINE],
+        )
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_caller_context_is_attached_to_both_events(self, mock_capture_exception, mock_capture_message):
+        """Variable detail belongs in structured context, never in the message — Sentry
+        groups capture_message by its text, so an interpolated screen id or response body
+        would create one issue per screen."""
+        boom = ValueError("boom")
+        with track_external_api_failures():
+            report_external_api_failure(HUD, "HUD is down", boom, context={"method": "Client.get", "detail": "500"})
+
+        expected = {"external_api": {"service": HUD, "method": "Client.get", "detail": "500"}}
+        self.assertEqual(mock_capture_exception.call_args.kwargs["contexts"], expected)
+        self.assertEqual(mock_capture_message.call_args.kwargs["contexts"], expected)
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_reports_once_per_service_per_run(self, mock_capture_exception, mock_capture_message):
+        """A single screen makes several calls to the same integration (five HUD lookups
+        across the MA calculators). An outage should produce one event, not one per call —
+        the later ones carry no information the first didn't."""
+        with track_external_api_failures():
+            report_external_api_failure(HUD, "HUD is down", ValueError("first"))
+            report_external_api_failure(HUD, "HUD is down", ValueError("second"))
+            report_external_api_failure(HUD, "HUD is down", ValueError("third"))
+
+            self.assertEqual(get_external_api_failures(), [HUD])
+
+        self.assertEqual(mock_capture_exception.call_count, 1)
+        self.assertEqual(mock_capture_message.call_count, 1)
+        self.assertEqual(str(mock_capture_exception.call_args.args[0]), "first")
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_dedupe_is_per_service_not_global(self, mock_capture_exception, mock_capture_message):
+        with track_external_api_failures():
+            report_external_api_failure(HUD, "HUD is down")
+            report_external_api_failure(POLICY_ENGINE, "PE is down")
+
+            self.assertEqual(get_external_api_failures(), sorted([HUD, POLICY_ENGINE]))
+
+        self.assertEqual(mock_capture_message.call_count, 2)
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_dedupe_resets_between_runs(self, mock_capture_exception, mock_capture_message):
+        """The next screen's outage is news again — dedupe is scoped to the tracking
+        context, not to the process."""
+        for _ in range(2):
+            with track_external_api_failures():
+                report_external_api_failure(HUD, "HUD is down")
+
+        self.assertEqual(mock_capture_message.call_count, 2)

--- a/integrations/tests.py
+++ b/integrations/tests.py
@@ -1,6 +1,8 @@
 """Tests for the request-scoped external-API failure registry
 (integrations/external_api_status.py)."""
 
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from integrations.external_api_status import (
@@ -8,6 +10,7 @@ from integrations.external_api_status import (
     POLICY_ENGINE,
     get_external_api_failures,
     record_external_api_failure,
+    report_external_api_failure,
     track_external_api_failures,
 )
 
@@ -48,3 +51,29 @@ class TestExternalApiStatus(SimpleTestCase):
             self.assertEqual(get_external_api_failures(), sorted([HUD, POLICY_ENGINE]))
         # The outermost context resets everything on exit.
         self.assertEqual(get_external_api_failures(), [])
+
+
+class TestReportExternalApiFailure(SimpleTestCase):
+    """report_external_api_failure is the canonical "loud + flag" handling shared by the
+    PolicyEngine and HUD integrations."""
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_captures_exception_and_message_at_error_level(self, mock_capture_exception, mock_capture_message):
+        boom = ValueError("boom")
+        with track_external_api_failures():
+            report_external_api_failure(HUD, "HUD is down", boom)
+            self.assertEqual(get_external_api_failures(), [HUD])
+
+        mock_capture_exception.assert_called_once_with(boom, level="error")
+        mock_capture_message.assert_called_once_with("HUD is down", level="error")
+
+    @patch("integrations.external_api_status.capture_message")
+    @patch("integrations.external_api_status.capture_exception")
+    def test_message_only_when_no_exception(self, mock_capture_exception, mock_capture_message):
+        with track_external_api_failures():
+            report_external_api_failure(POLICY_ENGINE, "no exception here")
+            self.assertEqual(get_external_api_failures(), [POLICY_ENGINE])
+
+        mock_capture_exception.assert_not_called()
+        mock_capture_message.assert_called_once_with("no exception here", level="error")

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -81,9 +81,10 @@ def calc_pe_eligibility(
                 print(repr(e))
             report_external_api_failure(
                 POLICY_ENGINE,
-                f"Failed to calculate eligibility with the {Method.method_name} method; "
-                f"PolicyEngine programs are unavailable for this screen.",
+                "Failed to calculate eligibility with PolicyEngine; PolicyEngine programs "
+                "are unavailable for this screen.",
                 e,
+                context={"method": Method.method_name},
             )
             # Preserve the payload that triggered the failure so admins can debug it
             # (the exact request is the most useful thing for diagnosing a 400).

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -7,7 +7,7 @@ from sentry_sdk import capture_exception, capture_message
 from .engines import Sim, pe_engines
 from .calculators.constants import MAIN_TAX_UNIT, SECONDARY_TAX_UNIT
 from . import versions as pe_versions
-from integrations.external_api_status import record_external_api_failure, POLICY_ENGINE
+from integrations.external_api_status import report_external_api_failure, POLICY_ENGINE
 from django.conf import settings
 
 
@@ -79,13 +79,12 @@ def calc_pe_eligibility(
             # non-PolicyEngine (custom) calculators.
             if settings.DEBUG:
                 print(repr(e))
-            capture_exception(e, level="error")
-            capture_message(
+            report_external_api_failure(
+                POLICY_ENGINE,
                 f"Failed to calculate eligibility with the {Method.method_name} method; "
                 f"PolicyEngine programs are unavailable for this screen.",
-                level="error",
+                e,
             )
-            record_external_api_failure(POLICY_ENGINE)
             # Preserve the payload that triggered the failure so admins can debug it
             # (the exact request is the most useful thing for diagnosing a 400).
             # _pe_data.request is admin-only — already popped for non-admins downstream.

--- a/programs/programs/policyengine/tests/test_pe_failure.py
+++ b/programs/programs/policyengine/tests/test_pe_failure.py
@@ -59,16 +59,21 @@ class TestCalcPeEligibilityFailure(TestCase):
 
     def _run(self, engines):
         """Run calc_pe_eligibility with `engines` as the engine list, everything else
-        mocked. Returns (result, constructed, capture_message, failures)."""
+        mocked. Returns (result, constructed, capture_message, failures).
+
+        The Sentry calls are patched in `integrations.external_api_status`, not here:
+        the failure path delegates to `report_external_api_failure`, which is the shared
+        "loud + flag" handling PolicyEngine and HUD both go through. Patching
+        `pe.capture_message` would only intercept the SystemExit branch."""
         constructed = []
         engine_classes = [_make_engine(name, constructed, raises=raises) for name, raises in engines]
 
         with patch.object(pe, "pe_engines", engine_classes), patch.object(
             pe, "pe_input", return_value={}
-        ), patch.object(pe, "all_eligibility", return_value={"prog": MagicMock()}), patch.object(
-            pe, "capture_message"
-        ) as capture_message, patch.object(
-            pe, "capture_exception"
+        ), patch.object(pe, "all_eligibility", return_value={"prog": MagicMock()}), patch(
+            "integrations.external_api_status.capture_message"
+        ) as capture_message, patch(
+            "integrations.external_api_status.capture_exception"
         ), track_external_api_failures():
             result = pe.calc_pe_eligibility(self.screen, self.calculators)
             failures = get_external_api_failures()

--- a/programs/programs/tx/fpp/calculator.py
+++ b/programs/programs/tx/fpp/calculator.py
@@ -64,6 +64,7 @@ class TxFpp(ProgramCalculator):
         # (DependencyError) instead of crashing calc_expenses() and 500-ing the whole request.
         "expense_type",
         "expense_amount",
+        "expense_frequency",
         "household_size",
     ]
 

--- a/programs/programs/tx/hcv/calculator.py
+++ b/programs/programs/tx/hcv/calculator.py
@@ -3,6 +3,7 @@ from types import MappingProxyType
 
 from integrations.clients.hud_income_limits import hud_client, HudIncomeClientError
 from programs.programs.calc import Eligibility, ProgramCalculator
+from programs.util import DependencyError, ProgramConfigurationError
 import programs.programs.messages as messages
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,10 @@ class TxHcv(ProgramCalculator):
 
     def _year_period(self) -> str:
         if self.program.year is None:
-            raise HudIncomeClientError("Program year not configured")
+            # Our own configuration is wrong, not HUD's availability. Raising
+            # HudIncomeClientError here made it indistinguishable from an outage and let
+            # the handler below bury it as "income limit unknown" forever.
+            raise ProgramConfigurationError("TxHcv program year is not configured")
         return self.program.year.period
 
     def _countable_gross_income(self) -> float:
@@ -146,9 +150,14 @@ class TxHcv(ProgramCalculator):
             gross_income = int(self._countable_gross_income())
             income_limit = hud_client.get_screen_il_ami(self.screen, self.ami_percent, self._year_period())
             e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+        except (DependencyError, ProgramConfigurationError):
+            # Not answers we can degrade into "not eligible": the household is outside
+            # HUD's published tables, or the program is misconfigured. Let them reach
+            # eligibility_results, which omits the program and flags the response.
+            raise
         except HudIncomeClientError:
-            # Expected when HUD data is unavailable (API down, county/ZIP not found,
-            # year unconfigured) — mark not eligible without noise.
+            # Expected when HUD data is unavailable (API down, county/ZIP not found) —
+            # mark not eligible without noise.
             e.condition(False, messages.income_limit_unknown())
         except Exception:
             # Unexpected failure — still degrade to not eligible rather than raise,
@@ -183,9 +192,11 @@ class TxHcv(ProgramCalculator):
 
             hap = max(0, gross_rent - ttp)
             return int(hap * 12)
+        except (DependencyError, ProgramConfigurationError):
+            raise
         except HudIncomeClientError:
-            # Expected when HUD data is unavailable (API down, county/ZIP not found,
-            # year unconfigured) — degrade to $0 without noise.
+            # Expected when HUD data is unavailable (API down, county/ZIP not found) —
+            # degrade to $0 without noise.
             return 0
         except Exception:
             # Unexpected bug in the value calculation — still degrade to $0 so one

--- a/programs/programs/tx/hcv/tests/test_tx_hcv.py
+++ b/programs/programs/tx/hcv/tests/test_tx_hcv.py
@@ -5,6 +5,7 @@ from integrations.clients.hud_income_limits import HudIncomeClientError
 from programs.programs.tx import tx_calculators
 from programs.programs.tx.hcv.calculator import TxHcv
 from programs.programs.calc import ProgramCalculator, Eligibility
+from programs.util import DependencyError, ProgramConfigurationError
 
 
 def make_member(
@@ -545,3 +546,39 @@ class TestTxHcvNeverRaises(TestCase):
             e = calc.calc()  # must not raise, despite a non-typed exception
         self.assertTrue(e.eligible)
         self.assertEqual(e.value, 0)
+
+
+class TestTxHcvDoesNotBuryOurOwnDefects(TestCase):
+    """The blanket degrade-to-"not eligible" above is right for a HUD outage, but two
+    cases must escape it: our own configuration being wrong, and a household outside
+    HUD's published tables. Both used to be answered with a definite "No" nobody could
+    see was unfounded."""
+
+    def _calc(self):
+        return make_calculator(members=[make_member(age=35, earned=12_000)], household_size=1)
+
+    def test_null_program_year_raises_configuration_error(self):
+        calc = self._calc()
+        calc.program.year = None
+        with patch_hud(il_ami=40_000, payment_standard=1000):
+            with self.assertRaises(ProgramConfigurationError):
+                calc.calc()
+
+    def test_null_program_year_raises_from_household_value(self):
+        calc = self._calc()
+        calc.program.year = None
+        with patch_hud(il_ami=40_000, payment_standard=1000):
+            with self.assertRaises(ProgramConfigurationError):
+                calc.household_value()
+
+    def test_household_outside_hud_tables_raises_dependency_error(self):
+        """The client turns an out-of-range household size into DependencyError; the
+        calculator must let it through so the program is omitted rather than answered."""
+        calc = self._calc()
+        with patch.multiple(
+            "programs.programs.tx.hcv.calculator.hud_client",
+            get_screen_il_ami=Mock(side_effect=DependencyError()),
+            get_screen_payment_standard=Mock(return_value=1000),
+        ):
+            with self.assertRaises(DependencyError):
+                calc.calc()

--- a/programs/programs/wa/hcv/calculator.py
+++ b/programs/programs/wa/hcv/calculator.py
@@ -2,6 +2,7 @@ import logging
 
 from integrations.clients.hud_income_limits import hud_client, HudIncomeClientError
 from programs.programs.calc import Eligibility, ProgramCalculator
+from programs.util import DependencyError, ProgramConfigurationError
 import programs.programs.messages as messages
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,10 @@ class WaHcv(ProgramCalculator):
 
     def _get_year_period(self) -> str:
         if self.program.year is None:
-            raise HudIncomeClientError("Program year not configured")
+            # Our own configuration is wrong, not HUD's availability. Raising
+            # HudIncomeClientError here made it indistinguishable from an outage and let
+            # the handler below bury it as "income limit unknown" forever.
+            raise ProgramConfigurationError("WaHcv program year is not configured")
         return self.program.year.period
 
     def household_eligible(self, e: Eligibility):
@@ -86,9 +90,14 @@ class WaHcv(ProgramCalculator):
             finally:
                 self.screen.household_size = original_hh
             e.condition(gross_income <= income_limit, messages.income(gross_income, income_limit))
+        except (DependencyError, ProgramConfigurationError):
+            # Not answers we can degrade into "not eligible": the household is outside
+            # HUD's published tables, or the program is misconfigured. Let them reach
+            # eligibility_results, which omits the program and flags the response.
+            raise
         except HudIncomeClientError:
-            # Expected when HUD data is unavailable (API down, county/ZIP not found,
-            # year unconfigured) — mark not eligible without noise.
+            # Expected when HUD data is unavailable (API down, county/ZIP not found) —
+            # mark not eligible without noise.
             e.condition(False, messages.income_limit_unknown())
         except Exception:
             # Unexpected failure — still degrade to not eligible rather than raise,
@@ -126,9 +135,11 @@ class WaHcv(ProgramCalculator):
 
             hap = max(0, gross_rent - ttp)
             return int(hap * 12)
+        except (DependencyError, ProgramConfigurationError):
+            raise
         except HudIncomeClientError:
-            # Expected when HUD data is unavailable (API down, county/ZIP not found,
-            # year unconfigured) — degrade to $0 without noise.
+            # Expected when HUD data is unavailable (API down, county/ZIP not found) —
+            # degrade to $0 without noise.
             return 0
         except Exception:
             # Unexpected bug in the value calculation — still degrade to $0 so one

--- a/programs/programs/wa/hcv/tests/test_wa_hcv.py
+++ b/programs/programs/wa/hcv/tests/test_wa_hcv.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch, PropertyMock
 from programs.programs.wa import wa_calculators
 from programs.programs.wa.hcv.calculator import WaHcv
 from programs.programs.calc import ProgramCalculator, Eligibility
+from programs.util import ProgramConfigurationError
 
 
 def make_member(
@@ -391,21 +392,28 @@ class TestWaHcvCalc(TestCase):
             self.assertTrue(e.eligible)
             self.assertEqual(e.value, 10620)
 
-    def test_calc_null_year_does_not_crash(self):
-        """Program.year = None must not raise AttributeError (crashes all WA programs)."""
+    def test_calc_null_year_raises_configuration_error(self):
+        """An unset program year is OUR configuration being wrong, not HUD being down.
+
+        It used to raise HudIncomeClientError, which the income handler caught and turned
+        into a permanent, silent "not eligible (income limit unknown)" — a misconfiguration
+        that could sit in production forever. It must now escape the calculator so
+        eligibility_results reports it and skips the program.
+        """
         head = make_member(age=35)
         calc = make_calculator(members=[head], gross_income=21600)
         calc.program.year = None
         with patch_hud_client(il_ami_value=50000, fmr_value=2000):
-            e = calc.calc()
-            self.assertFalse(e.eligible)
+            with self.assertRaises(ProgramConfigurationError):
+                calc.calc()
 
-    def test_household_value_null_year_returns_zero(self):
+    def test_household_value_null_year_raises_configuration_error(self):
         head = make_member(age=35)
         calc = make_calculator(members=[head], gross_income=21600)
         calc.program.year = None
         with patch_hud_client(fmr_value=2000):
-            self.assertEqual(calc.household_value(), 0)
+            with self.assertRaises(ProgramConfigurationError):
+                calc.household_value()
 
     def test_household_value_unexpected_error_returns_zero(self):
         """Non-HudIncomeClientError from get_screen_payment_standard must not propagate as a 500."""

--- a/programs/test_util.py
+++ b/programs/test_util.py
@@ -1,0 +1,83 @@
+"""Tests for programs/util.py — the Dependencies set and its malformed-value channel."""
+
+from django.test import SimpleTestCase
+
+from programs.util import Dependencies, MalformedValue
+
+
+class TestDependenciesMalformed(SimpleTestCase):
+    def test_report_malformed_keeps_the_value_structured(self):
+        """`malformed` holds MalformedValue, not a pre-formatted string, so the reporter
+        can group Sentry events by field name instead of by a message containing the
+        value (which would be one issue per screen)."""
+        deps = Dependencies()
+        deps.add("income_frequency")
+        deps.report_malformed("income_frequency", "fortnightly", "monthly()/yearly() cannot convert it")
+
+        self.assertEqual(len(deps.malformed), 1)
+        entry = deps.malformed[0]
+        self.assertIsInstance(entry, MalformedValue)
+        self.assertEqual(entry.field, "income_frequency")
+        self.assertEqual(entry.value, "fortnightly")
+        self.assertIn("fortnightly", entry.describe())
+
+    def test_a_fresh_dependencies_has_no_malformed_detail(self):
+        self.assertEqual(Dependencies().malformed, [])
+        self.assertEqual(Dependencies({"a", "b"}).malformed, [])
+
+
+class TestDependenciesUpdate(SimpleTestCase):
+    """`update()` is overridden to carry malformed detail along. It is the obvious method
+    to reach for, so it has to be the correct one — a separate `merge()` would just mean
+    detail is silently dropped the first time someone types `update()` out of habit."""
+
+    def test_update_carries_malformed_detail(self):
+        outer = Dependencies()
+        inner = Dependencies()
+        inner.add("income_type")
+        inner.report_malformed("income_type", "", "blank")
+
+        outer.update(inner)
+
+        self.assertIn("income_type", outer)
+        self.assertEqual([m.field for m in outer.malformed], ["income_type"])
+
+    def test_update_accumulates_across_several_sources(self):
+        outer = Dependencies()
+        for field, value in (("income_type", ""), ("expense_frequency", "hourly")):
+            inner = Dependencies()
+            inner.add(field)
+            inner.report_malformed(field, value, "unusable")
+            outer.update(inner)
+
+        self.assertEqual(sorted(m.field for m in outer.malformed), ["expense_frequency", "income_type"])
+
+    def test_update_accepts_multiple_arguments(self):
+        """set.update takes *others; the override must not quietly drop the extras."""
+        a, b = Dependencies(), Dependencies()
+        a.add("income_type")
+        a.report_malformed("income_type", "", "blank")
+        b.add("expense_type")
+        b.report_malformed("expense_type", "", "blank")
+
+        outer = Dependencies()
+        outer.update(a, b)
+
+        self.assertEqual(outer, {"income_type", "expense_type"})
+        self.assertEqual(len(outer.malformed), 2)
+
+    def test_update_with_a_plain_set_is_fine(self):
+        """Plain iterables have no `malformed`; unioning one in must not raise."""
+        deps = Dependencies()
+        deps.update({"county", "zipcode"})
+
+        self.assertEqual(deps, {"county", "zipcode"})
+        self.assertEqual(deps.malformed, [])
+
+    def test_update_does_not_mutate_the_source(self):
+        inner = Dependencies()
+        inner.report_malformed("income_type", "", "blank")
+
+        Dependencies().update(inner)
+
+        self.assertEqual(len(inner.malformed), 1)

--- a/programs/util.py
+++ b/programs/util.py
@@ -1,3 +1,22 @@
+from typing import Any, NamedTuple
+
+
+class MalformedValue(NamedTuple):
+    """One screener field that holds a present-but-unusable value.
+
+    Kept structured rather than pre-formatted so the reporter can group Sentry events by
+    `field` (one issue per kind of corruption) instead of by a message string that
+    embeds the value (one issue per screen).
+    """
+
+    field: str
+    value: Any
+    detail: str
+
+    def describe(self) -> str:
+        return f"{self.field}={self.value!r} ({self.detail})"
+
+
 class Dependencies(set):
     """The set of screener field names that are unusable for a given screen, and so
     gate any calculator declaring them (see `ProgramCalculator.can_calc`).
@@ -11,8 +30,8 @@ class Dependencies(set):
 
     def __init__(self, *args):
         super().__init__(*args)
-        # Human-readable descriptors of present-but-unusable values, for Sentry.
-        self.malformed: list[str] = []
+        # Present-but-unusable values, for Sentry. See MalformedValue.
+        self.malformed: list[MalformedValue] = []
 
     def has(self, *iter):
         for dependency in iter:
@@ -25,15 +44,31 @@ class Dependencies(set):
         """Record that `field` is unusable because of the value it holds rather than
         because it is missing. Callers still `add()` the field name separately — this
         only carries the diagnostic detail."""
-        self.malformed.append(f"{field}={value!r} ({detail})")
+        self.malformed.append(MalformedValue(field, value, detail))
 
-    def merge(self, other: "Dependencies") -> None:
-        """Union another Dependencies in, carrying its malformed-value details along.
-        Use instead of `update()` so nested detail isn't dropped on the way up."""
-        self.update(other)
-        self.malformed.extend(getattr(other, "malformed", ()))
+    def update(self, *others) -> None:
+        """Union other iterables in, carrying any malformed-value details along.
+
+        Overridden rather than offered as a separate `merge()` so the obvious method is
+        also the correct one — nested detail can't be dropped by reaching for `update()`
+        out of habit. Plain sets/iterables have no `malformed`, which is fine.
+        """
+        for other in others:
+            super().update(other)
+            self.malformed.extend(getattr(other, "malformed", ()))
 
 
 class DependencyError(Exception):
     def __init__(self):
         super().__init__("Missing at least dependency")
+
+
+class ProgramConfigurationError(Exception):
+    """A program is missing configuration it cannot be calculated without (an unset
+    `year`, for example).
+
+    Distinct from `DependencyError`, which means the *screen* didn't supply something:
+    this is our own data being wrong, so it is a defect that should be reported loudly.
+    Calculators that broadly degrade on failure must re-raise it rather than swallow it,
+    so it reaches the reporting handler in `eligibility_results`.
+    """

--- a/programs/util.py
+++ b/programs/util.py
@@ -1,10 +1,37 @@
 class Dependencies(set):
+    """The set of screener field names that are unusable for a given screen, and so
+    gate any calculator declaring them (see `ProgramCalculator.can_calc`).
+
+    A field lands here for one of two reasons, which `malformed` distinguishes:
+      - it was never answered (null) — ordinary partial-screen input, expected and quiet;
+      - it holds a value we can't compute with (blank string, unrecognized frequency) —
+        data corruption or serializer drift, recorded in `malformed` so the caller can
+        report it loudly and flag the results as incomplete.
+    """
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # Human-readable descriptors of present-but-unusable values, for Sentry.
+        self.malformed: list[str] = []
+
     def has(self, *iter):
         for dependency in iter:
             if dependency in self:
                 return True
 
         return False
+
+    def report_malformed(self, field: str, value, detail: str) -> None:
+        """Record that `field` is unusable because of the value it holds rather than
+        because it is missing. Callers still `add()` the field name separately — this
+        only carries the diagnostic detail."""
+        self.malformed.append(f"{field}={value!r} ({detail})")
+
+    def merge(self, other: "Dependencies") -> None:
+        """Union another Dependencies in, carrying its malformed-value details along.
+        Use instead of `update()` so nested detail isn't dropped on the way up."""
+        self.update(other)
+        self.malformed.extend(getattr(other, "malformed", ()))
 
 
 class DependencyError(Exception):

--- a/screener/management/commands/batch_snapshots.py
+++ b/screener/management/commands/batch_snapshots.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from integrations.external_api_status import track_external_api_failures
 from screener.models import Screen
 from screener.views import eligibility_results
 from tqdm import trange
@@ -39,7 +40,12 @@ class Command(BaseCommand):
         errors = []
         for i in trange(len(screens), desc="Screens"):
             try:
-                eligibility_results(screens[i], batch=True)
+                # Scope external-API failure tracking to one screen so an outage reports
+                # once per screen rather than once per integration call. Without a context
+                # the per-run dedupe in report_external_api_failure has nothing to dedupe
+                # against, and a batch over every screen becomes a Sentry flood.
+                with track_external_api_failures():
+                    eligibility_results(screens[i], batch=True)
                 time.sleep(1)
             except Exception as e:
                 errors.append(str(screens[i].id) + ": " + str(e))

--- a/screener/models.py
+++ b/screener/models.py
@@ -411,10 +411,10 @@ class Screen(models.Model):
                 missing_fields.add(field)
 
         for member in self.household_members.all():
-            missing_fields.merge(member.missing_fields())
+            missing_fields.update(member.missing_fields())
 
         for expence in self.expenses.all():
-            missing_fields.merge(expence.missing_fields())
+            missing_fields.update(expence.missing_fields())
 
         return missing_fields
 
@@ -612,7 +612,7 @@ class HouseholdMember(models.Model):
                 missing_fields.add(field)
 
         for income in self.income_streams.all():
-            missing_fields.merge(income.missing_fields())
+            missing_fields.update(income.missing_fields())
 
         return missing_fields
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -411,10 +411,10 @@ class Screen(models.Model):
                 missing_fields.add(field)
 
         for member in self.household_members.all():
-            missing_fields.update(member.missing_fields())
+            missing_fields.merge(member.missing_fields())
 
         for expence in self.expenses.all():
-            missing_fields.update(expence.missing_fields())
+            missing_fields.merge(expence.missing_fields())
 
         return missing_fields
 
@@ -612,7 +612,7 @@ class HouseholdMember(models.Model):
                 missing_fields.add(field)
 
         for income in self.income_streams.all():
-            missing_fields.update(income.missing_fields())
+            missing_fields.merge(income.missing_fields())
 
         return missing_fields
 
@@ -662,17 +662,44 @@ class IncomeStream(models.Model):
     def _hour_to_month(self):
         return self.amount * self.hours_worked * Decimal(4.35)
 
-    def missing_fields(self):
-        income_fields = (
-            "type",
-            "amount",
-            "frequency",
-        )
+    # The frequencies monthly()/yearly() above can actually convert. A present-but-
+    # unsupported value (including "") matches no branch, leaving the local unassigned
+    # and raising UnboundLocalError partway through a calculation — so it is treated as
+    # a missing dependency rather than allowed to reach the calculators.
+    SUPPORTED_FREQUENCIES: ClassVar[frozenset] = frozenset(
+        {"monthly", "weekly", "biweekly", "semimonthly", "yearly", "hourly"}
+    )
 
+    def missing_fields(self):
         missing_fields = Dependencies()
-        for field in income_fields:
-            if getattr(self, field) is None:
-                missing_fields.add("income_" + field)
+
+        if self.type is None:
+            missing_fields.add("income_type")
+        elif not str(self.type).strip():
+            # A blank type isn't null, so it clears the old `is None` gate, then fails
+            # every match in calc_gross_income except the unearned catch-all
+            # (`type not in earned_income_types`) — quietly counted as unearned income
+            # instead of crashing. Wrong totals, no error.
+            missing_fields.add("income_type")
+            missing_fields.report_malformed("income_type", self.type, "blank; would be counted as unearned income")
+
+        if self.amount is None:
+            missing_fields.add("income_amount")
+
+        if self.frequency is None:
+            missing_fields.add("income_frequency")
+        elif self.frequency not in self.SUPPORTED_FREQUENCIES:
+            missing_fields.add("income_frequency")
+            missing_fields.report_malformed("income_frequency", self.frequency, "monthly()/yearly() cannot convert it")
+
+        # hourly needs hours_worked to produce any figure (_hour_to_month). hours_worked
+        # is nullable and has never been part of the dependency vocabulary, so without
+        # this an hourly row with no hours raises TypeError mid-calculation. Reported
+        # under income_amount because that is the field calculators declare when they
+        # read an amount — a name no calculator declares would gate nothing.
+        if self.frequency == "hourly" and self.hours_worked is None:
+            missing_fields.add("income_amount")
+            missing_fields.report_malformed("income_hours_worked", None, "hourly income with no hours_worked")
 
         return missing_fields
 
@@ -712,14 +739,31 @@ class Expense(models.Model):
 
         return yearly
 
-    def missing_fields(self):
-        expense_fields = ("type", "amount")
+    # Same contract as IncomeStream.SUPPORTED_FREQUENCIES, minus "hourly" — Expense's
+    # monthly()/yearly() have no hourly branch.
+    SUPPORTED_FREQUENCIES: ClassVar[frozenset] = frozenset({"monthly", "weekly", "biweekly", "semimonthly", "yearly"})
 
+    def missing_fields(self):
         missing_fields = Dependencies()
 
-        for field in expense_fields:
-            if getattr(self, field) is None:
-                missing_fields.add("expense_" + field)
+        if self.type is None:
+            missing_fields.add("expense_type")
+        elif not str(self.type).strip():
+            missing_fields.add("expense_type")
+            missing_fields.report_malformed("expense_type", self.type, "blank; matches no expense type filter")
+
+        if self.amount is None:
+            missing_fields.add("expense_amount")
+
+        # frequency was absent from this list entirely, so a null or unsupported expense
+        # frequency reached Expense.yearly() and raised UnboundLocalError. Emitting it
+        # only gates calculators that declare "expense_frequency"; the catch-all in
+        # eligibility_results covers the ones that don't.
+        if self.frequency is None:
+            missing_fields.add("expense_frequency")
+        elif self.frequency not in self.SUPPORTED_FREQUENCIES:
+            missing_fields.add("expense_frequency")
+            missing_fields.report_malformed("expense_frequency", self.frequency, "monthly()/yearly() cannot convert it")
 
         return missing_fields
 

--- a/screener/tests/test_missing_fields.py
+++ b/screener/tests/test_missing_fields.py
@@ -69,8 +69,7 @@ class TestIncomeStreamMissingFields(MissingFieldsTestBase):
         missing = income.missing_fields()
 
         self.assertIn("income_type", missing)
-        self.assertEqual(len(missing.malformed), 1)
-        self.assertIn("income_type", missing.malformed[0])
+        self.assertEqual([m.field for m in missing.malformed], ["income_type"])
 
     def test_unsupported_frequency_is_missing_and_malformed(self):
         """yearly() matches no branch for this value and raises UnboundLocalError."""
@@ -81,8 +80,8 @@ class TestIncomeStreamMissingFields(MissingFieldsTestBase):
         missing = income.missing_fields()
 
         self.assertIn("income_frequency", missing)
-        self.assertEqual(len(missing.malformed), 1)
-        self.assertIn("income_frequency", missing.malformed[0])
+        self.assertEqual([m.field for m in missing.malformed], ["income_frequency"])
+        self.assertEqual(missing.malformed[0].value, "fortnightly")
 
     def test_every_supported_frequency_is_accepted(self):
         for frequency in IncomeStream.SUPPORTED_FREQUENCIES:
@@ -112,8 +111,7 @@ class TestIncomeStreamMissingFields(MissingFieldsTestBase):
         missing = income.missing_fields()
 
         self.assertIn("income_amount", missing)
-        self.assertEqual(len(missing.malformed), 1)
-        self.assertIn("income_hours_worked", missing.malformed[0])
+        self.assertEqual([m.field for m in missing.malformed], ["income_hours_worked"])
 
     def test_hourly_with_hours_worked_is_fine(self):
         income = IncomeStream.objects.create(
@@ -163,7 +161,7 @@ class TestExpenseMissingFields(MissingFieldsTestBase):
         missing = expense.missing_fields()
 
         self.assertIn("expense_frequency", missing)
-        self.assertEqual(len(missing.malformed), 1)
+        self.assertEqual([m.field for m in missing.malformed], ["expense_frequency"])
 
     def test_blank_type_is_missing_and_malformed(self):
         expense = Expense.objects.create(
@@ -173,8 +171,7 @@ class TestExpenseMissingFields(MissingFieldsTestBase):
         missing = expense.missing_fields()
 
         self.assertIn("expense_type", missing)
-        self.assertEqual(len(missing.malformed), 1)
-        self.assertIn("expense_type", missing.malformed[0])
+        self.assertEqual([m.field for m in missing.malformed], ["expense_type"])
 
 
 class TestScreenMissingFieldsAggregation(MissingFieldsTestBase):
@@ -192,7 +189,7 @@ class TestScreenMissingFieldsAggregation(MissingFieldsTestBase):
 
         self.assertIn("income_frequency", missing)
         self.assertIn("expense_frequency", missing)
-        self.assertEqual(len(missing.malformed), 2)
+        self.assertEqual(sorted(m.field for m in missing.malformed), ["expense_frequency", "income_frequency"])
 
     def test_clean_screen_has_no_malformed_detail(self):
         IncomeStream.objects.create(

--- a/screener/tests/test_missing_fields.py
+++ b/screener/tests/test_missing_fields.py
@@ -1,0 +1,204 @@
+"""Tests for the dependency gate's value validation (Screen/HouseholdMember/
+IncomeStream/Expense `missing_fields`).
+
+The gate historically only asked `is None`, so a present-but-unusable value — a blank
+income type, a frequency `monthly()`/`yearly()` can't convert, an hourly row with no
+hours — passed straight through to the calculators, where it either raised mid-calculation
+(500ing the whole eligibility response) or silently produced a wrong number. These tests
+pin the stricter behavior: such fields are treated as missing AND recorded in
+`Dependencies.malformed` so the results view can report them and flag `missing_programs`.
+"""
+
+from django.test import TestCase
+
+from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream, Expense
+
+
+class MissingFieldsTestBase(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=1,
+            household_assets=0,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(
+            screen=self.screen,
+            relationship="headOfHousehold",
+            age=35,
+            student=False,
+            pregnant=False,
+            visually_impaired=False,
+            disabled=False,
+            long_term_disability=False,
+        )
+
+
+class TestIncomeStreamMissingFields(MissingFieldsTestBase):
+    def test_complete_row_reports_nothing(self):
+        income = IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=2000, frequency="monthly"
+        )
+
+        missing = income.missing_fields()
+
+        self.assertEqual(set(missing), set())
+        self.assertEqual(missing.malformed, [])
+
+    def test_null_values_are_missing_but_not_malformed(self):
+        """An unanswered question is ordinary partial input — gated, but reported quietly."""
+        income = IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type=None, amount=None, frequency=None
+        )
+
+        missing = income.missing_fields()
+
+        self.assertEqual(set(missing), {"income_type", "income_amount", "income_frequency"})
+        self.assertEqual(missing.malformed, [])
+
+    def test_blank_type_is_missing_and_malformed(self):
+        """A blank type cleared the old `is None` gate, then fell through to the unearned
+        catch-all in calc_gross_income — counted as unearned income, no error."""
+        income = IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="   ", amount=100, frequency="monthly"
+        )
+
+        missing = income.missing_fields()
+
+        self.assertIn("income_type", missing)
+        self.assertEqual(len(missing.malformed), 1)
+        self.assertIn("income_type", missing.malformed[0])
+
+    def test_unsupported_frequency_is_missing_and_malformed(self):
+        """yearly() matches no branch for this value and raises UnboundLocalError."""
+        income = IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=100, frequency="fortnightly"
+        )
+
+        missing = income.missing_fields()
+
+        self.assertIn("income_frequency", missing)
+        self.assertEqual(len(missing.malformed), 1)
+        self.assertIn("income_frequency", missing.malformed[0])
+
+    def test_every_supported_frequency_is_accepted(self):
+        for frequency in IncomeStream.SUPPORTED_FREQUENCIES:
+            with self.subTest(frequency=frequency):
+                income = IncomeStream(
+                    screen=self.screen,
+                    household_member=self.head,
+                    type="wages",
+                    amount=100,
+                    frequency=frequency,
+                    hours_worked=40,
+                )
+                self.assertNotIn("income_frequency", income.missing_fields())
+
+    def test_hourly_without_hours_worked_is_gated(self):
+        """_hour_to_month multiplies by hours_worked, which is nullable and was never part
+        of the dependency vocabulary — an hourly row with no hours raised TypeError."""
+        income = IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="wages",
+            amount=20,
+            frequency="hourly",
+            hours_worked=None,
+        )
+
+        missing = income.missing_fields()
+
+        self.assertIn("income_amount", missing)
+        self.assertEqual(len(missing.malformed), 1)
+        self.assertIn("income_hours_worked", missing.malformed[0])
+
+    def test_hourly_with_hours_worked_is_fine(self):
+        income = IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="wages",
+            amount=20,
+            frequency="hourly",
+            hours_worked=40,
+        )
+
+        missing = income.missing_fields()
+
+        self.assertEqual(set(missing), set())
+        self.assertEqual(missing.malformed, [])
+
+
+class TestExpenseMissingFields(MissingFieldsTestBase):
+    def test_complete_row_reports_nothing(self):
+        expense = Expense.objects.create(
+            screen=self.screen, household_member=self.head, type="rent", amount=1200, frequency="monthly"
+        )
+
+        missing = expense.missing_fields()
+
+        self.assertEqual(set(missing), set())
+        self.assertEqual(missing.malformed, [])
+
+    def test_null_frequency_is_now_reported(self):
+        """frequency was absent from Expense's field list entirely, so a null reached
+        Expense.yearly() and raised UnboundLocalError."""
+        expense = Expense.objects.create(
+            screen=self.screen, household_member=self.head, type="rent", amount=1200, frequency=None
+        )
+
+        missing = expense.missing_fields()
+
+        self.assertIn("expense_frequency", missing)
+        self.assertEqual(missing.malformed, [])
+
+    def test_hourly_is_not_a_valid_expense_frequency(self):
+        """Expense.monthly()/yearly() have no hourly branch, unlike IncomeStream's."""
+        expense = Expense.objects.create(
+            screen=self.screen, household_member=self.head, type="rent", amount=1200, frequency="hourly"
+        )
+
+        missing = expense.missing_fields()
+
+        self.assertIn("expense_frequency", missing)
+        self.assertEqual(len(missing.malformed), 1)
+
+    def test_blank_type_is_missing_and_malformed(self):
+        expense = Expense.objects.create(
+            screen=self.screen, household_member=self.head, type="", amount=1200, frequency="monthly"
+        )
+
+        missing = expense.missing_fields()
+
+        self.assertIn("expense_type", missing)
+        self.assertEqual(len(missing.malformed), 1)
+        self.assertIn("expense_type", missing.malformed[0])
+
+
+class TestScreenMissingFieldsAggregation(MissingFieldsTestBase):
+    def test_malformed_detail_propagates_from_nested_rows(self):
+        """Screen.missing_fields merges through HouseholdMember -> IncomeStream and
+        Screen -> Expense; the malformed detail must survive both hops."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=100, frequency="fortnightly"
+        )
+        Expense.objects.create(
+            screen=self.screen, household_member=self.head, type="rent", amount=1200, frequency="hourly"
+        )
+
+        missing = self.screen.missing_fields()
+
+        self.assertIn("income_frequency", missing)
+        self.assertIn("expense_frequency", missing)
+        self.assertEqual(len(missing.malformed), 2)
+
+    def test_clean_screen_has_no_malformed_detail(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=2000, frequency="monthly"
+        )
+
+        missing = self.screen.missing_fields()
+
+        self.assertEqual(missing.malformed, [])

--- a/screener/tests/test_missing_programs.py
+++ b/screener/tests/test_missing_programs.py
@@ -12,12 +12,22 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from integrations.clients.hud_income_limits import hud_client
 from integrations.external_api_status import HUD, record_external_api_failure, track_external_api_failures
-from programs.models import Program, ProgramCategory
+from programs.models import (
+    Program,
+    ProgramCategory,
+    UrgentNeed,
+    UrgentNeedCategory,
+    UrgentNeedFunction,
+    UrgentNeedType,
+    WarningMessage,
+)
 from programs.programs.calc import Eligibility, ProgramCalculator
-from programs.util import DependencyError
-from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream
-from screener.views import eligibility_results
+from programs.programs.urgent_needs.base import UrgentNeedFunction as UrgentNeedFunctionCalculator
+from programs.util import DependencyError, ProgramConfigurationError
+from screener.models import Screen, HouseholdMember, ProgramEligibilitySnapshot, WhiteLabel, IncomeStream
+from screener.views import eligibility_results, urgent_need_results
 
 
 class BoomCalculator(ProgramCalculator):
@@ -38,6 +48,24 @@ class SkipCalculator(ProgramCalculator):
 
 class FineCalculator(ProgramCalculator):
     amount = 100
+
+
+class MisconfiguredCalculator(ProgramCalculator):
+    """Stands in for TxHcv/WaHcv with an unset `program.year` — our own data being wrong,
+    which is a defect rather than a screen-data gap."""
+
+    def household_eligible(self, e: Eligibility):
+        raise ProgramConfigurationError("program year is not configured")
+
+
+class OversizedHouseholdCalculator(ProgramCalculator):
+    """Stands in for the seven HUD-backed calculators on a 9-person household: HUD's
+    published tables stop at 8, so there is no income limit to test against."""
+
+    amount = 100
+
+    def household_eligible(self, e: Eligibility):
+        hud_client.get_screen_il_ami(self.screen, "80%", "2025")
 
 
 class MissingProgramsTestBase(TestCase):
@@ -108,10 +136,27 @@ class TestCalculatorCrashSetsMissingPrograms(MissingProgramsTestBase):
 
         self.assertTrue(missing_programs)
         # Loud: both the exception and a human-readable context line, at error level.
-        self.assertEqual(mock_capture_exception.call_args.kwargs, {"level": "error"})
         self.assertIsInstance(mock_capture_exception.call_args.args[0], UnboundLocalError)
-        self.assertIn(program.name_abbreviated, mock_capture_message.call_args.args[0])
-        self.assertEqual(mock_capture_message.call_args.kwargs, {"level": "error"})
+        self.assertEqual(mock_capture_exception.call_args.kwargs["level"], "error")
+        self.assertEqual(mock_capture_message.call_args.kwargs["level"], "error")
+
+        # The message is static and the program rides in context + fingerprint: Sentry
+        # should show one issue per broken program, not one per screen that hit it.
+        message = mock_capture_message.call_args.args[0]
+        self.assertNotIn(program.name_abbreviated, message)
+        self.assertNotIn(str(self.screen.id), message)
+        for mock in (mock_capture_exception, mock_capture_message):
+            contexts = mock.call_args.kwargs["contexts"]
+            self.assertEqual(contexts["program"]["name_abbreviated"], program.name_abbreviated)
+            self.assertEqual(contexts["program"]["stage"], "eligibility")
+            self.assertEqual(contexts["screen"]["id"], self.screen.id)
+        self.assertEqual(
+            mock_capture_message.call_args.kwargs["fingerprint"],
+            ["program-eligibility-failure", program.name_abbreviated, "eligibility"],
+        )
+        # capture_exception keeps Sentry's own stack-trace grouping so two different bugs
+        # in the same program stay separate issues.
+        self.assertNotIn("fingerprint", mock_capture_exception.call_args.kwargs)
 
     def test_one_crashing_program_does_not_lose_the_others(self):
         """The whole point: previously this 500'd and the user got zero results."""
@@ -164,10 +209,51 @@ class TestMalformedDataSetsMissingPrograms(MissingProgramsTestBase):
             missing_programs = self._run()
 
         self.assertTrue(missing_programs)
+        kwargs = mock_capture_message.call_args.kwargs
+        self.assertEqual(kwargs["level"], "error")
+
+        # Static message; the screen id and the offending value are structured context, so
+        # Sentry groups by the KIND of corruption (the field names) rather than by screen.
         message = mock_capture_message.call_args.args[0]
-        self.assertIn("income_frequency", message)
-        self.assertIn("fortnightly", message)
-        self.assertEqual(mock_capture_message.call_args.kwargs, {"level": "error"})
+        self.assertNotIn("fortnightly", message)
+        self.assertNotIn(str(self.screen.id), message)
+        self.assertEqual(kwargs["contexts"]["malformed_data"]["fields"], ["income_frequency"])
+        self.assertIn("fortnightly", kwargs["contexts"]["malformed_data"]["values"][0])
+        self.assertEqual(kwargs["contexts"]["screen"]["id"], self.screen.id)
+        self.assertEqual(kwargs["fingerprint"], ["malformed-screen-data", "income_frequency"])
+
+    def test_same_corruption_on_two_screens_groups_together(self):
+        """Two screens with the same defect must produce the same fingerprint — otherwise
+        a widespread serializer drift arrives as thousands of separate Sentry issues."""
+        fingerprints = []
+        for _ in range(2):
+            screen = Screen.objects.create(
+                white_label=self.white_label,
+                zipcode="78701",
+                county="Test County",
+                household_size=1,
+                household_assets=0,
+                completed=False,
+            )
+            member = HouseholdMember.objects.create(
+                screen=screen,
+                relationship="headOfHousehold",
+                age=35,
+                student=False,
+                pregnant=False,
+                visually_impaired=False,
+                disabled=False,
+                long_term_disability=False,
+            )
+            IncomeStream.objects.create(
+                screen=screen, household_member=member, type="wages", amount=100, frequency="fortnightly"
+            )
+            with patch("screener.views.capture_message") as mock_capture_message:
+                with track_external_api_failures():
+                    eligibility_results(screen)
+            fingerprints.append(mock_capture_message.call_args.kwargs["fingerprint"])
+
+        self.assertEqual(fingerprints[0], fingerprints[1])
 
     def test_null_data_does_not_trigger_the_malformed_report(self):
         """A null income row is ordinary partial input: it still gates programs that
@@ -180,3 +266,193 @@ class TestMalformedDataSetsMissingPrograms(MissingProgramsTestBase):
             self._run()
 
         mock_capture_message.assert_not_called()
+
+
+class TestPresentationCrashIsIsolated(MissingProgramsTestBase):
+    """The eligibility call was guarded, but everything after it — warning calculators,
+    translation lookups, snapshot construction — reads the same screen data and ran
+    unguarded. A `fortnightly` income row crashing `calc_gross_income()` inside a warning
+    calculator 500'd the response exactly as hard as one crashing the calculator itself.
+    """
+
+    def _attach_warning(self, program: Program, calculator: str) -> None:
+        warning = WarningMessage.objects.new_warning(self.white_label.code, calculator)
+        program.warning_messages.add(warning)
+
+    def test_broken_warning_skips_only_that_program(self):
+        """An unregistered warning calculator raises `... is not a valid calculator name`,
+        which used to abort the entire response."""
+        program = self._seed_program("fine")
+        self._attach_warning(program, "no_such_warning_calculator")
+
+        with patch.dict("programs.models.calculators", {"fine": FineCalculator}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    with track_external_api_failures():
+                        programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        self.assertTrue(missing_programs)
+        self.assertNotIn("fine", {p["short_name"] for p in programs})
+        mock_capture_exception.assert_called_once()
+        self.assertEqual(
+            mock_capture_message.call_args.kwargs["contexts"]["program"]["stage"],
+            "presentation",
+        )
+
+    def test_a_broken_warning_does_not_lose_the_other_programs(self):
+        broken = self._seed_program("broken")
+        self._attach_warning(broken, "no_such_warning_calculator")
+        self._seed_program("fine")
+
+        with patch.dict(
+            "programs.models.calculators",
+            {"broken": FineCalculator, "fine": FineCalculator},
+            clear=False,
+        ):
+            with patch("screener.views.capture_exception"), patch("screener.views.capture_message"):
+                with track_external_api_failures():
+                    programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        self.assertTrue(missing_programs)
+        returned = {p["short_name"] for p in programs}
+        self.assertIn("fine", returned)
+        self.assertNotIn("broken", returned)
+
+    def test_partial_output_is_rolled_back(self):
+        """The crashed program must leave no half-rendered entry or snapshot row behind."""
+        program = self._seed_program("broken")
+        self._attach_warning(program, "no_such_warning_calculator")
+
+        with patch.dict("programs.models.calculators", {"broken": FineCalculator}, clear=False):
+            with patch("screener.views.capture_exception"), patch("screener.views.capture_message"):
+                with track_external_api_failures():
+                    programs, _missing, _categories, _pe_data = eligibility_results(self.screen)
+
+        self.assertEqual(programs, [])
+        self.assertFalse(ProgramEligibilitySnapshot.objects.filter(name_abbreviated=program.name_abbreviated).exists())
+
+
+class TestUrgentNeedCrashIsIsolated(MissingProgramsTestBase):
+    """urgent_need_results had no protection at all, and IlRentAsst calls the HUD client
+    with no handler of its own — so a HUD outage took the whole results response down."""
+
+    def setUp(self):
+        super().setUp()
+        self.screen.needs_food = True
+        self.screen.save()
+
+        category = UrgentNeedCategory.objects.create(name="food")
+        need_type = UrgentNeedType.objects.new_urgent_need_type(self.white_label.code, "food-type", "")
+
+        self.need = UrgentNeed.objects.new_urgent_need(self.white_label.code, "boom-need", "")
+        self.need.active = True
+        self.need.category_type = need_type
+        self.need.save()
+        self.need.type_short.add(category)
+        self.need.functions.add(UrgentNeedFunction.objects.create(name="boom_need_function"))
+
+    def test_crashing_urgent_need_is_reported_and_skipped(self):
+        class BoomNeed(UrgentNeedFunctionCalculator):
+            def eligible(self):
+                raise UnboundLocalError("cannot access local variable 'yearly'")
+
+        with patch.dict("screener.views.urgent_need_functions", {"boom_need_function": BoomNeed}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    needs = urgent_need_results(self.screen, [])
+
+        self.assertEqual(needs, [])
+        mock_capture_exception.assert_called_once()
+        self.assertEqual(
+            mock_capture_message.call_args.kwargs["fingerprint"],
+            ["urgent-need-failure", str(self.need.id)],
+        )
+
+    def test_dependency_error_in_an_urgent_need_stays_quiet(self):
+        class SkipNeed(UrgentNeedFunctionCalculator):
+            def eligible(self):
+                raise DependencyError()
+
+        with patch.dict("screener.views.urgent_need_functions", {"boom_need_function": SkipNeed}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    needs = urgent_need_results(self.screen, [])
+
+        self.assertEqual(needs, [])
+        mock_capture_exception.assert_not_called()
+        mock_capture_message.assert_not_called()
+
+
+class TestMisconfiguredProgramIsLoud(MissingProgramsTestBase):
+    """An unset `program.year` used to be raised as HudIncomeClientError, which the
+    HUD-backed calculators caught and turned into a permanent, silent "not eligible
+    (income limit unknown)". It is our own data being wrong, so it must be loud."""
+
+    def test_configuration_error_is_reported_and_the_program_skipped(self):
+        program = self._seed_program("misconfigured")
+
+        with patch.dict("programs.models.calculators", {"misconfigured": MisconfiguredCalculator}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    with track_external_api_failures():
+                        programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        self.assertTrue(missing_programs)
+        self.assertNotIn(program.name_abbreviated, {p["short_name"] for p in programs})
+        self.assertIsInstance(mock_capture_exception.call_args.args[0], ProgramConfigurationError)
+        self.assertEqual(mock_capture_message.call_args.kwargs["level"], "error")
+
+
+class TestHouseholdOutsideHudTables(MissingProgramsTestBase):
+    """HUD publishes income limits for households of 1-8. A 9-person household used to get
+    a definite "not eligible (income limit unknown)" across all seven HUD-backed programs,
+    with no flag and no event — a "No" derived from a number we never had."""
+
+    def _make_oversized_household(self):
+        self.screen.household_size = 9
+        self.screen.save()
+
+    def test_oversized_household_omits_the_program_and_flags_the_response(self):
+        program = self._seed_program("oversized")
+        self._make_oversized_household()
+
+        with patch.dict("programs.models.calculators", {"oversized": OversizedHouseholdCalculator}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    with track_external_api_failures():
+                        programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        # Omitted rather than answered "not eligible".
+        self.assertNotIn(program.name_abbreviated, {p["short_name"] for p in programs})
+        self.assertTrue(missing_programs)
+        # Quiet: nothing external failed, so this must not page anyone or tell the user an
+        # external service is down.
+        mock_capture_exception.assert_not_called()
+        mock_capture_message.assert_not_called()
+
+    def test_oversized_household_does_not_claim_an_external_api_failed(self):
+        self._seed_program("oversized")
+        self._make_oversized_household()
+
+        with patch.dict("programs.models.calculators", {"oversized": OversizedHouseholdCalculator}, clear=False):
+            with track_external_api_failures() as _:
+                eligibility_results(self.screen)
+                from integrations.external_api_status import get_external_api_failures
+
+                self.assertEqual(get_external_api_failures(), [])
+
+    def test_supported_household_size_still_reaches_hud(self):
+        """The gate must be the household size, not the program: an 8-person household is
+        inside HUD's tables and must still be calculated."""
+        self._seed_program("oversized")
+        self.screen.household_size = 8
+        self.screen.save()
+
+        with patch.dict("programs.models.calculators", {"oversized": OversizedHouseholdCalculator}, clear=False):
+            with patch.object(hud_client, "get_screen_il_ami", return_value=50_000) as mock_lookup:
+                with track_external_api_failures():
+                    programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        mock_lookup.assert_called_once()
+        self.assertIn("oversized", {p["short_name"] for p in programs})
+        self.assertFalse(missing_programs)

--- a/screener/tests/test_missing_programs.py
+++ b/screener/tests/test_missing_programs.py
@@ -1,0 +1,182 @@
+"""Locks the three ways a degraded eligibility run must reach `missing_programs`.
+
+`missing_programs` is the only signal the response carries that results are incomplete.
+It used to be set for exactly two reasons — a DependencyError from a custom calculator,
+or a PolicyEngine program absent from the PE result — which left three degradations
+completely silent: an external integration (HUD) failing under a calculator that
+swallows the error, a calculator crashing on data the dependency gate let through, and
+screen data that is malformed rather than null. These tests pin all of them.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from integrations.external_api_status import HUD, record_external_api_failure, track_external_api_failures
+from programs.models import Program, ProgramCategory
+from programs.programs.calc import Eligibility, ProgramCalculator
+from programs.util import DependencyError
+from screener.models import Screen, HouseholdMember, WhiteLabel, IncomeStream
+from screener.views import eligibility_results
+
+
+class BoomCalculator(ProgramCalculator):
+    """Stands in for a calculator that crashes on data the gate let through — e.g. an
+    income row whose frequency is unrecognized, so IncomeStream.yearly() falls through
+    every branch and raises UnboundLocalError."""
+
+    def household_eligible(self, e: Eligibility):
+        raise UnboundLocalError("cannot access local variable 'yearly'")
+
+
+class SkipCalculator(ProgramCalculator):
+    """Stands in for the ordinary partial-screen path."""
+
+    def calc(self) -> Eligibility:
+        raise DependencyError()
+
+
+class FineCalculator(ProgramCalculator):
+    amount = 100
+
+
+class MissingProgramsTestBase(TestCase):
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=1,
+            household_assets=0,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(
+            screen=self.screen,
+            relationship="headOfHousehold",
+            age=35,
+            student=False,
+            pregnant=False,
+            visually_impaired=False,
+            disabled=False,
+            long_term_disability=False,
+        )
+
+    def _seed_program(self, name_abbreviated: str) -> Program:
+        """new_program() creates an inactive, uncategorized row; eligibility_results only
+        looks at active + categorized + has_calculator programs."""
+        if not hasattr(self, "_category"):
+            self._category = ProgramCategory.objects.new_program_category(self.white_label.code, "test-category", None)
+
+        program = Program.objects.new_program(self.white_label.code, name_abbreviated)
+        program.active = True
+        program.has_calculator = True
+        program.category = self._category
+        program.save()
+        return program
+
+    def _run(self):
+        """Run eligibility_results inside a tracking context, as the results view does."""
+        with track_external_api_failures():
+            _programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+        return missing_programs
+
+
+class TestExternalApiFailureSetsMissingPrograms(MissingProgramsTestBase):
+    def test_recorded_hud_failure_sets_missing_programs(self):
+        """HUD-backed calculators catch HudIncomeClientError and degrade to "not eligible
+        (income limit unknown)", so nothing raises and no program is skipped — the
+        recorded failure is the only trace, and it has to flip the flag."""
+        with track_external_api_failures():
+            record_external_api_failure(HUD)
+            _programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        self.assertTrue(missing_programs)
+
+    def test_no_failure_leaves_flag_false(self):
+        self.assertFalse(self._run())
+
+
+class TestCalculatorCrashSetsMissingPrograms(MissingProgramsTestBase):
+    def test_crash_is_reported_and_flagged_not_fatal(self):
+        program = self._seed_program("boom")
+
+        with patch.dict("programs.models.calculators", {"boom": BoomCalculator}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    missing_programs = self._run()
+
+        self.assertTrue(missing_programs)
+        # Loud: both the exception and a human-readable context line, at error level.
+        self.assertEqual(mock_capture_exception.call_args.kwargs, {"level": "error"})
+        self.assertIsInstance(mock_capture_exception.call_args.args[0], UnboundLocalError)
+        self.assertIn(program.name_abbreviated, mock_capture_message.call_args.args[0])
+        self.assertEqual(mock_capture_message.call_args.kwargs, {"level": "error"})
+
+    def test_one_crashing_program_does_not_lose_the_others(self):
+        """The whole point: previously this 500'd and the user got zero results."""
+        self._seed_program("boom")
+        self._seed_program("fine")
+
+        with patch.dict(
+            "programs.models.calculators",
+            {"boom": BoomCalculator, "fine": FineCalculator},
+            clear=False,
+        ):
+            with patch("screener.views.capture_exception"), patch("screener.views.capture_message"):
+                with track_external_api_failures():
+                    programs, missing_programs, _categories, _pe_data = eligibility_results(self.screen)
+
+        self.assertTrue(missing_programs)
+        returned = {p["short_name"] for p in programs}
+        self.assertIn("fine", returned)
+        self.assertNotIn("boom", returned)
+
+    def test_dependency_error_stays_quiet(self):
+        """An unanswered question is not a defect — flag the response, but don't page
+        anyone."""
+        self._seed_program("skip")
+
+        with patch.dict("programs.models.calculators", {"skip": SkipCalculator}, clear=False):
+            with patch("screener.views.capture_exception") as mock_capture_exception:
+                with patch("screener.views.capture_message") as mock_capture_message:
+                    missing_programs = self._run()
+
+        self.assertTrue(missing_programs)
+        mock_capture_exception.assert_not_called()
+        mock_capture_message.assert_not_called()
+
+
+class TestMalformedDataSetsMissingPrograms(MissingProgramsTestBase):
+    def test_malformed_screen_data_is_reported_and_flagged(self):
+        """Set independently of which calculators happen to declare the field: with no
+        calculator declaring income_frequency, nothing would raise DependencyError, yet
+        the run is still degraded."""
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="wages",
+            amount=100,
+            frequency="fortnightly",
+        )
+
+        with patch("screener.views.capture_message") as mock_capture_message:
+            missing_programs = self._run()
+
+        self.assertTrue(missing_programs)
+        message = mock_capture_message.call_args.args[0]
+        self.assertIn("income_frequency", message)
+        self.assertIn("fortnightly", message)
+        self.assertEqual(mock_capture_message.call_args.kwargs, {"level": "error"})
+
+    def test_null_data_does_not_trigger_the_malformed_report(self):
+        """A null income row is ordinary partial input: it still gates programs that
+        declare it, but must not fire a Sentry error."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type=None, amount=None, frequency=None
+        )
+
+        with patch("screener.views.capture_message") as mock_capture_message:
+            self._run()
+
+        mock_capture_message.assert_not_called()

--- a/screener/views.py
+++ b/screener/views.py
@@ -1,6 +1,7 @@
 import hashlib
 import requests
 from typing import Optional
+from sentry_sdk import capture_exception, capture_message
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from integrations.clients.rewiring_america import RewiringAmericaClient
@@ -423,6 +424,19 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
 
     missing_dependencies = screen.missing_fields()
 
+    # Fields that hold an unusable value rather than being unanswered. Unlike a blank
+    # question this is data corruption or serializer drift, and until now it either 500'd
+    # the request or silently produced a wrong number, so report it loudly. One event per
+    # request listing every affected field, rather than one per row.
+    malformed_fields = getattr(missing_dependencies, "malformed", [])
+    if malformed_fields:
+        capture_message(
+            f"Malformed screen data treated as missing dependencies (screen {screen.id}): "
+            f"{'; '.join(malformed_fields)}. Any program declaring these fields was skipped; "
+            f"results are flagged incomplete either way.",
+            level="error",
+        )
+
     program_by_abbr = {p.name_abbreviated: p for p in all_programs}
     pe_calculators = {}
     for calculator_name, Calculator in all_calculators.items():
@@ -459,7 +473,10 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
 
         return calc_order.index(program.name_abbreviated)
 
-    missing_programs = False
+    # Flagged on malformed data whether or not any calculator happens to declare the
+    # affected field: a program that read it without declaring it produced a number from
+    # data we know is bad, which is exactly the case that used to pass silently.
+    missing_programs = bool(malformed_fields)
 
     # make certain benifits calculate first so that they can be used in other benefits
     all_programs = sorted(all_programs, key=sort_first)
@@ -481,6 +498,22 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
             try:
                 eligibility = program.eligibility(screen, program_eligibility, missing_dependencies)
             except DependencyError:
+                # Expected: a declared dependency was unanswered. Skip quietly — this is
+                # ordinary partial-screen behavior, not a defect.
+                missing_programs = True
+                continue
+            except Exception as e:
+                # A calculator raised something other than DependencyError — a bug, or
+                # screen data that is malformed rather than null and so slipped past
+                # can_calc(). Previously this escaped the loop and 500'd the whole
+                # response, losing every other program's results. Skip just this program,
+                # loudly, and flag the response as incomplete.
+                capture_exception(e, level="error")
+                capture_message(
+                    f"Failed to calculate eligibility for program {program.name_abbreviated} "
+                    f"(screen {screen.id}); the program was skipped for this screen.",
+                    level="error",
+                )
                 missing_programs = True
                 continue
         else:
@@ -630,6 +663,16 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
         clean_program = program
         clean_program["estimated_value"] = math.trunc(clean_program["estimated_value"])
         eligible_programs.append(clean_program)
+
+    # An integration that failed during this run means some program was computed from a
+    # fallback rather than real data — HUD-backed programs, for instance, degrade to "not
+    # eligible (income limit unknown)" and would otherwise present that guess as a
+    # confident answer. PolicyEngine already reaches missing_programs via the
+    # `not in pe_eligibility` branch above; this covers every other integration.
+    # Reads the collector established by track_external_api_failures() around the caller;
+    # empty (harmless) when no tracking context is active.
+    if get_external_api_failures():
+        missing_programs = True
 
     return eligible_programs, missing_programs, categories, pe_data
 

--- a/screener/views.py
+++ b/screener/views.py
@@ -428,13 +428,25 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
     # question this is data corruption or serializer drift, and until now it either 500'd
     # the request or silently produced a wrong number, so report it loudly. One event per
     # request listing every affected field, rather than one per row.
-    malformed_fields = getattr(missing_dependencies, "malformed", [])
-    if malformed_fields:
+    #
+    # The message is static and the fingerprint is the set of affected field names, so
+    # Sentry groups by *kind* of corruption — one issue per drift pattern to chase down,
+    # not one per screen. Screen id and the offending values ride along as context.
+    malformed_values = missing_dependencies.malformed
+    if malformed_values:
+        malformed_field_names = sorted({m.field for m in malformed_values})
         capture_message(
-            f"Malformed screen data treated as missing dependencies (screen {screen.id}): "
-            f"{'; '.join(malformed_fields)}. Any program declaring these fields was skipped; "
-            f"results are flagged incomplete either way.",
+            "Malformed screen data treated as missing dependencies. Any program declaring "
+            "these fields was skipped; results are flagged incomplete either way.",
             level="error",
+            contexts={
+                "screen": {"id": screen.id, "white_label": screen.white_label.code},
+                "malformed_data": {
+                    "fields": malformed_field_names,
+                    "values": [m.describe() for m in malformed_values],
+                },
+            },
+            fingerprint=["malformed-screen-data", *malformed_field_names],
         )
 
     program_by_abbr = {p.name_abbreviated: p for p in all_programs}
@@ -476,7 +488,7 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
     # Flagged on malformed data whether or not any calculator happens to declare the
     # affected field: a program that read it without declaring it produced a number from
     # data we know is bad, which is exactly the case that used to pass silently.
-    missing_programs = bool(malformed_fields)
+    missing_programs = bool(malformed_values)
 
     # make certain benifits calculate first so that they can be used in other benefits
     all_programs = sorted(all_programs, key=sort_first)
@@ -485,6 +497,26 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
     eligible_program_data: list[tuple] = []  # (program, data_index) for post-loop navigator pass
 
     program_eligibility = {}
+
+    def report_program_failure(program: Program, e: Exception, stage: str) -> None:
+        """One crashing program must not cost the user every other program's results.
+        Report loudly, then let the caller skip just this one.
+
+        The message is static and fingerprinted on the program: Sentry should show one
+        issue per broken program to fix, not one per screen that hit it. `capture_exception`
+        is left to group on its own stack trace so two different bugs in the same program
+        stay distinguishable."""
+        context = {
+            "program": {"name_abbreviated": program.name_abbreviated, "id": program.id, "stage": stage},
+            "screen": {"id": screen.id, "white_label": screen.white_label.code},
+        }
+        capture_exception(e, level="error", contexts=context)
+        capture_message(
+            "Failed to calculate eligibility for a program; it was skipped for this screen.",
+            level="error",
+            contexts=context,
+            fingerprint=["program-eligibility-failure", program.name_abbreviated, stage],
+        )
 
     for program in all_programs:
         # Tracking-only programs (has_calculator=False) and disabled programs
@@ -498,22 +530,18 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
             try:
                 eligibility = program.eligibility(screen, program_eligibility, missing_dependencies)
             except DependencyError:
-                # Expected: a declared dependency was unanswered. Skip quietly — this is
-                # ordinary partial-screen behavior, not a defect.
+                # Expected: a declared dependency was unanswered, or the household falls
+                # outside an external table we depend on. Skip quietly — this is ordinary
+                # partial-screen behavior, not a defect.
                 missing_programs = True
                 continue
             except Exception as e:
-                # A calculator raised something other than DependencyError — a bug, or
-                # screen data that is malformed rather than null and so slipped past
-                # can_calc(). Previously this escaped the loop and 500'd the whole
-                # response, losing every other program's results. Skip just this program,
-                # loudly, and flag the response as incomplete.
-                capture_exception(e, level="error")
-                capture_message(
-                    f"Failed to calculate eligibility for program {program.name_abbreviated} "
-                    f"(screen {screen.id}); the program was skipped for this screen.",
-                    level="error",
-                )
+                # A calculator raised something other than DependencyError — a bug, a
+                # misconfigured program (ProgramConfigurationError), or screen data that is
+                # malformed rather than null and so slipped past can_calc(). Previously this
+                # escaped the loop and 500'd the whole response, losing every other program's
+                # results. Skip just this program, loudly, and flag the response incomplete.
+                report_program_failure(program, e, "eligibility")
                 missing_programs = True
                 continue
         else:
@@ -525,99 +553,120 @@ def eligibility_results(screen: Screen, batch=False, pe_version: Optional[str] =
 
         program_eligibility[program.name_abbreviated] = eligibility
 
-        if previous_snapshot is not None:
-            new = True
-            for previous_snapshot in previous_results:
-                if (
-                    previous_snapshot.name_abbreviated == program.name_abbreviated
-                    and eligibility.eligible == previous_snapshot.eligible
-                ):
-                    new = False
-        else:
-            new = False
+        # Everything from here on is presentation: warning calculators, translation
+        # lookups and snapshot construction, all of which read the same screen data the
+        # eligibility calculators do. A `fortnightly` income row crashing
+        # `screen.calc_gross_income()` inside a warning calculator is the same defect as
+        # one crashing the calculator itself, and it 500'd the whole response just as
+        # hard. Guard it the same way, rolling back this program's partial output so a
+        # half-rendered entry never reaches the response.
+        snapshots_len, data_len, eligible_len = len(program_snapshots), len(data), len(eligible_program_data)
+        try:
+            if previous_snapshot is not None:
+                new = True
+                for previous_snapshot in previous_results:
+                    if (
+                        previous_snapshot.name_abbreviated == program.name_abbreviated
+                        and eligibility.eligible == previous_snapshot.eligible
+                    ):
+                        new = False
+            else:
+                new = False
 
-        warnings = []
+            warnings = []
 
-        # don't calculate warnings for ineligible programs
-        if eligibility.eligible:
-            for warning in program.warning_messages.all():
-                if warning.calculator not in warning_calculators:
-                    raise Exception(f"{warning.calculator} is not a valid calculator name")
+            # don't calculate warnings for ineligible programs
+            if eligibility.eligible:
+                for warning in program.warning_messages.all():
+                    if warning.calculator not in warning_calculators:
+                        raise Exception(f"{warning.calculator} is not a valid calculator name")
 
-                warning_calculator = warning_calculators[warning.calculator](
-                    screen, warning, eligibility, missing_dependencies
+                    warning_calculator = warning_calculators[warning.calculator](
+                        screen, warning, eligibility, missing_dependencies
+                    )
+
+                    if warning_calculator.calc():
+                        warnings.append(WarningMessageSerializer(warning).data)
+
+            if not skip and program.active:
+                legal_status = [status.status for status in program.legal_status_required.all()]
+                program_snapshots.append(
+                    ProgramEligibilitySnapshot(
+                        eligibility_snapshot=snapshot,
+                        name=program.name.text,
+                        name_abbreviated=program.name_abbreviated,
+                        value_type=program.value_type,
+                        estimated_value=eligibility.value,
+                        estimated_delivery_time=program.estimated_delivery_time.text,
+                        estimated_application_time=program.estimated_application_time.text,
+                        eligible=eligibility.eligible,
+                        failed_tests=json.dumps(eligibility.fail_messages),
+                        passed_tests=json.dumps(eligibility.pass_messages),
+                        new=new,
+                    )
                 )
+                program_translations = GetProgramTranslation(screen, program, missing_dependencies)
 
-                if warning_calculator.calc():
-                    warnings.append(WarningMessageSerializer(warning).data)
+                member_data = []
+                for member_eligibility in eligibility.eligible_members:
+                    member_data.append(
+                        {
+                            "frontend_id": str(member_eligibility.member.frontend_id),
+                            "eligible": member_eligibility.eligible,
+                            "value": member_eligibility.value,
+                            "already_has": member_eligibility.member.has_insurance(program.name_abbreviated),
+                        }
+                    )
 
-        if not skip and program.active:
-            legal_status = [status.status for status in program.legal_status_required.all()]
-            program_snapshots.append(
-                ProgramEligibilitySnapshot(
-                    eligibility_snapshot=snapshot,
-                    name=program.name.text,
-                    name_abbreviated=program.name_abbreviated,
-                    value_type=program.value_type,
-                    estimated_value=eligibility.value,
-                    estimated_delivery_time=program.estimated_delivery_time.text,
-                    estimated_application_time=program.estimated_application_time.text,
-                    eligible=eligibility.eligible,
-                    failed_tests=json.dumps(eligibility.fail_messages),
-                    passed_tests=json.dumps(eligibility.pass_messages),
-                    new=new,
-                )
-            )
-            program_translations = GetProgramTranslation(screen, program, missing_dependencies)
-
-            member_data = []
-            for member_eligibility in eligibility.eligible_members:
-                member_data.append(
+                data.append(
                     {
-                        "frontend_id": str(member_eligibility.member.frontend_id),
-                        "eligible": member_eligibility.eligible,
-                        "value": member_eligibility.value,
-                        "already_has": member_eligibility.member.has_insurance(program.name_abbreviated),
+                        "program_id": program.id,
+                        "name": program_translations.get_translation("name"),
+                        "name_abbreviated": program.name_abbreviated,
+                        "external_name": program.external_name,
+                        "estimated_value": eligibility.value,
+                        "household_value": eligibility.household_value,
+                        "estimated_delivery_time": program_translations.get_translation("estimated_delivery_time"),
+                        "estimated_application_time": program_translations.get_translation(
+                            "estimated_application_time"
+                        ),
+                        "description_short": program_translations.get_translation("description_short"),
+                        "short_name": program.name_abbreviated,
+                        "description": program_translations.get_translation("description"),
+                        "value_type": program.value_type,
+                        "learn_more_link": program_translations.get_translation("learn_more_link"),
+                        "apply_button_link": program_translations.get_translation("apply_button_link"),
+                        "apply_button_description": program_translations.get_translation("apply_button_description"),
+                        "legal_status_required": legal_status,
+                        "estimated_value_override": program_translations.get_translation("estimated_value"),
+                        "eligible": eligibility.eligible,
+                        "members": member_data,
+                        "failed_tests": eligibility.fail_messages,
+                        "passed_tests": eligibility.pass_messages,
+                        "navigators": [],  # populated in second pass once program_eligibility is complete
+                        "already_has": screen.has_benefit(program.name_abbreviated),
+                        "new": new,
+                        "low_confidence": program.low_confidence,
+                        "documents": [serialized_document(document) for document in program.documents.all()],
+                        "warning_messages": warnings,
+                        "required_programs": [p.id for p in program.required_programs.all()],
+                        "excludes_programs": [p.id for p in program.excludes_programs.all()],
+                        "value_format": program.value_format,
                     }
                 )
 
-            data.append(
-                {
-                    "program_id": program.id,
-                    "name": program_translations.get_translation("name"),
-                    "name_abbreviated": program.name_abbreviated,
-                    "external_name": program.external_name,
-                    "estimated_value": eligibility.value,
-                    "household_value": eligibility.household_value,
-                    "estimated_delivery_time": program_translations.get_translation("estimated_delivery_time"),
-                    "estimated_application_time": program_translations.get_translation("estimated_application_time"),
-                    "description_short": program_translations.get_translation("description_short"),
-                    "short_name": program.name_abbreviated,
-                    "description": program_translations.get_translation("description"),
-                    "value_type": program.value_type,
-                    "learn_more_link": program_translations.get_translation("learn_more_link"),
-                    "apply_button_link": program_translations.get_translation("apply_button_link"),
-                    "apply_button_description": program_translations.get_translation("apply_button_description"),
-                    "legal_status_required": legal_status,
-                    "estimated_value_override": program_translations.get_translation("estimated_value"),
-                    "eligible": eligibility.eligible,
-                    "members": member_data,
-                    "failed_tests": eligibility.fail_messages,
-                    "passed_tests": eligibility.pass_messages,
-                    "navigators": [],  # populated in second pass once program_eligibility is complete
-                    "already_has": screen.has_benefit(program.name_abbreviated),
-                    "new": new,
-                    "low_confidence": program.low_confidence,
-                    "documents": [serialized_document(document) for document in program.documents.all()],
-                    "warning_messages": warnings,
-                    "required_programs": [p.id for p in program.required_programs.all()],
-                    "excludes_programs": [p.id for p in program.excludes_programs.all()],
-                    "value_format": program.value_format,
-                }
-            )
-
-            if eligibility.eligible:
-                eligible_program_data.append((program, len(data) - 1))
+                if eligibility.eligible:
+                    eligible_program_data.append((program, len(data) - 1))
+        except Exception as e:
+            del program_snapshots[snapshots_len:]
+            del data[data_len:]
+            del eligible_program_data[eligible_len:]
+            # program_eligibility keeps its entry on purpose: the eligibility value was
+            # computed correctly and later programs may depend on it. Only the rendering
+            # of this program failed.
+            report_program_failure(program, e, "presentation")
+            missing_programs = True
+            continue
 
     update_navigators(eligible_program_data, program_eligibility, data, screen.county, referrer)
 
@@ -757,33 +806,54 @@ def urgent_need_results(screen: Screen, data):
 
     eligible_urgent_needs = []
     for need in urgent_need_resources:
-        eligible = True
+        # Urgent-need functions run the same eligibility machinery as the programs above
+        # and reach the same integrations — IlRentAsst calls the HUD client with no
+        # handler of its own — so an outage or a malformed income row raising here took
+        # the whole results response down with it. Skip the one need instead.
+        try:
+            eligible = True
 
-        calculators = [urgent_need_functions[f.name] for f in need.functions.all()]
+            calculators = [urgent_need_functions[f.name] for f in need.functions.all()]
 
-        if len(calculators) == 0:
-            calculators = [UrgentNeedFunction]
+            if len(calculators) == 0:
+                calculators = [UrgentNeedFunction]
 
-        for Calculator in calculators:
-            calculator = Calculator(screen, need, missing_dependencies, data)
+            for Calculator in calculators:
+                calculator = Calculator(screen, need, missing_dependencies, data)
 
-            if not calculator.calc():
-                eligible = False
-        if eligible:
-            phone_number = str(need.phone_number) if need.phone_number else None
-            need_data = {
-                "name": default_message(need.name),
-                "description": default_message(need.description),
-                "link": default_message(need.link),
-                "category_type": default_message(need.category_type.name),
-                "icon": need.category_type.icon_name,
-                "warning": default_message(need.warning),
-                "phone_number": phone_number,
-                "notification_message": (
-                    default_message(need.notification_message) if need.notification_message else None
-                ),
+                if not calculator.calc():
+                    eligible = False
+            if eligible:
+                phone_number = str(need.phone_number) if need.phone_number else None
+                need_data = {
+                    "name": default_message(need.name),
+                    "description": default_message(need.description),
+                    "link": default_message(need.link),
+                    "category_type": default_message(need.category_type.name),
+                    "icon": need.category_type.icon_name,
+                    "warning": default_message(need.warning),
+                    "phone_number": phone_number,
+                    "notification_message": (
+                        default_message(need.notification_message) if need.notification_message else None
+                    ),
+                }
+                eligible_urgent_needs.append(need_data)
+        except DependencyError:
+            # Expected: unanswered screen data, or a household outside an external table.
+            continue
+        except Exception as e:
+            context = {
+                "urgent_need": {"id": need.id, "name": default_message(need.name)},
+                "screen": {"id": screen.id, "white_label": screen.white_label.code},
             }
-            eligible_urgent_needs.append(need_data)
+            capture_exception(e, level="error", contexts=context)
+            capture_message(
+                "Failed to calculate an urgent need; it was skipped for this screen.",
+                level="error",
+                contexts=context,
+                fingerprint=["urgent-need-failure", str(need.id)],
+            )
+            continue
 
     return eligible_urgent_needs
 


### PR DESCRIPTION
## Context & Motivation

`missing_programs` is the only signal the results response carries that a screen's results are incomplete, and it was set for exactly two reasons: a custom calculator raising `DependencyError`, or a PolicyEngine program absent from the PE result. That left three degradations completely silent — no Sentry event, no flag, a response that looked complete and confident:

1. **HUD API failure.** All seven HUD-backed calculators (`Cha`, `TxHcv`, `MaCpp`, `Homebridge`, `MiddleIncomeRental`, `SeattleFreshBucks`, `IlRentAsst`) catch `HudIncomeClientError` and degrade to `e.condition(False, messages.income_limit_unknown())`. The user is shown a definite "not eligible" based on a number we never received. Nothing raised, nothing was skipped, so nothing set the flag. The `HUD = "hud"` constant existed but was never recorded outside tests.
2. **Calculator crash on non-null malformed data.** `missing_fields()` only tested `is None`, so a present-but-unusable value cleared the dependency gate. An `IncomeStream.frequency` of `""` or `"fortnightly"` matches no branch in `yearly()` → `UnboundLocalError` → escaped the calculator loop and **500'd the entire request**, losing every other program's results.
3. **Malformed data that computes a wrong answer.** A blank `IncomeStream.type` passed the gate, then failed every match in `calc_gross_income` *except* the unearned catch-all (`type not in earned_income_types` is true for `""`) — quietly counted as unearned income. Wrong totals, no error.

There was also no logging of any kind in `eligibility_results()`, so a suppressed or mis-computed program was undiagnosable after the fact.

- Fixes [MFB-1424](https://linear.app/myfriendben/issue/MFB-1424/make-degraded-eligibility-runs-visible-sentry-missing-programs-for-hud)

## Changes Made

### Reporting

- **Shared "loud + flag" helper.** `report_external_api_failure(service_id, message, exception=None, context=None)` in `integrations/external_api_status.py`: one Sentry error for the exception, one for the context, then the request-scoped record. PolicyEngine and HUD both go through it, so they provably match rather than approximately match.
- **Reports at most once per service per tracking context.** One screen makes several independent calls to the same integration — five HUD lookups across the MA calculators, one PolicyEngine call per method — each raising its own exception. Without this an outage is a double-digit event count per screen that says nothing the first event didn't. `batch_snapshots` now wraps each screen in `track_external_api_failures()` so the dedupe applies there too; a nightly batch over every screen was the biggest amplifier.
- **Static messages, structured context, explicit fingerprints.** Sentry groups `capture_message` by its text, so interpolating a screen id, program name, or upstream response body creates one issue per screen. Every report site now passes a static message with the variable parts in `contexts`, and a `fingerprint` chosen for the grouping we actually want:
  - malformed data → fingerprint on the affected **field names** (one issue per drift pattern)
  - program crash → fingerprint on **(program, stage)** (one issue per broken program)
  - external API → fingerprint on **service id**
  - `capture_exception` keeps Sentry's own stack-trace grouping, so two different bugs in the same program stay separate issues.
- **HUD response bodies truncated** to 500 chars before they reach either the exception message or the Sentry context — HUD serves HTML error pages.

### HUD client

- **Reporting at the public-method boundary** via a `_report_hud_failure` decorator on the six `get_screen_*` / `approximate_*` methods — covers transport errors, unrecognized county, and a 200 response missing the needed field. Reports once per exception instance, since `approximate_screen_mtsp_ami` calls `get_screen_mtsp_ami` and both are decorated.
- **New `HudIncomeClientInputError(HudIncomeClientError)`** for out-of-range arguments (household size outside 1–8, bedrooms outside 0–4, AMI % outside the MTSP range). These are ordinary screener data, not outages — without the split, every 9-person household would fire a Sentry error and warn the user an external service failed.
- **Out-of-range input is translated to `DependencyError`** at the decorator, so it never reaches the calculators' `except HudIncomeClientError` handlers. Previously a 9-person household was answered with a definite "not eligible (income limit unknown)" across all seven HUD-backed programs — a "No" derived from a number we never had, with no flag and no event. Now the program is **omitted** and `missing_programs` is set, quietly (nothing external failed). Doing it at the one decorator rather than in seven calculators means forgetting it can't silently reintroduce the old behavior.
- **Removed the five `capture_exception` calls inside `_api_request`** and added `from e` chaining, so the boundary event carries the full cause chain in one event instead of two.

### Dependency gate

- **`Dependencies.update()` is overridden** to carry malformed-value detail along, rather than offering a separate `merge()` — the obvious method is also the correct one, so nested detail can't be dropped by reaching for `update()` out of habit. The three call sites in `screener/models.py` are unchanged from before this PR.
- **`Dependencies.malformed` holds `MalformedValue(field, value, detail)`** rather than a pre-formatted string, so the reporter can group by field name instead of by a message containing the value.
- **`missing_fields()` now validates values, not just nullness**: blank strings, frequencies `monthly()`/`yearly()` cannot convert (per-model supported sets — `Expense` has no hourly branch), and hourly income with null `hours_worked` (previously `TypeError` in `_hour_to_month`). `Expense.missing_fields()` now emits `expense_frequency`, which it never did; `TxFpp` declares it.

### Eligibility loop

- **Catch-all `except Exception` after `except DependencyError`**: one crashing program is skipped and reported instead of 500ing the response. `DependencyError` stays silent — ordinary partial-screen input is not a defect.
- **The guard covers the presentation phase too.** Warning calculators, translation lookups and snapshot construction read the same screen data the eligibility calculators do; a `fortnightly` income row crashing `calc_gross_income()` inside a warning calculator 500'd the response exactly as hard. The crashed program's partial output is rolled back so no half-rendered entry survives; `program_eligibility` keeps its entry, since the eligibility value itself was computed correctly and later programs may depend on it. `raise Exception(f"{warning.calculator} is not a valid calculator name")` is now a skip rather than a 500.
- **`urgent_need_results` got the same treatment** — it had no protection at all, and `IlRentAsst` calls the HUD client with no handler of its own.
- **New `ProgramConfigurationError`** (`programs/util.py`) for a program missing configuration it can't be calculated without. `TxHcv._year_period` / `WaHcv._get_year_period` raised `HudIncomeClientError("Program year not configured")`, which their own handler caught and buried as a permanent, silent "income limit unknown" — a misconfiguration that could sit in production forever. Both now raise `ProgramConfigurationError` and re-raise it (and `DependencyError`) ahead of their blanket `except Exception`, so it reaches the reporting handler.
- **`missing_programs` wiring**: set from any recorded external-API failure, and from malformed data regardless of whether a calculator declares the affected field (a program that read it without declaring it computed from data we know is bad — exactly the case that used to pass silently).

## Testing

- Migrations to run: none
- Configuration updates needed: none
- Environment variables/settings to add: none (`HUD_API_TOKEN` and the Sentry DSN are already configured; `capture_message` is a no-op without a DSN, so local runs and tests are unaffected)
- `python manage.py test screener integrations programs --keepdb` → **2456 tests, OK (17 skipped)**. The `WaHcv`/`TxHcv` tracebacks in the output are those calculators' own `logger.exception` from tests that deliberately inject failures — pre-existing noise, not regressions.
- `black --check` clean.
- New/updated coverage:
  - `programs/test_util.py` (new) — `Dependencies.update()` carries `malformed`, accumulates across sources, accepts varargs, tolerates plain sets, doesn't mutate the source.
  - `integrations/tests.py` — caller context attached to both events; once per service per run; dedupe is per-service not global; dedupe resets between runs.
  - `integrations/clients/hud_income_limits/tests/test_client.py` — five failing lookups in one run produce 2 events not 10; static message with method/detail in context; oversized upstream body truncated; out-of-range input raises `DependencyError` with the cause chain preserved.
  - `screener/tests/test_missing_programs.py` — broken warning skips only that program / doesn't lose the others / rolls back partial output; crashing urgent need reported and skipped, `DependencyError` there stays quiet; `ProgramConfigurationError` reported loudly and skipped; 9-person household omitted + flagged + silent, 8-person household still reaches HUD; same corruption on two screens produces the same fingerprint.
  - `screener/tests/test_missing_fields.py` — value validation.
  - `programs/programs/{tx,wa}/hcv/tests/` — null program year now raises instead of degrading silently (these previously *pinned* the silent behavior); Tx gained the null-year coverage it lacked.
- To see the HUD path end to end, unset `HUD_API_TOKEN` and request results for a screen in a HUD-backed white label (MA/TX/WA/IL): the program still returns "not eligible (income limit unknown)", the response now carries `missing_programs: true` and `external_api_failures: ["hud"]`, and Sentry receives two error events.

## Deployment

- Post-deployment scripts needed: none
- Production config updates: none
- Admin updates needed: none
- **Product-visible change:** households of 9+ no longer see the seven HUD-backed programs as "not eligible" — those programs are omitted, and the response carries `missing_programs: true`. Showing a definite "No" derived from a limit HUD does not publish was the worse of the two options, but this is what the user sees, so it's worth a product nod.
- Notify team/users of: **expect a Sentry volume increase on first deploy.** These paths were silent in production, so the initial events are pre-existing conditions becoming visible, not new breakage. Volume is bounded by the per-service-per-run dedupe and the fingerprinting above, so an outage should read as a handful of issues rather than one per screen. Worth reviewing the first batch: a steady stream of malformed-screen-data events would point at a serializer contract drift worth fixing at the source, and a steady stream of HUD events would point at either an outage or a county-name mismatch (MA stores city names in `county`, which is why those calculators pass `county_override`).

## Notes for Reviewers

- **Worth focusing on:** the catch-all `except Exception` in `eligibility_results`, now in two places (eligibility and presentation). It's the highest-leverage change (any calculator bug stops being fatal to the whole response) and the highest-blast-radius one — it converts previously-loud 500s into logged skips. `SystemExit` / `KeyboardInterrupt` are `BaseException` and still propagate, matching the existing PE handling. I confirmed the only `transaction.atomic()` block in `views.py` is in the current-benefits toggle view, unrelated to `eligibility_results`, so there's no broken-transaction risk from swallowing a DB error mid-loop.
- **Layering compromise worth a second opinion:** `integrations/clients/hud_income_limits/client.py` imports `DependencyError` from `programs/`. The alternative is repeating the input-error translation in all seven HUD-backed calculators, where forgetting it silently reintroduces an unjustified "not eligible". The client already imports `screener.models.Screen`.

### On the 1–8 household size limit

Verified against the live API rather than assumed. The household size is never sent to HUD — both calls fetch a whole-county payload and the size only selects a field out of it. For MA/Middlesex 2025:

```
il/data     extremely_low -> il30_p1 … il30_p8
            very_low      -> il50_p1 … il50_p8
            low           -> il80_p1 … il80_p8
mtspil/data 50/60/80percent -> il{n}_p1 … il{n}_p8
```

Nothing past `_p8` in either endpoint, so `_validate_household_size` guards a real data boundary; it just fails before the network call instead of after. It's also load-bearing for classification now — without it the code falls through to the *generic* `HudIncomeClientError`, which the decorator would report as a HUD outage. The rest of the calculation is fine for 9+ households: `BEDROOM_MAP` already caps at 4 bedrooms, so payment standards still resolve.

A follow-up could extrapolate 9+ using HUD's published 8%-of-the-4-person-limit-per-additional-person rule. Checked against live p5–p8 across MA/Middlesex, IL/Cook, TX/Harris and WA/King, that rule reproduces the **50% and 80%** limits to within $50 (a rounding-convention difference) — but it is badly wrong for **30% ELI** (TX/Harris p8: 54,150 actual vs 42,450 predicted), because the Extremely Low Income limit is floored at the federal poverty guideline, which scales on its own schedule. No calculator here requests 30%, but any such follow-up must be scoped to the 50%/80% paths.

### Known limitations

- **A HUD failure in the urgent-needs path doesn't set `missing_programs`.** `all_results` captures `missing_programs` from `eligibility_results` before `urgent_need_results` runs, so a failure recorded only during urgent needs (`IlRentAsst`) populates `external_api_failures` but not the flag. Left for a separate ticket: the frontend has no way to act on it today, so backend and frontend should land together.
- Reporting is Sentry-only, so these paths stay invisible locally and in CI (`capture_*` is a no-op without a DSN). Deliberate for now.
- `IncomeStream.type` is **not** validated against the white label's configured `income_options_by_category`. That option set lives in the `Configuration` table per white label and would cost a lookup on the hot eligibility path; blank-string detection covers the realistic corruption without the coupling. A non-blank but bogus type (`"wagez"`) still slips through and is counted as unearned income.
- `SUPPORTED_FREQUENCIES` duplicates the `if/elif` chains in `monthly()`/`yearly()`. It matches `configuration/white_labels/base.py` and the validation schema today, and no white label overrides `frequency_options` — but that config is DB-backed and the frontend renders keys it doesn't know about, so a new option added via admin would land as a per-screen Sentry error rather than a supported frequency.
- `expense_frequency` is now emitted but only `TxFpp` declares it. `DenverPropertyTaxRelief` correctly doesn't need it (it only calls `has_expense`, never converting an amount). Any future calculator calling `calc_expenses` should declare it; the loop catch-all covers the gap in the meantime.
- `missing_programs` remains a single global boolean — it says *something* is incomplete, not which programs. Per-program reporting would need a response shape change.

### Future considerations

- The frontend reads `missing_programs` in exactly one place (`Referrer.tsx`), gated on `immutableReferrer === 'lgs'`, and renders tax-form-specific copy. For every other referrer the flag is fetched and never used. Now that the backend sets it accurately, surfacing it the way `external_api_failures` already is (a "some results may be unavailable" banner for all users) is the natural follow-up — and the natural home for the urgent-needs gap above.
- The malformed-data validation could move up into the serializer, rejecting bad values on write instead of tolerating them on read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
