### PR TITLE
Add Missouri SSI (mo_ssi)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_ssi_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_ssi_initial_config.json
@@ -25,9 +25,10 @@
     "estimated_application_time": "30 - 60 minutes",
     "estimated_delivery_time": "",
     "estimated_value": "",
-    "value_type": "benefit",
     "value_format": null,
     "website_description": "Monthly cash help for older adults and people who are blind or have a disability",
+    "active": true,
+    "low_confidence": false,
     "show_on_current_benefits": true,
     "show_in_has_benefits_step": true,
     "has_calculator": true

--- a/programs/management/commands/import_program_config_data/data/mo_ssi_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_ssi_initial_config.json
@@ -1,0 +1,127 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_cash",
+    "name": "Cash Assistance",
+    "icon": "cash"
+  },
+  "program": {
+    "name_abbreviated": "mo_ssi",
+    "year": "2026",
+    "base_program": "ssi",
+    "legal_status_required": [
+      "citizen",
+      "refugee",
+      "gc_5plus"
+    ],
+    "name": "Supplemental Security Income (SSI)",
+    "description": "Supplemental Security Income (SSI) gives monthly cash payments. It helps older adults and people who are blind or have a disability.\n\nYour monthly payment depends on your income, living situation, and other factors. You can use the money for food, clothing, housing, and other basic needs.\n\nSSI has a resource limit. Resources include cash and money in bank accounts. Some things you own do not count. Social Security checks your resources when you apply. Living in some institutions may also affect your SSI payment.\n\nClick 'Apply Now' to start your SSI application with Social Security. You can also apply by phone by calling 1-800-772-1213.",
+    "description_short": "Monthly cash help for older adults and people who are blind or have a disability",
+    "learn_more_link": "https://www.ssa.gov/ssi",
+    "apply_button_link": "https://www.ssa.gov/apply/ssi",
+    "apply_button_description": "",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_type": "benefit",
+    "value_format": null,
+    "website_description": "Monthly cash help for older adults and people who are blind or have a disability",
+    "show_on_current_benefits": true,
+    "show_in_has_benefits_step": true,
+    "has_calculator": true
+  },
+  "warning_messages": [
+    {
+      "external_name": "mo_ssi_ssdi_interaction",
+      "calculator": "_show",
+      "message": "If you get SSDI, the amount of your SSI payment may be lower. In some cases, you may not get SSI if you also get SSDI."
+    },
+    {
+      "external_name": "mo_ssi_approval_time",
+      "calculator": "_show",
+      "message": "If you apply based on a disability, the first decision usually takes 6 to 8 months. If Social Security denies your application, you can appeal the decision."
+    }
+  ],
+  "documents": [
+    {
+      "external_name": "mo_id_proof",
+      "text": "Proof of identity, if requested (such as a driver's license or state ID)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ssn",
+      "text": "Social Security card or number",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ssi_age",
+      "text": "Proof of age (birth certificate or other birth record)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_home",
+      "text": "Lease, rent receipt, and household cost information",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_earned_income",
+      "text": "Proof of work income (pay stubs or tax return)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_unearned_income",
+      "text": "Proof of other income (award letters, bank statements, or court orders)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_us_status",
+      "text": "Proof of citizenship or immigration status",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ssi_resources",
+      "text": "Bank statements and records of property or other resources",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ssi_medical",
+      "text": "Medical records, provider contacts, and medicines (for disability or blindness claims)",
+      "link_url": "https://www.ssa.gov/disability/disability_starter_kits.htm",
+      "link_text": "View disability checklist"
+    },
+    {
+      "external_name": "mo_ssi_work_history",
+      "text": "Work history (for disability claims)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_ssi_school_records",
+      "text": "School records or IEP (for child disability claims)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "mo_whole_person",
+      "name": "The Whole Person",
+      "email": "hello@thewholeperson.org",
+      "phone_number": "+18165610304",
+      "description": "The Whole Person helps people with disabilities apply for SSI or SSDI. Staff can help gather documents, communicate with Social Security, and prepare appeals.",
+      "assistance_link": "https://thewholeperson.org/support-services/",
+      "counties": ["Cass", "Clay", "Jackson", "Platte", "Andrew", "Atchison", "Buchanan", "Clinton", "DeKalb", "Gentry", "Holt", "Nodaway", "Worth"],
+      "languages": []
+    }
+  ]
+}

