### PR TITLE
Add MO National School Lunch Program (mo)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_nslp_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_nslp_initial_config.json
@@ -1,0 +1,66 @@
+{
+  "white_label": {"code": "mo"},
+  "program_category": {
+    "external_name": "mo_food",
+    "name": "Food and Nutrition",
+    "icon": "food"
+  },
+  "program": {
+    "name_abbreviated": "mo_nslp",
+    "year": "2026",
+    "base_program": "nslp",
+    "legal_status_required": ["citizen", "non_citizen", "refugee", "gc_5plus", "gc_5less", "otherWithWorkPermission"],
+    "name": "National School Lunch Program",
+    "description_short": "Free or reduced-price school meals for eligible Missouri students",
+    "description": "\n\nThe National School Lunch Program gives free or lower-cost meals to students at Missouri schools that take part.\n\nStudents from families with low incomes get free meals. Families with slightly higher incomes get lower-cost meals. Children get free meals right away if their family gets SNAP, FDPIR, or TANF benefits. Foster children, homeless children, runaway children, migrant children, and children in Head Start also get free meals right away.\n\nThe program is open to all students at schools that take part. Anyone who qualifies can get school meals, no matter their legal or immigration papers.\n\nTo apply, select Apply Now. Then find your school district and fill out the online form. If you cannot find your district or apply online, contact your child's school for help. You can apply at any time during the school year.",
+    "learn_more_link": "https://www.fna.usda.gov/nslp",
+    "apply_button_link": "https://www.myschoolapps.com/",
+    "apply_button_description": "",
+    "estimated_application_time": "5-15 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": null,
+    "value_type": "benefit",
+    "website_description": "Free or reduced-price school meals for eligible Missouri students",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "documents": [
+    {
+      "external_name": "mo_nslp_application",
+      "text": "Completed school meal application (if applying with a paper form from your child's school or school district)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_nslp_income",
+      "text": "Proof of household income for all members (ex: pay stubs, tax returns, employer letter)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_nslp_case_number",
+      "text": "Case number for SNAP, FDPIR, or TANF (if applicable — waives income verification)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_nslp_ssn",
+      "text": "Last four digits of the Social Security Number of the adult household member signing the application (or a statement that no SSN has been assigned)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "usda_national_hunger_hotline",
+      "name": "USDA National Hunger Hotline",
+      "email": "",
+      "description": "A federal hotline staffed to help callers with school meal applications and other food assistance programs. Live representatives are available Monday–Friday, 7am–10pm ET, with Spanish-language support. You can also text for automated help.",
+      "assistance_link": "https://www.fna.usda.gov/national-hunger-hotline",
+      "phone_number": "+18663486479",
+      "languages": ["English", "Spanish"]
+    }
+  ]
+}

--- a/programs/programs/mo/pe/__init__.py
+++ b/programs/programs/mo/pe/__init__.py
@@ -1,10 +1,16 @@
 import programs.programs.mo.pe.member as member
+import programs.programs.mo.pe.spm as spm
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
 
 mo_member_calculators = {
     "mo_wic": member.MoWic,
 }
 
+mo_spm_calculators = {
+    "mo_nslp": spm.MoNslp,
+}
+
 mo_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {
     **mo_member_calculators,
+    **mo_spm_calculators,
 }

--- a/programs/programs/mo/pe/spm.py
+++ b/programs/programs/mo/pe/spm.py
@@ -1,0 +1,33 @@
+import programs.programs.policyengine.calculators.dependencies as dependency
+from programs.programs.federal.pe.spm import SchoolLunch
+
+
+class MoNslp(SchoolLunch):
+    """
+    Missouri National School Lunch Program (NSLP) calculator.
+
+    Uses PolicyEngine's federal ``SchoolLunch`` calculator (pe_name
+    ``school_meal_net_subsidy``) as-is. NSLP is a federal program with two federal
+    income tiers — free at <=130% FPG, reduced-price at <=185% FPG — and no
+    Missouri-specific variance, so the federal eligibility and value logic applies
+    unchanged. Mirrors the ks_nslp / tx_nslp / il_nslp precedents.
+
+    ``MoStateCodeDependency`` is load-bearing, not boilerplate. PolicyEngine's school
+    meal tier branches on the state's universal-free-meals election, and
+    ``pe_input()`` never sends ``state_code`` on its own — it is only ever supplied by
+    an explicit StateCode dependency in a calculator's ``pe_inputs``. Omit it and PE
+    falls back to its own default state, which *does* have universal free meals:
+    verified live against PE ``current`` with a household of 2 (one 9-year-old) at
+    $90,000/yr — far above the 185% FPG reduced-price limit:
+
+        state_code=MO   -> school_meal_net_subsidy $0.00      school_meal_tier PAID
+        state_code omitted -> school_meal_net_subsidy $1130.96 school_meal_tier FREE
+
+    So without this input every Missouri household would be shown eligible for
+    free meals regardless of income. ``test_spm.py`` pins it for that reason.
+    """
+
+    pe_inputs = [
+        *SchoolLunch.pe_inputs,
+        dependency.household.MoStateCodeDependency,
+    ]

--- a/programs/programs/mo/pe/tests/test_spm.py
+++ b/programs/programs/mo/pe/tests/test_spm.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for the MO SPM-level PolicyEngine calculator ``MoNslp`` (mo_nslp).
+
+MoNslp is a straight passthrough to PolicyEngine's federal ``SchoolLunch`` calculator:
+eligibility and the benefit dollar value come from PE, so there is no MFB-side routing
+to unit-test. What *does* live on the MFB side is the ``pe_inputs`` wiring, and one
+input beyond the federal set is load-bearing:
+
+  - ``MoStateCodeDependency`` — PE's school meal tier branches on the state's
+    universal-free-meals election, and ``pe_input()`` never sends ``state_code`` on
+    its own. Without this input PE falls back to its default state, which *does* have
+    universal free meals, so every MO household would be scored FREE tier at any
+    income. Verified live against PE ``current``: a household of 2 (one 9-year-old) at
+    $90,000/yr returns $0 / PAID with ``state_code=MO`` but $1130.96 / FREE with the
+    state code omitted.
+
+These tests pin that wiring so a future refactor can't silently drop it.
+"""
+
+from django.test import TestCase
+
+from programs.programs.federal.pe.spm import SchoolLunch
+from programs.programs.mo.pe import mo_pe_calculators, mo_spm_calculators
+from programs.programs.mo.pe.spm import MoNslp
+from programs.programs.policyengine.calculators.registry import (
+    all_calculators,
+    all_spm_unit_calculators,
+)
+import programs.programs.policyengine.calculators.dependencies as dependency
+
+
+class TestMoNslpWiring(TestCase):
+    """MoNslp registration and MO-specific pe_inputs handling."""
+
+    def test_is_subclass_of_school_lunch(self):
+        self.assertTrue(issubclass(MoNslp, SchoolLunch))
+
+    def test_pe_name_is_school_meal_net_subsidy(self):
+        """The annual net subsidy, not the per-day ``school_meal_daily_subsidy``."""
+        self.assertEqual(MoNslp.pe_name, "school_meal_net_subsidy")
+
+    def test_is_registered_in_mo_spm_calculators(self):
+        self.assertIn("mo_nslp", mo_spm_calculators)
+        self.assertIs(mo_spm_calculators["mo_nslp"], MoNslp)
+
+    def test_is_registered_in_mo_pe_calculators(self):
+        self.assertIn("mo_nslp", mo_pe_calculators)
+        self.assertIs(mo_pe_calculators["mo_nslp"], MoNslp)
+
+    def test_is_registered_in_the_global_registry(self):
+        """screener.views matches Program.name_abbreviated against all_calculators keys,
+        so the MO spm calculators must be spread into the global registry too."""
+        self.assertIn("mo_nslp", all_spm_unit_calculators)
+        self.assertIs(all_spm_unit_calculators["mo_nslp"], MoNslp)
+        self.assertIn("mo_nslp", all_calculators)
+        self.assertIs(all_calculators["mo_nslp"], MoNslp)
+
+    def test_pe_outputs_are_inherited_from_school_lunch(self):
+        self.assertEqual(
+            MoNslp.pe_outputs,
+            [dependency.spm.SchoolMealNetSubsidy, dependency.spm.SchoolMealTier],
+        )
+
+    # --- the load-bearing input (over-eligibility regression guard) ---
+
+    def test_pe_inputs_includes_mo_state_code(self):
+        """Dropping this scores every MO household FREE tier at any income."""
+        self.assertIn(dependency.household.MoStateCodeDependency, MoNslp.pe_inputs)
+
+    # --- federal inputs must survive the MO override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in SchoolLunch.pe_inputs:
+            self.assertIn(federal_input, MoNslp.pe_inputs)
+
+    def test_pe_inputs_includes_school_meal_countable_income(self):
+        self.assertIn(dependency.spm.SchoolMealCountableIncomeDependency, MoNslp.pe_inputs)
+
+    def test_pe_inputs_includes_age(self):
+        """PE derives ``is_in_k12_school`` from age; without it there are no K-12 children
+        to value and the subsidy collapses to $0."""
+        self.assertIn(dependency.member.AgeDependency, MoNslp.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_one_input_over_federal(self):
+        self.assertEqual(len(MoNslp.pe_inputs), len(SchoolLunch.pe_inputs) + 1)

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -627,3 +627,58 @@ class TestWaTanfDependency(TestCase):
         """WaShowAllCashAssistanceProgramsDependency always returns True to bypass PE immigration checks."""
         dep = spm.WaShowAllCashAssistanceProgramsDependency(self.screen, None, {})
         self.assertTrue(dep.value())
+
+
+class TestSchoolMealOutputDependencies(TestCase):
+    """Tests for the school meal *output* dependencies read back from PolicyEngine.
+
+    ``SchoolMealNetSubsidy`` and ``SchoolMealTier`` are the ``pe_outputs`` of the federal
+    ``SchoolLunch`` calculator (and therefore of every state NSLP subclass — il_nslp,
+    ks_nslp, mo_nslp, tx_nslp, wa_nslp). The field strings below are what get written into
+    the PE request so PE returns them; a typo silently yields no value rather than an error,
+    so pin them. ``SchoolMealDailySubsidy`` is the per-day figure and is deliberately *not*
+    what the calculators value households on — it is defined but unused, and is pinned here
+    so it can't be confused for the annual variable.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Missouri", code="mo", state_code="MO")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="63101",
+            county="St. Louis City",
+            household_size=2,
+            completed=False,
+        )
+
+    def test_net_subsidy_field_name(self):
+        dep = spm.SchoolMealNetSubsidy(self.screen, None, {})
+        self.assertEqual(dep.field, "school_meal_net_subsidy")
+
+    def test_tier_field_name(self):
+        dep = spm.SchoolMealTier(self.screen, None, {})
+        self.assertEqual(dep.field, "school_meal_tier")
+
+    def test_daily_subsidy_field_name(self):
+        """The per-day variable — distinct from the annual net subsidy the calculators use."""
+        dep = spm.SchoolMealDailySubsidy(self.screen, None, {})
+        self.assertEqual(dep.field, "school_meal_daily_subsidy")
+
+    def test_all_are_spm_unit_scoped(self):
+        for Dep in (spm.SchoolMealNetSubsidy, spm.SchoolMealTier, spm.SchoolMealDailySubsidy):
+            dep = Dep(self.screen, None, {})
+            self.assertEqual(dep.unit, "spm_units")
+            self.assertEqual(dep.sub_unit, "spm_unit")
+
+    def test_outputs_send_no_input_value(self):
+        """These are read-back-only: value() must stay None so we never overwrite PE's
+        own computation with a placeholder."""
+        for Dep in (spm.SchoolMealNetSubsidy, spm.SchoolMealTier, spm.SchoolMealDailySubsidy):
+            dep = Dep(self.screen, None, {})
+            self.assertIsNone(dep.value())
+
+    def test_are_not_version_gated(self):
+        """No min/max PE version window, so pe_input never withholds them."""
+        for Dep in (spm.SchoolMealNetSubsidy, spm.SchoolMealTier, spm.SchoolMealDailySubsidy):
+            self.assertEqual(Dep.min_pe_version, ())
+            self.assertEqual(Dep.max_pe_version, ())

