### PR TITLE
MFB-1382: capture SNAP + WIC as income

### DIFF
--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -213,9 +213,6 @@ class ConfigurationData:
             },
             "unemployment": {"_label": "incomeOptions.unemployment", "_default_message": "Unemployment Benefits"},
             "cashAssistance": {"_label": "incomeOptions.cashAssistance", "_default_message": "Cash Assistance Grant"},
-            # SNAP and WIC are collected here so the reported dollar amount is available to
-            # send to PolicyEngine as the snap/wic input. They are NOT countable income —
-            # see NON_COUNTABLE_INCOME_TYPES in screener/models.py.
             "snap": {
                 "_label": "incomeOptions.snap",
                 "_default_message": "Supplemental Nutrition Assistance Program (SNAP)",

--- a/configuration/white_labels/base.py
+++ b/configuration/white_labels/base.py
@@ -213,6 +213,17 @@ class ConfigurationData:
             },
             "unemployment": {"_label": "incomeOptions.unemployment", "_default_message": "Unemployment Benefits"},
             "cashAssistance": {"_label": "incomeOptions.cashAssistance", "_default_message": "Cash Assistance Grant"},
+            # SNAP and WIC are collected here so the reported dollar amount is available to
+            # send to PolicyEngine as the snap/wic input. They are NOT countable income —
+            # see NON_COUNTABLE_INCOME_TYPES in screener/models.py.
+            "snap": {
+                "_label": "incomeOptions.snap",
+                "_default_message": "Supplemental Nutrition Assistance Program (SNAP)",
+            },
+            "wic": {
+                "_label": "incomeOptions.wic",
+                "_default_message": "Women, Infants, and Children (WIC)",
+            },
             "workersComp": {"_label": "incomeOptions.workersComp", "_default_message": "Worker's Compensation"},
             "veteran": {"_label": "incomeOptions.veteran", "_default_message": "Veteran's Pension or Benefits"},
         },

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -501,6 +501,89 @@ class TestSocialSecurityIncomeDependency(TestCase):
         self.assertEqual(dep.value(), 0)
 
 