--- a/programs/programs/mo/pe/__init__.py
+++ b/programs/programs/mo/pe/__init__.py
@@ -6,6 +6,7 @@ mo_member_calculators = {
     "mo_wic": member.MoWic,
     "mo_head_start": member.MoHeadStart,
     "mo_early_head_start": member.MoEarlyHeadStart,
+    "mo_ssi": member.MoSsi,
 }
 
 mo_spm_calculators = {

--- a/programs/programs/mo/pe/member.py
+++ b/programs/programs/mo/pe/member.py
@@ -2,6 +2,7 @@ from programs.programs.federal.pe.member import (
     Wic,
     HeadStart,
     EarlyHeadStart,
+    Ssi,
 )
 import programs.programs.policyengine.calculators.dependencies as dependency
 from screener.models import HouseholdMember
@@ -87,5 +88,47 @@ class MoEarlyHeadStart(EarlyHeadStart):
 
     pe_inputs = [
         *EarlyHeadStart.pe_inputs,
+        dependency.household.MoStateCodeDependency,
+    ]
+
+
+class MoSsi(Ssi):
+    """
+    Missouri Supplemental Security Income — federal SSI applied to MO residents.
+
+    A thin wrapper on the federal ``Ssi`` PolicyEngine calculator that adds only the MO
+    state code, mirroring ``KsSsi`` / ``TxSsi`` / ``WaSsi``. SSI is federal end to end:
+    PolicyEngine's ``ssi`` variable reads only ``gov.ssa.ssi.*`` parameters, with no state
+    key anywhere in the formula, and PE models SSI *state supplements* for NM, SC, and TX
+    only — there is no MO supplement module. So the output is the federal Benefit Rate
+    (sourced from PE's parameters at calculation time, so it tracks SSA COLA updates
+    automatically) minus PolicyEngine's countable income.
+
+    Missouri's own state cash programs for this population — Blind Pension, Supplemental
+    Aid to the Blind, and Supplemental Nursing Care — are deliberately out of scope here
+    and tracked as a separate program (MFB-1263).
+
+    All eligibility math lives in PolicyEngine: the aged / blind / disabled categorical
+    entry, the $20 general + $65 earned + 1/2 remainder exclusion stack, the SGA cutoff,
+    in-kind support and maintenance, spousal and parental deeming, and the resource limit.
+    The screener contributes only the per-member inputs inherited from ``Ssi.pe_inputs``
+    plus the MO state code.
+
+    Two of those inherited inputs are load-bearing rather than boilerplate:
+
+    - ``MeetsSsiDisabilityCriteriaDependency`` — PE 1.715.2+ no longer infers SSI
+      disability from ``is_disabled`` or reported receipt, so without it a disabled
+      non-aged, non-blind applicant returns ``ssi: 0`` (MFB-1102). It is version-gated,
+      so it only reaches models that define the field.
+    - ``SsiCountableResourcesDependency`` — the resource limit is a hard cutoff, and this
+      splits reported household assets across adults to approximate the per-person figure.
+
+    Duplicate-enrollment filtering ("not already receiving SSI") happens a layer up via
+    ``Screen.has_benefit("mo_ssi")``, which is why the config sets
+    ``show_in_has_benefits_step: true``.
+    """
+
+    pe_inputs = [
+        *Ssi.pe_inputs,
         dependency.household.MoStateCodeDependency,
     ]

--- a/programs/programs/mo/pe/member.py
+++ b/programs/programs/mo/pe/member.py
@@ -106,7 +106,7 @@ class MoSsi(Ssi):
 
     Missouri's own state cash programs for this population — Blind Pension, Supplemental
     Aid to the Blind, and Supplemental Nursing Care — are deliberately out of scope here
-    and tracked as a separate program (MFB-1263).
+    and tracked as a separate program.
 
     All eligibility math lives in PolicyEngine: the aged / blind / disabled categorical
     entry, the $20 general + $65 earned + 1/2 remainder exclusion stack, the SGA cutoff,
@@ -118,8 +118,8 @@ class MoSsi(Ssi):
 
     - ``MeetsSsiDisabilityCriteriaDependency`` — PE 1.715.2+ no longer infers SSI
       disability from ``is_disabled`` or reported receipt, so without it a disabled
-      non-aged, non-blind applicant returns ``ssi: 0`` (MFB-1102). It is version-gated,
-      so it only reaches models that define the field.
+      non-aged, non-blind applicant returns ``ssi: 0``. It is version-gated, so it only
+      reaches models that define the field.
     - ``SsiCountableResourcesDependency`` — the resource limit is a hard cutoff, and this
       splits reported household assets across adults to approximate the per-person figure.
 

--- a/programs/programs/mo/pe/tests/test_member.py
+++ b/programs/programs/mo/pe/tests/test_member.py
@@ -36,6 +36,17 @@ The federal dependency logic is covered in
 wiring. The spec's dollar-value scenarios (Head Start: $16,314 per eligible child, $32,629 for
 two children) are verified end-to-end against the live PolicyEngine API — see
 ``programs/programs/mo/head_start/spec.md``.