--- a/programs/programs/policyengine/calculators/registry.py
+++ b/programs/programs/policyengine/calculators/registry.py
@@ -40,7 +40,7 @@ from programs.programs.ma.pe import (
     ma_spm_calculators,
     ma_tax_unit_calculators,
 )
-from programs.programs.mo.pe import mo_member_calculators
+from programs.programs.mo.pe import mo_member_calculators, mo_spm_calculators
 from programs.programs.nc.pe import nc_member_calculators, nc_spm_calculators
 from programs.programs.tx.pe import (
     tx_member_calculators,
@@ -67,6 +67,7 @@ all_spm_unit_calculators: dict[str, type[PolicyEngineSpmCalulator]] = {
     **il_spm_calculators,
     **ks_spm_calculators,
     **ma_spm_calculators,
+    **mo_spm_calculators,
     **nc_spm_calculators,
     **tx_spm_calculators,
     **wa_spm_calculators,


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Implements [MFB-1206: + Program: MO National School Lunch Program](https://linear.app/myfriendben/issue/MFB-1206/program-mo-national-school-lunch-program)
- Discovery: [MFB-1267](https://linear.app/myfriendben/issue/MFB-1267/discovery-mo-national-school-lunch-program) (Done) — Engine: **PE**, Tier: **Fed (as-is)**, Δ for MO: **None**
- Part of the **MO Launch** project. MO previously had no SPM-level PE calculators at all (`programs/programs/mo/pe/` contained only `member.py`), so this adds the first one.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- **New program config** — `programs/management/commands/import_program_config_data/data/mo_nslp_initial_config.json`, from the discovery artifact on MFB-1206 (post-review version incorporating Kate's discovery-review feedback).
  - One deliberate deviation from the attachment: `name_abbreviated` changed from `mo_school_meal_daily_subsidy` to **`mo_nslp`**. This field *is* the calculator registry key — `screener/views.py:426-432` matches `Program.name_abbreviated` against `all_calculators` keys exactly. The original value also embedded the wrong PE variable (`school_meal_daily_subsidy` is the per-day figure; we value households on the annual `school_meal_net_subsidy`). `mo_nslp` matches the `ks_nslp` / `wa_nslp` / `tx_nslp` / `il_nslp` convention — no `name_abbreviated` anywhere in the repo is a PE variable name.
- **New calculator** — `programs/programs/mo/pe/spm.py` adds `MoNslp(SchoolLunch)`: the federal `SchoolLunch` calculator (`pe_name = school_meal_net_subsidy`) plus `MoStateCodeDependency`. No MO-specific variance to model — the two income tiers (free ≤130% FPG, reduced-price ≤185% FPG) are federal, and MO is not in PE's universal-free-meals param.
- **Registration** — new `mo_spm_calculators` dict in `programs/programs/mo/pe/__init__.py`; imported and spread into `all_spm_unit_calculators` in `programs/programs/policyengine/calculators/registry.py`.
- **Tests** —
  - `programs/programs/mo/pe/tests/test_spm.py` (new, 12 tests): pins `MoNslp` registration through all three dicts, `pe_name`, `pe_outputs`, and that the federal inputs survive the MO override. Explicitly guards `MoStateCodeDependency` (see Notes for Reviewers).
  - `programs/programs/policyengine/calculators/dependencies/tests/test_spm.py` (+6 tests): fills a pre-existing gap — `SchoolMealNetSubsidy`, `SchoolMealTier`, and `SchoolMealDailySubsidy` had **no** coverage despite being the `pe_outputs` of every state NSLP calculator (il/ks/mo/tx/wa). Pins field strings, spm-unit scoping, `value()` staying `None`, and the absence of a version gate.

## Testing

<!-- Steps needed to test this PR locally -->

- **Migrations to run:** none — no model changes.
- **Configuration updates needed:** import the program config, then activate it:
  ```bash
  venv/bin/python manage.py import_program_config \
    programs/management/commands/import_program_config_data/data/mo_nslp_initial_config.json
  venv/bin/python manage.py shell -c "from programs.models import Program; Program.objects.filter(white_label__code='mo', name_abbreviated='mo_nslp').update(active=True)"
  ```
  The import creates the `mo_food` category reference, 4 documents (`mo_nslp_application`, `mo_nslp_income`, `mo_nslp_case_number`, `mo_nslp_ssn`), and the `usda_national_hunger_hotline` navigator, and auto-translates all copy. No ICU placeholders in the copy, so no post-import translation repair needed.
- **Environment variables/settings to add:** none.
- **Manual testing steps:**
  1. Full suite passes locally: `venv/bin/python -m pytest -q` → **2572 passed, 19 skipped**.
  2. Targeted: `venv/bin/python -m pytest programs/programs/mo programs/programs/policyengine -q`.
  3. Confirm the Program row resolves to the calculator:
     ```bash
     venv/bin/python manage.py shell -c "from programs.programs.policyengine.calculators.registry import all_calculators; print(all_calculators['mo_nslp'])"
     ```
  4. Screen an MO household with a school-age child (age 5–17) and verify the tiers. Verified live against PE `current`, household of 2 with one 9-year-old:
     - `$20,000/yr` → `school_meal_tier` `FREE`, `school_meal_net_subsidy` **$1,130.96**
     - `$90,000/yr` → `school_meal_tier` `PAID`, `school_meal_net_subsidy` **$0** (program correctly drops out via the `value > 0` filter)
  5. No spec.md in this PR — Fed (as-is) tier is config-only, confirmed on MFB-1267 ("config only, no spec expected"). Matches the `ks_nslp` precedent this was replicated from, which also ships without one.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- **Post-deployment scripts needed:** run `import_program_config` for `mo_nslp_initial_config.json` on staging, then prod (same two commands as above). Import is create-only for a new program, so no duplicate-row risk here.
- **Production config updates:** set `active=True` on the `mo_nslp` Program row once MO launch copy is signed off.
- **Admin updates needed:** none beyond activation. `show_in_has_benefits_step` stays `false` — verified nothing keys off NSLP receipt (see Notes for Reviewers).
- **Notify team/users of:** MO launch stakeholders — MO now surfaces a second Food & Nutrition program alongside `mo_wic`.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

**Please focus on two things:**

1. **`MoStateCodeDependency` matters here, though less dramatically than it first appears.** PE's school meal tier branches on the state's universal-free-meals election, and PE's fallback default behaves like CA (universal free). Verified against PE `current` with an isolated request (household of 2, one 9-y/o, $90,000/yr — far above the 185% FPG limit):

   | `state_code` | `school_meal_net_subsidy` | `school_meal_tier` |
   |---|---|---|
   | `MO` | $0.00 | `PAID` |
   | omitted | $1,142.24 | `FREE` |

   (Measured against the private `household.api.policyengine.org` at the resolved `current` version — the same endpoint the app uses. Numbers from the public `api.policyengine.org` differ because it ignores the request `version` field.)

   **Important caveat:** `state_code` is a *shared* household field — `pe_input()` writes every household-level dependency into one `households.household` dict for the whole request, so a single supplier covers all programs on the screen. The table above is therefore the isolated behaviour, not what MO would necessarily do in production. It still matters because MO is a thin white label: only `mo_wic` and `mo_nslp` supply a state code today, so without this input `mo_nslp` would depend entirely on `mo_wic` staying active. Adding it makes the calculator self-sufficient and matches the il/ks/tx precedent. `test_pe_inputs_includes_mo_state_code` guards it.

2. **The `name_abbreviated` rename** (see Changes Made). It deviates from the discovery attachment, so it should be a conscious sign-off rather than slipping through — cc @chanelle @kate.

**Known limitations:**

- **Latent fragility in the federal base class (no action needed, noted for awareness):** `programs/programs/federal/pe/__init__.py:16` registers `"nslp": spm.SchoolLunch` — the bare federal class with no state code dependency — and that row is `active=True` in CO, NC, and MA. Because household dependencies are shared per request (see note 1), this is **not** a live bug: CO has 11 other active programs supplying `CoStateCodeDependency`, NC has 6, MA has 12, so `nslp` resolves against the correct state in all three. Worth knowing only because the base class isn't self-sufficient on its own.
- No spec.md, so there are no spec-derived QA scenarios to run against this program. The boundaries to assert are 130% FPG (free) and 185% FPG (reduced-price), plus a high-income household returning `PAID` / $0.
- `show_in_has_benefits_step: false` is intentional. No non-test code reads `has_benefit("nslp")` or `has_base_benefit("nslp")` — CO's `MySpark` reads the *calculated* `nslp` result via `self.data.get("nslp")`, not reported receipt. And free/reduced meals does not confer WIC eligibility: [7 CFR 246.7](https://www.ecfr.gov/current/title-7/subtitle-B/chapter-II/subchapter-A/part-246/subpart-C/section-246.7) limits adjunctive eligibility to SNAP/TANF/Medicaid. Some states accept an FRL letter as income *documentation* at the same 185% FPG threshold, but that is not a pathway that overrides the income limit.

**Future considerations:**

- If MO ever adopts a statewide universal-free-meals policy, this needs no code change — PE keys that off its own state parameter, which `MoStateCodeDependency` already feeds.
- The `SchoolMealDailySubsidy` dependency class remains defined but unused. Now pinned by a test noting it is distinct from the annual variable, so it is less likely to be picked up by mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Missouri’s National School Lunch Program.
  * Added Missouri-specific eligibility calculations, including universal free-meal settings and required household information.
  * Added program details, application links, descriptions, required documents, and USDA Hunger Hotline information.
  * Registered the Missouri program in the broader school meal program calculator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->