+class TestSsiDependency(TestCase):
+    """Tests for the Ssi dependency — dual-role as PE input (the reported SSI amount) and
+    output (PE's computed SSI).
+
+    A reported `sSI` income stream is what reaches PolicyEngine as the person-level `ssi`
+    input. The value is annual; pe_input() writes it under the program's period
+    (`{"ssi": {"<year>": amount}}`) and PolicyEngine spreads an annual figure across the
+    months itself. With nothing reported the input is `None` and PolicyEngine computes SSI.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=2,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+
+    def test_field_name(self):
+        dep = member.Ssi(self.screen, self.head, {})
+        self.assertEqual(dep.field, "ssi")
+
+    def test_value_returns_reported_annual_amount(self):
+        """A reported monthly sSI amount is sent as the annual figure."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSI", amount=943, frequency="monthly"
+        )
+
+        dep = member.Ssi(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 11316)  # $943/month * 12
+
+    def test_value_returns_reported_amount_for_yearly_frequency(self):
+        """A yearly-frequency stream passes through unscaled."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSI", amount=11316, frequency="yearly"
+        )
+
+        dep = member.Ssi(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 11316)
+
+    def test_value_sums_multiple_reported_streams(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSI", amount=500, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSI", amount=100, frequency="monthly"
+        )
+
+        dep = member.Ssi(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 7200)  # ($500 + $100) * 12
+
+    def test_value_returns_none_without_reported_ssi(self):
+        """No reported amount → None, so PolicyEngine computes SSI itself."""
+        dep = member.Ssi(self.screen, self.head, {})
+        self.assertIsNone(dep.value())
+
+    def test_value_is_member_scoped(self):
+        """The amount is per person: another member's SSI must not leak into this one's
+        input, or PE would attribute one person's benefit to another."""
+        spouse = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=65)
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=spouse, type="sSI", amount=943, frequency="monthly"
+        )
+
+        self.assertIsNone(member.Ssi(self.screen, self.head, {}).value())
+        self.assertEqual(member.Ssi(self.screen, spouse, {}).value(), 11316)
+
+    def test_value_ignores_other_income_types(self):
+        """Only sSI counts — SSDI and wages must not inflate the SSI input."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSDisability", amount=1500, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=2000, frequency="monthly"
+        )
+
+        dep = member.Ssi(self.screen, self.head, {})
+        self.assertIsNone(dep.value())
+
+
 class TestPregnancyDependency(TestCase):
     """Tests for PregnancyDependency class used by WIC calculators."""
 

--- a/screener/models.py
+++ b/screener/models.py
@@ -37,6 +37,15 @@ class WhiteLabel(models.Model):
         return self._get_flag_value(key)
 
 
+# Income types collected so the reported dollar amount is available to send to PolicyEngine
+# as that benefit's own input (the `snap`/`wic` fields), but which are NOT countable income:
+# federal rules exclude SNAP and WIC from income tests, and PolicyEngine computes both
+# separately, so folding them into an aggregate would double-count. calc_gross_income()
+# therefore skips them for the "all"/"earned"/"unearned" buckets and returns them only when
+# named explicitly, e.g. calc_gross_income("yearly", ["snap"]).
+NON_COUNTABLE_INCOME_TYPES = frozenset({"snap", "wic"})
+
+
 # The screen is the top most container for all information collected in the
 # app and is synonymous with a household model. In addition to general
 # application fields like submission_date, it also contains non-individual
@@ -472,8 +481,14 @@ class HouseholdMember(models.Model):
             if income_stream.type in exclude:
                 continue
 
-            include_all = "all" in types
             specific_match = income_stream.type in types
+
+            # Non-countable benefit income (SNAP/WIC) is only ever returned when the caller
+            # names the type; it never lands in an "all"/"earned"/"unearned" aggregate.
+            if income_stream.type in NON_COUNTABLE_INCOME_TYPES and not specific_match:
+                continue
+
+            include_all = "all" in types
             earned_income_match = "earned" in types and income_stream.type in earned_income_types
             unearned_income_match = "unearned" in types and income_stream.type not in earned_income_types
             if include_all or earned_income_match or unearned_income_match or specific_match:

--- a/screener/tests/test_models.py
+++ b/screener/tests/test_models.py
@@ -100,6 +100,70 @@ class TestScreen(TestCase):
         result = self.screen.calc_gross_income("yearly", ["earned"])
         self.assertEqual(result, 30000)  # ($2000 + $500) * 12
 
+    # Non-countable benefit income (SNAP/WIC): captured as income streams so the reported
+    # amount can be sent to PolicyEngine, but never folded into an income aggregate.
+
+    def test_calc_gross_income_excludes_snap_and_wic_from_all(self):
+        """SNAP/WIC amounts are collected as income streams but are not countable income,
+        so an "all" aggregate must not see them."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=2000, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="snap", amount=200, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wic", amount=50, frequency="monthly"
+        )
+
+        result = self.screen.calc_gross_income("yearly", ["all"])
+        self.assertEqual(result, 24000)  # wages only
+
+    def test_calc_gross_income_excludes_snap_and_wic_from_unearned(self):
+        """They are also kept out of the "unearned" bucket, which would otherwise match any
+        type that isn't wages/selfEmployment."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="alimony", amount=500, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="snap", amount=200, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wic", amount=50, frequency="monthly"
+        )
+
+        result = self.screen.calc_gross_income("yearly", ["unearned"])
+        self.assertEqual(result, 6000)  # alimony only
+
+    def test_calc_gross_income_returns_snap_when_named_explicitly(self):
+        """Naming the type is how a reported amount is read back: a caller that wants the
+        SNAP figure has to ask for it explicitly."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="snap", amount=200, frequency="monthly"
+        )
+
+        self.assertEqual(self.screen.calc_gross_income("yearly", ["snap"]), 2400)
+        self.assertEqual(self.screen.calc_gross_income("monthly", ["snap"]), 200)
+
+    def test_calc_gross_income_returns_wic_when_named_explicitly(self):
+        """Same for `wic`."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wic", amount=50, frequency="monthly"
+        )
+
+        self.assertEqual(self.screen.calc_gross_income("yearly", ["wic"]), 600)
+
+    def test_calc_gross_income_snap_excluded_alongside_named_wic(self):
+        """A named non-countable type doesn't drag the other one in."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="snap", amount=200, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wic", amount=50, frequency="monthly"
+        )
+
+        self.assertEqual(self.screen.calc_gross_income("yearly", ["wic"]), 600)
+
     # Tests for Screen.calc_expenses() method
 
     def test_calc_expenses_single_type_yearly(self):


### PR DESCRIPTION
## Context & Motivation

- Linear: **MFB-1382** — Income capture: add SNAP + WIC as income options; verify SSI/TANF amount capture
- Blocks: **MFB-1312** (actual-receipt vs. would-be-eligibility contract for SSI/TANF/SNAP/WIC)
- **Sequence: this PR → #1674 (MFB-1571) → MFB-1312.** #1674 carries the `has_benefit()` cleanup that makes reported SNAP/WIC receipt readable at all, which MFB-1312's take-up contract depends on — without it every household reads as a non-recipient.