+
+MO SSI:
+
+``MoSsi`` is the same shape — federal ``Ssi`` plus the MO state code, mirroring
+``KsSsi`` / ``TxSsi`` / ``WaSsi``. SSI has no MO-specific variance (PE's ``ssi`` reads only
+``gov.ssa.ssi.*``, and PE models state supplements for NM/SC/TX only), so the tests here pin
+the wiring and the two inherited inputs that are load-bearing rather than boilerplate:
+``MeetsSsiDisabilityCriteriaDependency`` (without it, disabled non-aged/non-blind applicants
+get ``ssi: 0`` — MFB-1102) and ``SsiCountableResourcesDependency`` (the resource limit is a
+hard cutoff). The dependency values themselves are covered in
+``policyengine/calculators/dependencies/tests/test_member.py``.
 """
 
 from unittest.mock import MagicMock, Mock
@@ -44,9 +55,9 @@ from django.test import TestCase
 from screener.models import HouseholdMember, IncomeStream, Screen, WhiteLabel
 
 import programs.programs.policyengine.calculators.dependencies as dependency
-from programs.programs.federal.pe.member import Wic, HeadStart, EarlyHeadStart
+from programs.programs.federal.pe.member import Wic, HeadStart, EarlyHeadStart, Ssi as FederalSsi
 from programs.programs.mo.pe import mo_member_calculators, mo_pe_calculators
-from programs.programs.mo.pe.member import MoWic, MoHeadStart, MoEarlyHeadStart
+from programs.programs.mo.pe.member import MoWic, MoHeadStart, MoEarlyHeadStart, MoSsi
 from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
 from programs.programs.policyengine.calculators.dependencies import member as member_deps
 from programs.programs.policyengine.calculators.dependencies.household import MoStateCodeDependency
@@ -54,7 +65,13 @@ from programs.programs.policyengine.calculators.dependencies.member import (
     AgeDependency,
     PregnancyDependency,
     FosterCareDependency,
+    IsBlindDependency,
+    MeetsSsiDisabilityCriteriaDependency,
     Ssi,
+    SsiCountableResourcesDependency,
+    SsiEarnedIncomeDependency,
+    SsiReportedDependency,
+    SsiUnearnedIncomeDependency,
     HeadStart as HeadStartOutput,
     EarlyHeadStart as EarlyHeadStartOutput,
 )
@@ -372,3 +389,147 @@ class TestMoEarlyHeadStartWiring(TestCase):
     def test_does_not_reuse_head_start_variable(self):
         """EHS must resolve PE's ``early_head_start`` variable, not the ``head_start`` one."""
         self.assertNotEqual(MoEarlyHeadStart.pe_name, "head_start")