MFB-1312 adopts PolicyEngine's actual-receipt contract, which requires sending the **reported dollar amount** of SSI, TANF, SNAP and WIC as that program's PE input. Only two of the four had usable amount capture: SSI via the `sSI` income option and TANF via `cashAssistance`. SNAP and WIC had none. This PR adds the two missing income options and verifies the SSI side.

Scope is deliberately just the capture. Nothing reads the new amounts yet — they're stored on the screen and available as `screen.calc_gross_income("yearly", ["snap"])` for MFB-1312 to send to PolicyEngine. **No program's eligibility or benefit value changes.**

## Changes Made

One commit.

- **Income options.** `snap` and `wic` added to `income_options_by_category["government"]` in `configuration/white_labels/base.py`, after `cashAssistance`. All 8 white labels spread the base `"government"` dict, so all inherit them. No `benefits-calculator` change is needed — the income step is fully config-driven (`useHouseholdMemberConfig.tsx` reads `income_options_by_category` straight from the API).
- **Not countable income.** `NON_COUNTABLE_INCOME_TYPES = {"snap", "wic"}` in `screener/models.py`. Without it these amounts would count as household income at ~114 `calc_gross_income(..., ["all"] / ["unearned"])` call sites — including `snap_gross_income` / `snap_unearned_income` (SNAP counting its own benefit as income), `irs_gross_income`, Pell Grant, and the CO/IL/MA/NC TANF countable-income inputs. They're skipped for the `"all"` / `"earned"` / `"unearned"` buckets and returned only when a caller names the type, which is how MFB-1312 will read the amount.
- **`Ssi` dependency tests** (ticket scope 3). The dependency had **zero** tests. Added: annual figure from a reported monthly amount, yearly-frequency pass-through, multiple streams summed, `None` when unreported, other income types ignored, and member-scoping — `ssi` is a person-level PE input, so leaking a spouse's amount would attribute one person's benefit to another. No behavior change; this pins what already works.
- **TANF needed nothing.** `Tanf.value()` already sends the reported `cashAssistance` amount, three tests already cover it, and `base_program="tanf"` is set on all 8 variants. Confirmed against the database.

### Moved out of this PR

An earlier revision of this branch also fixed a class of dead `has_benefit()` reads found while verifying the SNAP receipt path — `Screen.has_benefit()` is an exact `name_abbreviated` match, and no white label ships a program literally named `snap` / `tanf` / `section_8`, so those reads were always False across ~14 calculators and the PolicyEngine `Snap` input. That work, plus the `wa_snap` `base_program` backfill migration, the income-derived receipt in `_derived_current_benefit_names()`, and a two-pass rewrite of the PolicyEngine payload builder, now lives on **#1674 (MFB-1571)**, which was already stacked on this branch and carries all of it. It changes live eligibility results (NC SUN Bucks, WA WIC, WA Head Start, and PE categorical eligibility in the SNAP states), which is why it doesn't belong in an income-capture PR.

That pairing is deliberate rather than convenient: MFB-1571's `ReceivesSnapDependency` resolves receipt through `has_base_benefit("snap")`, so it only works with the cleanup alongside it. A snapshot of the pre-split branch is preserved at `david/has-benefit-cleanup` if anything needs recovering.

## Testing

- **Migrations to run:** none.
- **Configuration updates needed:** `python manage.py add_config --all` — required, otherwise the two new income options never reach the frontend. Note this rewrites every `Configuration` row from code, so any config edited through the Django admin is reset to the checked-in values.
- **Environment variables/settings to add:** none.
- **Translation rows:** the two new `incomeOptions.*` labels have **no `Translation` row in any environment**:
  ```bash
  cat > /tmp/mfb1382_labels.json <<'JSON'
  {
    "incomeOptions.snap": "Supplemental Nutrition Assistance Program (SNAP)",
    "incomeOptions.wic": "Women, Infants, and Children (WIC)"
  }
  JSON
  python manage.py add_translations /tmp/mfb1382_labels.json
  ```
  Nothing hard-breaks without this: the frontend renders `<FormattedMessage id={_label} defaultMessage={_default_message} />` (`configHook.tsx`), so both options display their English default text. The cost of skipping it is that the other 17 languages silently serve English. `add_translations` auto-translates into all of them. **Restart the dev server afterwards** — `TranslationCache` is per-process with a 24h expiry (`translations/models.py`), so a running server keeps serving its cached dict.
- **Automated tests:** `python manage.py test screener programs configuration` → **2474 pass, 0 failures** locally; CI runs the full suite. New coverage:
  - `TestScreen.test_calc_gross_income_*` (`screener/tests/test_models.py`) — SNAP/WIC excluded from `"all"` and `"unearned"`, returned when named, and one named type doesn't drag the other in.
  - `TestSsiDependency` (`dependencies/tests/test_member.py`) — the six cases above.
- **Manual testing steps:**
  1. Screener → income step → a household member with income: "Government Benefits" now lists SNAP and WIC. Enter an amount for each and finish the screen.
  2. Confirm the reported amounts do **not** inflate income-tested results — a household whose only "income" is SNAP/WIC should still read as $0 income (`screen.calc_gross_income("yearly", ["all"]) == 0`), while `calc_gross_income("yearly", ["snap"])` returns the reported figure.
  3. Confirm no result changes: the same household with and without a SNAP/WIC amount should get an identical program list and identical values.

## Deployment

- **Post-deployment scripts needed:**
  1. `heroku run python manage.py add_config --all -a <app>` — this is what exposes the new income options.
  2. `heroku run python manage.py add_translations /tmp/... -a <app>` (or paste the map into `heroku run python manage.py shell`). Every environment needs it — the labels exist nowhere yet.
  3. **Restart the web dynos after step 2.** `add_translations` in a one-off dyno cannot invalidate the web dynos' `TranslationCache` (in-process, 24h expiry). On staging, restart *before* driving traffic at it — a cold 512 MB dyno rebuilding the translation cache under parallel load can hit R15 / SIGKILL.
- **Production config updates:** the two income options appear in **every** white label once `add_config --all` runs. If any white label should not collect SNAP/WIC as income, add a per-white-label override before deploying to prod. Also note `add_config` overwrites admin-side edits to `Configuration` rows.
- **Admin updates needed:** none.
- **Notify team/users of:** nothing user-visible beyond the two new dropdown options. No eligibility or benefit-value changes.
- **Rollback note:** reverting the code leaves the `Configuration` and `Translation` rows in place, which is harmless — the options simply stop being offered. Income streams already saved with `type="snap"` / `"wic"` stay in the database and would begin counting as income again on the next screen calculation, since `NON_COUNTABLE_INCOME_TYPES` goes away with the revert. Only relevant for screens submitted between deploy and revert.

## Notes for Reviewers

- **English copy is not signed off.** "Supplemental Nutrition Assistance Program (SNAP)" and "Women, Infants, and Children (WIC)" mirror the existing benefit-tile wording for recognition, but they're my proposal. No `Translation` rows exist yet in any environment, so a wording change is cheap — edit `_default_message` in `base.py` and the `add_translations` map, with nothing to re-translate.
- **The non-countable rule is the one thing to scrutinize.** It's a single early-`continue` in `HouseholdMember.calc_gross_income()`, but it applies to every income calculation in the codebase. The intended reading: a SNAP/WIC amount is returned *only* when a caller names that type, never via `"all"` / `"earned"` / `"unearned"`. Federal rules exclude both from income tests and PolicyEngine computes them separately, so including them would double-count.
- **Known limitation.** SNAP is loaded onto EBT monthly and WIC is a food package, so most users won't know a dollar amount. Expect low fill rates — fine here, since MFB-1312's contract has a "receiving X, amount unknown" state.
- **Follow-ups:**
  - MFB-1312 consumes these amounts. Two of its architecture anchors are stale and I've commented on that ticket: the SNAP receipt sentinel never fired, and `Ssi` is **not** in `SNAP_BASE_INPUTS` (only KS SNAP wires it, in `ks/pe/spm.py`), so 6 states still need it.
  - #1674 needs a rebase once this lands — it still contains this branch's pre-split commits, and the slim versions of `base.py` / `screener/models.py` / `test_models.py` / `test_member.py` will conflict.
  - The income-type reference tables in `team-claude-config/skills/{api-qa-execution,add-custom-program,discovery-review}/SKILL.md` don't list `snap`/`wic` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SNAP and WIC as available income options with localized labels and display messages.
  - SNAP and WIC can be viewed individually in household income details.

- **Bug Fixes**
  - SNAP and WIC are now excluded from total, earned, and unearned income calculations where appropriate.
  - Improved handling of reported SSI amounts, including annualized and recurring income values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->