+
+
+class TestMoSsiWiring(TestCase):
+    """MoSsi inherits the federal SSI calculator and adds only the MO state code."""
+
+    def test_is_subclass_of_federal_ssi(self):
+        self.assertTrue(issubclass(MoSsi, FederalSsi))
+        self.assertTrue(issubclass(MoSsi, PolicyEngineMembersCalculator))
+
+    def test_pe_name_is_ssi(self):
+        self.assertEqual(MoSsi.pe_name, "ssi")
+
+    def test_is_registered_as_mo_ssi(self):
+        self.assertIs(mo_member_calculators["mo_ssi"], MoSsi)
+        self.assertIs(mo_pe_calculators["mo_ssi"], MoSsi)
+
+    def test_is_registered_in_global_registry(self):
+        """A calculator missing from the registry never runs — screener/views.py iterates it."""
+        self.assertIs(all_member_calculators["mo_ssi"], MoSsi)
+        self.assertIs(all_calculators["mo_ssi"], MoSsi)
+
+    def test_pe_inputs_includes_mo_state_code(self):
+        self.assertIn(MoStateCodeDependency, MoSsi.pe_inputs)
+
+    def test_pe_inputs_preserve_federal_ssi_inputs(self):
+        """The MO wrapper only appends the state code; it must not drop any federal input."""
+        for dep in FederalSsi.pe_inputs:
+            self.assertIn(dep, MoSsi.pe_inputs)
+
+    def test_adds_nothing_but_the_state_code(self):
+        """
+        Pins "Δ for MO: None". PE's ``ssi`` reads only ``gov.ssa.ssi.*`` params and PE models
+        SSI state supplements for NM/SC/TX only, so any extra MO input here would be a new
+        claim about state variance that needs its own justification.
+        """
+        self.assertEqual(set(MoSsi.pe_inputs) - set(FederalSsi.pe_inputs), {MoStateCodeDependency})
+
+    def test_pe_inputs_include_disability_criteria(self):
+        """
+        Regression guard for MFB-1102. PE 1.715.2+ stopped inferring SSI disability from
+        ``is_disabled`` / reported receipt, so dropping this input returns ``ssi: 0`` for a
+        disabled non-aged, non-blind applicant.
+        """
+        self.assertIn(MeetsSsiDisabilityCriteriaDependency, MoSsi.pe_inputs)
+        self.assertIn(IsBlindDependency, MoSsi.pe_inputs)
+
+    def test_pe_inputs_include_resource_and_income_tests(self):
+        """The resource limit is a hard cutoff, and earned/unearned split drives the exclusion stack."""
+        self.assertIn(SsiCountableResourcesDependency, MoSsi.pe_inputs)
+        self.assertIn(SsiEarnedIncomeDependency, MoSsi.pe_inputs)
+        self.assertIn(SsiUnearnedIncomeDependency, MoSsi.pe_inputs)
+        self.assertIn(SsiReportedDependency, MoSsi.pe_inputs)
+
+    def test_pe_outputs_is_ssi_variable(self):
+        self.assertEqual(MoSsi.pe_outputs, [Ssi])
+
+    def test_does_not_override_member_value(self):
+        """
+        MoSsi returns PolicyEngine's computed dollar amount via the inherited
+        ``member_value``. Unlike WIC, there is no zeroed category table to work around,
+        so an override here would mean hardcoding an FBR that stops tracking SSA COLAs.
+        """
+        self.assertIs(MoSsi.member_value, PolicyEngineMembersCalculator.member_value)
+
+
+class TestMoSsiPeInput(TestCase):
+    """MoSsi's dependencies land in the pe_input payload sent to PolicyEngine."""
+
+    PERIOD = "2026"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.white_label = WhiteLabel.objects.create(name="Missouri", code="mo", state_code="MO")
+
+    def setUp(self):
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Cole County",
+            household_size=1,
+            household_assets=1_500,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(
+            screen=self.screen,
+            relationship="headOfHousehold",
+            age=67,
+            disabled=True,
+        )
+
+    def _calculator(self):
+        program = Mock()
+        program.year.period = self.PERIOD
+        return MoSsi(self.screen, program, self.screen.missing_fields())
+
+    def test_sends_mo_state_code(self):
+        household = pe_input(self.screen, [self._calculator()])["household"]["households"]["household"]
+
+        self.assertIn("state_code", household)
+        self.assertIn("MO", household["state_code"].values())
+
+    def test_sends_ssi_eligibility_inputs_for_the_member(self):
+        people = pe_input(self.screen, [self._calculator()])["household"]["people"]
+        head = people[str(self.head.id)]
+
+        for field in ("age", "is_blind", "is_disabled", "ssi_countable_resources", "ssi_reported"):
+            self.assertIn(field, head)
+
+    def test_splits_household_assets_into_countable_resources(self):
+        people = pe_input(self.screen, [self._calculator()])["household"]["people"]
+        head = people[str(self.head.id)]
+
+        self.assertEqual(head["ssi_countable_resources"], {self.PERIOD: 1_500})
+
+    def test_sends_earned_and_unearned_income_separately(self):
+        """
+        SSI's exclusion stack treats the two differently ($20 general, then $65 + 1/2 of
+        remaining earned), so collapsing them would understate the benefit.
+        """
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="wages",
+            amount=500,
+            frequency="monthly",
+        )
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="sSA",
+            amount=300,
+            frequency="monthly",
+        )
+
+        people = pe_input(self.screen, [self._calculator()])["household"]["people"]
+        head = people[str(self.head.id)]
+
+        self.assertEqual(head["ssi_earned_income"], {self.PERIOD: 6_000})
+        self.assertEqual(head["ssi_unearned_income"], {self.PERIOD: 3_600})
+
+    def test_requests_ssi_output_for_the_member(self):
+        people = pe_input(self.screen, [self._calculator()])["household"]["people"]
+
+        self.assertIn("ssi", people[str(self.head.id)])

--- a/programs/programs/mo/pe/tests/test_member.py
+++ b/programs/programs/mo/pe/tests/test_member.py
@@ -44,7 +44,7 @@ MO SSI:
 ``gov.ssa.ssi.*``, and PE models state supplements for NM/SC/TX only), so the tests here pin
 the wiring and the two inherited inputs that are load-bearing rather than boilerplate:
 ``MeetsSsiDisabilityCriteriaDependency`` (without it, disabled non-aged/non-blind applicants
-get ``ssi: 0`` — MFB-1102) and ``SsiCountableResourcesDependency`` (the resource limit is a
+get ``ssi: 0``) and ``SsiCountableResourcesDependency`` (the resource limit is a
 hard cutoff). The dependency values themselves are covered in
 ``policyengine/calculators/dependencies/tests/test_member.py``.
 """
@@ -428,7 +428,7 @@ class TestMoSsiWiring(TestCase):
 
     def test_pe_inputs_include_disability_criteria(self):
         """
-        Regression guard for MFB-1102. PE 1.715.2+ stopped inferring SSI disability from
+        Regression guard. PE 1.715.2+ stopped inferring SSI disability from
         ``is_disabled`` / reported receipt, so dropping this input returns ``ssi: 0`` for a
         disabled non-aged, non-blind applicant.
         """

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1564,3 +1564,179 @@ class TestCareExpensesDependency(TestCase):
         HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=38, long_term_disability=True)
         # $6,000/yr split across 2 incapable members → $3,000 each.
         self.assertEqual(member.CareExpensesDependency(self.screen, d1, {}).value(), 3000)
+
+
+class TestSsiReportedDependency(TestCase):
+    """
+    Tests for SsiReportedDependency, which tells PolicyEngine how much SSI the member
+    already reports receiving. Only the screener's ``sSI`` income type counts — SSDI
+    (``sSDisability``) is a different program and must not be folded in.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Test County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+
+    def test_field_name(self):
+        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).field, "ssi_reported")
+
+    def test_value_annualizes_reported_ssi(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSI", amount=943, frequency="monthly"
+        )
+        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).value(), 11316)
+
+    def test_value_returns_zero_when_no_ssi_reported(self):
+        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).value(), 0)
+
+    def test_value_excludes_ssdi_and_other_income(self):
+        """SSDI is a separate program; counting it as reported SSI would suppress the benefit."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSDisability", amount=1000, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=500, frequency="monthly"
+        )
+        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).value(), 0)
+
+
+class TestSsiCountableResourcesDependency(TestCase):
+    """
+    Tests for SsiCountableResourcesDependency. SSI's resource limit is a hard cutoff, and
+    the screener collects assets only at the household level — so this splits the household
+    total evenly across adults (19+) to approximate a per-person figure, and attributes
+    nothing to children.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Test County",
+            household_size=3,
+            household_assets=6000,
+            completed=False,
+        )
+
+    def test_field_name(self):
+        head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+        self.assertEqual(member.SsiCountableResourcesDependency(self.screen, head, {}).field, "ssi_countable_resources")
+
+    def test_single_adult_gets_all_household_assets(self):
+        screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Test County",
+            household_size=1,
+            household_assets=1500,
+            completed=False,
+        )
+        head = HouseholdMember.objects.create(screen=screen, relationship="headOfHousehold", age=67)
+        self.assertEqual(member.SsiCountableResourcesDependency(screen, head, {}).value(), 1500)
+
+    def test_assets_split_evenly_across_adults(self):
+        head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+        HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=65)
+        HouseholdMember.objects.create(screen=self.screen, relationship="child", age=10)
+        # $6,000 across 2 adults (the 10-year-old is not counted) -> $3,000 each.
+        self.assertEqual(member.SsiCountableResourcesDependency(self.screen, head, {}).value(), 3000)
+
+    def test_children_are_attributed_no_resources(self):
+        HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+        child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=10)
+        self.assertEqual(member.SsiCountableResourcesDependency(self.screen, child, {}).value(), 0)
+
+    def test_age_19_counts_as_an_adult(self):
+        """num_adults() uses age_max=19, so 19 is the boundary — 18 gets nothing, 19 gets a share."""
+        eighteen = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=18)
+        nineteen = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=19)
+        HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+
+        self.assertEqual(member.SsiCountableResourcesDependency(self.screen, eighteen, {}).value(), 0)
+        # $6,000 across the 19-year-old and the 67-year-old -> $3,000 each.
+        self.assertEqual(member.SsiCountableResourcesDependency(self.screen, nineteen, {}).value(), 3000)
+
+    def test_value_is_an_int(self):
+        """PolicyEngine gets an int; an uneven split must not leak a float."""
+        head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+        HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=65)
+        HouseholdMember.objects.create(screen=self.screen, relationship="parent", age=88)
+
+        value = member.SsiCountableResourcesDependency(self.screen, head, {}).value()
+        self.assertIsInstance(value, int)
+        self.assertEqual(value, 2000)
+
+
+class TestSsiEarnedAndUnearnedIncomeDependencies(TestCase):
+    """
+    Tests for SsiEarnedIncomeDependency / SsiUnearnedIncomeDependency. SSI applies a
+    different exclusion to each ($20 general, then $65 + half of remaining earned), so the
+    two must stay split — collapsing them would understate the benefit.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="65101",
+            county="Test County",
+            household_size=1,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+
+    def test_field_names(self):
+        self.assertEqual(member.SsiEarnedIncomeDependency(self.screen, self.head, {}).field, "ssi_earned_income")
+        self.assertEqual(member.SsiUnearnedIncomeDependency(self.screen, self.head, {}).field, "ssi_unearned_income")
+
+    def test_earned_covers_wages_and_self_employment_only(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=1000, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="selfEmployment", amount=500, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSA", amount=800, frequency="monthly"
+        )
+
+        self.assertEqual(member.SsiEarnedIncomeDependency(self.screen, self.head, {}).value(), 18000)
+
+    def test_unearned_covers_everything_that_is_not_earned(self):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSA", amount=800, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="pension", amount=200, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=1000, frequency="monthly"
+        )
+
+        self.assertEqual(member.SsiUnearnedIncomeDependency(self.screen, self.head, {}).value(), 12000)
+
+    def test_the_two_partition_all_income_without_overlap(self):
+        """Every income stream lands in exactly one bucket — nothing double-counted, nothing dropped."""
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="wages", amount=1000, frequency="monthly"
+        )
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="sSA", amount=800, frequency="monthly"
+        )
+
+        earned = member.SsiEarnedIncomeDependency(self.screen, self.head, {}).value()
+        unearned = member.SsiUnearnedIncomeDependency(self.screen, self.head, {}).value()
+
+        self.assertEqual(earned + unearned, self.head.calc_gross_income("yearly", ["all"]))
+
+    def test_both_return_zero_with_no_income(self):
+        self.assertEqual(member.SsiEarnedIncomeDependency(self.screen, self.head, {}).value(), 0)
+        self.assertEqual(member.SsiUnearnedIncomeDependency(self.screen, self.head, {}).value(), 0)

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1665,7 +1665,12 @@ class TestSsiCountableResourcesDependency(TestCase):
         self.assertEqual(member.SsiCountableResourcesDependency(self.screen, nineteen, {}).value(), 3000)
 
     def test_value_is_an_int(self):
-        """PolicyEngine gets an int; an uneven split must not leak a float."""
+        """PolicyEngine gets an int; an uneven split must not leak a Decimal."""
+        # $6,001 across 3 adults divides to Decimal('2000.333...'), so this exercises the
+        # int() truncation. An evenly divisible amount would pass whether or not the cast
+        # is there.
+        self.screen.household_assets = 6001
+        self.screen.save()
         head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
         HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=65)
         HouseholdMember.objects.create(screen=self.screen, relationship="parent", age=88)


### PR DESCRIPTION
## Context & Motivation

Adds Missouri Supplemental Security Income (SSI) to the MO white label, part of the MO Launch project.

- Implements [MFB-1212](https://linear.app/myfriendben/issue/MFB-1212/program-mo-supplemental-security-income-ssi)
- Discovery: [MFB-1263](https://linear.app/myfriendben/issue/MFB-1263/discovery-mo-supplemental-security-income-ssi) (Done)

Ticket classification is **PE engine / Fed (as-is) tier**, and discovery verified "Δ for MO: None" against source. That holds up: PolicyEngine's `ssi` variable reads only `gov.ssa.ssi.*` parameters with no state key anywhere in the formula, and PE models SSI *state supplements* for NM, SC, and TX only — there is no MO supplement module. So MO gets the federal calculator plus the MO state code, nothing more. Because nothing varies by state, discovery delivered **config only and no `spec.md`**, matching the `ks_ssi` precedent.

Missouri's own state cash programs for this population — Blind Pension, Supplemental Aid to the Blind, and Supplemental Nursing Care — are deliberately out of scope and tracked separately.

## Changes Made

**Program config** — `mo_ssi_initial_config.json`

- Commit 1 adds the discovery artifact verbatim as signed off in MFB-1263, so the delta below is visible in history.
- Commit 2 fixes two things the importer would have gotten wrong:
  - **Added `"active": true`** (plus explicit `"low_confidence": false`, matching `wa_ssi`/`ks_ssi`). `Program.objects.new_program()` creates with `active=False`, and `_import_program_configuration` only sets the field when it's present — so the config as delivered would have imported `mo_ssi` **inactive** and it would never have surfaced in results.
  - **Dropped `"value_type": "benefit"`.** There is no `value_type` field on the `Program` model and it isn't in the importer's `simple_config_fields`, so it was silently discarded. No sibling SSI config carries it.

**Calculator** — `programs/programs/mo/pe/member.py`

- `MoSsi(Ssi)` adding only `MoStateCodeDependency`, mirroring `KsSsi` / `TxSsi` / `WaSsi`. Value is the federal Benefit Rate read from PE's parameters at calculation time (so it tracks SSA COLAs automatically) minus PE's countable income.
- Registered as `mo_ssi` in `mo_member_calculators`.

**Tests** — 211 pass

- `programs/mo/pe/tests/test_member.py` — MO wiring: subclassing, registration in both the MO and global registries, and that the MO delta is *exactly* the state code and nothing else (so any future extra input has to justify itself as a state-variance claim). Pins the two inherited inputs that are load-bearing rather than boilerplate: `MeetsSsiDisabilityCriteriaDependency` (MFB-1102 — PE 1.715.2+ stopped inferring SSI disability from `is_disabled`/reported receipt, so without it a disabled non-aged, non-blind applicant gets `ssi: 0`) and `SsiCountableResourcesDependency` (the resource limit is a hard cutoff). Plus a `pe_input` round trip asserting the MO state code reaches the payload, the per-member eligibility fields are present, and earned/unearned income stay split.
- `policyengine/calculators/dependencies/tests/test_member.py` — `Ssi.pe_inputs` had **four of eleven** inputs untested; all four now covered. `SsiReportedDependency` (including that SSDI is excluded — folding it in would suppress the benefit), `SsiCountableResourcesDependency` (household assets split across adults, the age-19 boundary, children attributed nothing, int not float), and `SsiEarnedIncomeDependency` / `SsiUnearnedIncomeDependency` (they must stay split for SSI's exclusion stack, and they partition all income without overlap). The other seven were already covered.

## Testing

- **Migrations to run:** none.
- **Configuration updates needed:** `python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_ssi_initial_config.json`
- **Environment variables/settings to add:** none.
- **Manual testing steps:**

Unit tests:

```
python manage.py test programs.programs.policyengine.calculators.dependencies.tests.test_member programs.programs.mo.pe
```

Verified the imported row locally — `active=True`, `has_calculator=True`, `base_program=ssi`, `year=2026`, category `[Missouri] Cash Assistance`, legal statuses `citizen/refugee/gc_5plus`, and `mo_ssi` surfacing in the MO `has-benefits-programs` list.

Then a **live smoke test against the private PolicyEngine API** through `calc_pe_eligibility` — all five scenarios come back correct:

| Scenario | Eligible | Annual value |
| --- | --- | --- |
| Aged 67, no income, $1,500 assets | ✅ | $11,928 (= $994/mo, the 2026 FBR) |
| Aged 67, $2,000/mo wages, $1,500 assets | ✅ | $438 |
| Age 40 disabled, no income, $1,500 assets | ✅ | $11,928 |
| Age 40, neither aged/blind/disabled | ❌ | $0 |
| Aged 67, no income, $50,000 assets | ❌ | $0 |

The $438 figure checks out by hand against SSA's exclusion stack: $2,000/mo earned − $20 general − $65 earned = $1,915, halved = $957.50 countable; $994 − $957.50 = $36.50/mo × 12 = $438. The disabled-age-40 row is the MFB-1102 regression path, confirming the version-gated disability input is reaching PE.

## Deployment

- **Post-deployment scripts needed:** run the config import on staging, then prod:
  `python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_ssi_initial_config.json`
- **Production config updates:** the import creates the `[Missouri] Cash Assistance` program category, 11 documents, and 1 navigator (The Whole Person, KC) alongside the program. First MO cash-assistance program, so the category is new.
- **Admin updates needed:** none — `active` and `show_in_has_benefits_step` both come from the config.
- **Notify team/users of:** MO now shows an SSI tile on the "I already have this benefit" screener step.

## Notes for Reviewers

- **Known limitations:**
  - `show_in_has_benefits_step: true` comes from discovery, justified by Missouri's SNAP manual (DSS 1135.035.00 — SSI recipients are categorically SNAP-eligible in MO). **MO has no SNAP program in the codebase yet**, so nothing reads SSI receipt for MO today and that justification is forward-looking. Keeping it `true` is still right: it matches `ks_ssi`/`wa_ssi`, and it's what lets the tile suppress SSI for households already receiving it via `Screen.has_benefit("mo_ssi")`. Worth a look when MO SNAP lands — that calculator should read this benefit.
  - Missouri is a **209(b) state**, so SSI approval does *not* auto-grant MO HealthNet. Discovery caught and removed an earlier draft description that claimed otherwise; this is not a Medicaid claim.
  - `legal_status_required` is `citizen/refugee/gc_5plus` — a visibility filter, not a determination. SSA's additional noncitizen conditions (40 qualifying quarters, veteran/active-duty status, the 8/22/1996 grandfather rule) are disclosed in the description rather than gated in the screener, consistent with how the resource limit and institutional-living effects are handled.
- **Future considerations:** MO Blind Pension / SAB / SNC (the state supplements) are a separate ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Missouri SSI program support to the calculator.
  - Includes Missouri-specific eligibility information, benefit descriptions, application links, required documents, warnings, and calculator guidance.
  - Provides navigator assistance details for participating Missouri counties.
  - Supports federal SSI eligibility and benefit calculations with Missouri state information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->