### PR TITLE
Add MO Federal Earned Income Tax Credit (mo_eitc) + consolidate federal EITC reuse

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_eitc_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_eitc_initial_config.json
@@ -20,11 +20,11 @@
     ],
     "name": "Federal Earned Income Tax Credit (EITC)",
     "description_short": "A federal tax credit for working people with lower incomes. It can lower your taxes or increase your refund",
-    "description": "The Earned Income Tax Credit (EITC) is a federal tax break. It helps working people with lower incomes.\n\nYou claim the EITC when you file your federal tax return. You do not need a separate Missouri application. The credit can lower the federal tax you owe. If the credit is more than you owe, you may get the rest as part of your refund.\n\nThis tool cannot check every tax rule. You need a valid Social Security number to claim the EITC. Your spouse also needs one if you file a joint return. Each child you claim for the EITC needs one too. You cannot claim the EITC if you file Form 2555 for foreign earned income.\n\nIf you do not claim a child for the EITC, you must have lived in the United States for more than half the year. No one else can claim you as a dependent or qualifying child on their tax return.\n\nTo claim the EITC, select \"File Your Taxes\" to prepare and file your federal tax return through IRS Free File.",
+    "description": "The Earned Income Tax Credit (EITC) is a federal tax break. It helps working people with lower incomes.\n\nYou claim the EITC when you file your federal tax return. You do not need a separate Missouri application. The credit can lower the federal tax you owe. If the credit is more than you owe, you may get the rest as part of your refund.\n\nThis tool cannot check every tax rule. You need a valid Social Security number to claim the EITC. Your spouse also needs one if you file a joint return. Each child you claim for the EITC needs one too. You cannot claim the EITC if you file Form 2555 for foreign earned income.\n\nIf you do not claim a child for the EITC, you must have lived in the United States for more than half the year. No one else can claim you as a dependent or qualifying child on their tax return.\n\nTo claim the EITC, select \"File for Free\" to prepare and file your federal tax return at no cost. If you would rather have someone help you file, see the \"Get Help Applying\" section.",
     "learn_more_link": "https://www.irs.gov/credits-deductions/individuals/earned-income-tax-credit/who-qualifies-for-the-earned-income-tax-credit-eitc",
     "apply_button_link": "https://www.irs.gov/filing/free-file-do-your-federal-taxes-for-free",
-    "apply_button_description": "File Your Taxes",
-    "estimated_application_time": "30 - 60 minutes",
+    "apply_button_description": "File for Free",
+    "estimated_application_time": "45 minutes",
     "estimated_delivery_time": "",
     "estimated_value": "",
     "value_format": "estimated_annual",
@@ -67,6 +67,14 @@
     }
   ],
   "navigators": [
+    {
+      "external_name": "mo_eitc_get_your_refund",
+      "name": "GetYourRefund",
+      "phone_number": "",
+      "email": "",
+      "assistance_link": "https://www.getyourrefund.org/en",
+      "description": "Free tax filing from Code for America, in partnership with IRS-certified VITA volunteers. You can file on your own with help by chat or email, have a tax expert file for you, or find an in-person site near you."
+    },
     {
       "external_name": "mo_eitc_vita_free_tax_prep",
       "name": "VITA Free Tax Preparation (IRS Volunteer Income Tax Assistance)",

--- a/programs/management/commands/import_program_config_data/data/mo_eitc_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_eitc_initial_config.json
@@ -1,0 +1,87 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_tax",
+    "name": "Tax Credits",
+    "icon": "tax_credit",
+    "tax_category": true
+  },
+  "program": {
+    "name_abbreviated": "mo_eitc",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission"
+    ],
+    "name": "Federal Earned Income Tax Credit (EITC)",
+    "description_short": "A federal tax credit for working people with lower incomes. It can lower your taxes or increase your refund",
+    "description": "The Earned Income Tax Credit (EITC) is a federal tax break. It helps working people with lower incomes.\n\nYou claim the EITC when you file your federal tax return. You do not need a separate Missouri application. The credit can lower the federal tax you owe. If the credit is more than you owe, you may get the rest as part of your refund.\n\nThis tool cannot check every tax rule. You need a valid Social Security number to claim the EITC. Your spouse also needs one if you file a joint return. Each child you claim for the EITC needs one too. You cannot claim the EITC if you file Form 2555 for foreign earned income.\n\nIf you do not claim a child for the EITC, you must have lived in the United States for more than half the year. No one else can claim you as a dependent or qualifying child on their tax return.\n\nTo claim the EITC, select \"File Your Taxes\" to prepare and file your federal tax return through IRS Free File.",
+    "learn_more_link": "https://www.irs.gov/credits-deductions/individuals/earned-income-tax-credit/who-qualifies-for-the-earned-income-tax-credit-eitc",
+    "apply_button_link": "https://www.irs.gov/filing/free-file-do-your-federal-taxes-for-free",
+    "apply_button_description": "File Your Taxes",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": "estimated_annual",
+    "website_description": "A federal tax credit for working people with lower incomes. It can lower your taxes or increase your refund",
+    "base_program": "eitc",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "documents": [
+    {
+      "external_name": "mo_eitc_ssn",
+      "text": "Valid Social Security Number (SSN) for you and any qualifying children. Your spouse needs one too if you file a joint return.",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_eitc_earned_income",
+      "text": "Proof of earned income (ex: W-2 forms, 1099-NEC forms, self-employment records)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_eitc_investment_income",
+      "text": "Records of investment income (ex: 1099-INT, 1099-DIV, 1099-B)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_eitc_prior_year_return",
+      "text": "Last year's federal tax return, if you filed one (used to verify your identity when e-filing)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_eitc_id_proof",
+      "text": "Proof of identity (ex: driver's license, state ID). Only needed if you use VITA or another in-person tax preparer.",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "mo_eitc_vita_free_tax_prep",
+      "name": "VITA Free Tax Preparation (IRS Volunteer Income Tax Assistance)",
+      "phone_number": "+18009069887",
+      "email": "",
+      "assistance_link": "https://freetaxassistance.for.irs.gov/s/sitelocator",
+      "description": "Free tax preparation help for people who earn low to moderate income. Trained volunteers can help you file your federal return and claim the EITC."
+    },
+    {
+      "external_name": "mo_eitc_aarp_tax_aide",
+      "name": "AARP Foundation Tax-Aide",
+      "phone_number": "+18882277669",
+      "email": "taxaide@aarp.org",
+      "assistance_link": "https://www.aarp.org/money/taxes/aarp-taxaide/",
+      "description": "AARP Foundation Tax-Aide provides free federal tax preparation help at sites across Missouri. Volunteers can help you claim the EITC on your federal return. No AARP membership required. Use the site locator to find an appointment near you."
+    }
+  ]
+}

--- a/programs/programs/federal/pe/tests/test_tax.py
+++ b/programs/programs/federal/pe/tests/test_tax.py
@@ -1,22 +1,27 @@
 """
-Unit tests for the federal tax-unit PolicyEngine calculator ``Ctc``.
+Unit tests for the shared federal tax-unit PolicyEngine calculators.
 
-``Ctc`` is shared: Kansas, Missouri, Texas, and Washington all register their
-own program slug (``ks_ctc``, ``mo_ctc``, ...) against this exact class object
-rather than subclassing it, because the federal Child Tax Credit has no state
-variance. That makes this class's wiring a cross-state contract — the properties
-asserted here hold for every state that reuses it, so each state file only needs
-to prove it points at this object (see e.g. ``TestMoCtcWiring``).
+``Ctc`` and ``Eitc`` are shared: states register their own program slug
+(``ks_ctc``, ``mo_ctc``, ``mo_eitc``, ...) against these exact class objects
+rather than subclassing them, because neither federal credit has state variance.
+That makes each class's wiring a cross-state contract — the properties asserted
+here hold for every state that reuses it, so a state file only needs to prove it
+points at this object (see e.g. ``TestMoCtcWiring``).
 
-The eligibility math itself — the per-child maximum, the phase-out, the
-refundable portion, and the limitation by tax liability — lives in PolicyEngine
-and is covered by PolicyEngine's own test suite, not duplicated here.
+Neither federal credit reads ``state_code``: there is no state reference
+anywhere under PolicyEngine's ``gov/irs/credits/ctc`` or
+``gov/irs/credits/earned_income`` variable trees. ``test_pe_inputs_carry_no_state_code``
+pins that generically for both.
+
+The eligibility math itself — phase-ins, phase-outs, per-child maximums, the
+refundable portions, and the investment-income cap — lives in PolicyEngine and is
+covered by PolicyEngine's own test suite, not duplicated here.
 """
 
 from django.test import TestCase
 
 from programs.programs.federal.pe import federal_tax_unit_calculators
-from programs.programs.federal.pe.tax import Ctc
+from programs.programs.federal.pe.tax import Ctc, Eitc
 from programs.programs.policyengine.calculators.base import PolicyEngineTaxUnitCalulator
 from programs.programs.policyengine.calculators.dependencies import (
     irs_gross_income,
@@ -80,4 +85,56 @@ class TestFederalCtc(TestCase):
             self.assertFalse(
                 isinstance(pe_input, type) and issubclass(pe_input, StateCode),
                 f"{pe_input.__name__} sends a state code to the federal CTC",
+            )
+
+
+class TestFederalEitc(TestCase):
+    """Wiring of the shared federal Earned Income Tax Credit calculator."""
+
+    def test_is_a_tax_unit_calculator(self):
+        self.assertTrue(issubclass(Eitc, PolicyEngineTaxUnitCalulator))
+
+    def test_is_registered_as_eitc(self):
+        self.assertIs(federal_tax_unit_calculators["eitc"], Eitc)
+        self.assertIs(all_tax_unit_calculators["eitc"], Eitc)
+        self.assertIs(all_calculators["eitc"], Eitc)
+
+    def test_pe_name_is_eitc(self):
+        self.assertEqual(Eitc.pe_name, "eitc")
+
+    def test_pe_outputs_read_the_eitc_field(self):
+        self.assertEqual(Eitc.pe_outputs, [tax.Eitc])
+        self.assertEqual(tax.Eitc.field, "eitc")
+
+    def test_pe_inputs_include_age_and_tax_unit_composition(self):
+        """Age drives the 25-64 rule for childless filers; the dependent/spouse
+        structure drives the qualifying-child count and the joint-filer thresholds."""
+        self.assertIn(member.AgeDependency, Eitc.pe_inputs)
+        self.assertIn(member.TaxUnitDependentDependency, Eitc.pe_inputs)
+        self.assertIn(member.TaxUnitSpouseDependency, Eitc.pe_inputs)
+
+    def test_pe_inputs_include_irs_gross_income(self):
+        """The credit phases in and back out on income, so every gross income
+        input is sent."""
+        for income_input in irs_gross_income:
+            self.assertIn(income_input, Eitc.pe_inputs)
+
+    def test_pe_inputs_carry_no_state_code(self):
+        """Nothing under PolicyEngine's ``gov/irs/credits/earned_income`` variable
+        tree reads ``state_code``, so no state's federal EITC should send one.
+
+        ``TxEitc`` and ``WaEitc`` were subclasses that appended their state code to
+        these inputs while still targeting the federal ``eitc`` variable. It changed
+        no output — verified against live PE 1.779.3 across six households — and both
+        were removed. This asserts the general case, so a subclass for any state
+        would have to fail it.
+
+        Contrast ``co_eitc``, ``il_eitc``, ``ks_total_eitc``, and ``ma_eitc``: those
+        are genuine *state* EITCs under ``gov/states/`` with their own calculators,
+        and they do need a state code.
+        """
+        for pe_input in Eitc.pe_inputs:
+            self.assertFalse(
+                isinstance(pe_input, type) and issubclass(pe_input, StateCode),
+                f"{pe_input.__name__} sends a state code to the federal EITC",
             )

--- a/programs/programs/federal/pe/tests/test_tax.py
+++ b/programs/programs/federal/pe/tests/test_tax.py
@@ -70,13 +70,11 @@ class TestFederalCtc(TestCase):
 
     def test_pe_inputs_carry_no_state_code(self):
         """Nothing under PolicyEngine's ``gov/irs/credits/ctc`` variable tree reads
-        ``state_code``, so no state's CTC should send one.
+        ``state_code``, so no state's CTC sends one — a state code here would be an
+        input the formula ignores.
 
-        Texas previously registered a ``TxCtc`` subclass that appended
-        ``TxStateCodeDependency`` to these inputs. It changed no output — verified
-        against live PE 1.779.3 across eight households — and was removed. This
-        asserts the general case rather than one state's dependency, so a subclass
-        for any state would have to fail it.
+        Asserted against the ``StateCode`` base class rather than one state's
+        dependency, so a subclass adding any state's code fails this.
 
         Contrast ``co_ctc`` and ``il_ctc``: those are genuine *state* credits under
         ``gov/states/`` with their own calculators, and they do need a state code.
@@ -121,13 +119,11 @@ class TestFederalEitc(TestCase):
 
     def test_pe_inputs_carry_no_state_code(self):
         """Nothing under PolicyEngine's ``gov/irs/credits/earned_income`` variable
-        tree reads ``state_code``, so no state's federal EITC should send one.
+        tree reads ``state_code``, so no state's federal EITC sends one — a state
+        code here would be an input the formula ignores.
 
-        ``TxEitc`` and ``WaEitc`` were subclasses that appended their state code to
-        these inputs while still targeting the federal ``eitc`` variable. It changed
-        no output — verified against live PE 1.779.3 across six households — and both
-        were removed. This asserts the general case, so a subclass for any state
-        would have to fail it.
+        Asserted against the ``StateCode`` base class rather than one state's
+        dependency, so a subclass adding any state's code fails this.
 
         Contrast ``co_eitc``, ``il_eitc``, ``ks_total_eitc``, and ``ma_eitc``: those
         are genuine *state* EITCs under ``gov/states/`` with their own calculators,

--- a/programs/programs/mo/pe/__init__.py
+++ b/programs/programs/mo/pe/__init__.py
@@ -1,4 +1,4 @@
-from programs.programs.federal.pe.tax import Ctc
+from programs.programs.federal.pe.tax import Ctc, Eitc
 import programs.programs.mo.pe.member as member
 import programs.programs.mo.pe.spm as spm
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
@@ -15,6 +15,7 @@ mo_spm_calculators = {
 
 mo_tax_unit_calculators = {
     "mo_ctc": Ctc,
+    "mo_eitc": Eitc,
 }
 
 mo_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {

--- a/programs/programs/mo/pe/tests/test_tax.py
+++ b/programs/programs/mo/pe/tests/test_tax.py
@@ -8,16 +8,14 @@ Missouri has no state CTC or state EITC and no MO-specific variance, so
 
 That makes registration the only MO-side fact to pin, and one part of it is
 load-bearing: ``mo_tax_unit_calculators`` must be spread into the global
-``all_tax_unit_calculators``. Missouri previously had no tax-unit calculators at
-all, so the registry imported only its member and SPM dicts. Registering
-``mo_ctc`` in ``mo_pe_calculators`` alone leaves it invisible to
-``screener.views``, which resolves ``Program.name_abbreviated`` against
-``all_calculators`` — the program would silently return no value.
+``all_tax_unit_calculators`` in ``registry.py``. ``screener.views`` resolves
+``Program.name_abbreviated`` against ``all_calculators``, so a program registered
+only in ``mo_pe_calculators`` is invisible to it and silently returns no value.
 
-Everything else about the calculator (``pe_name``, ``pe_outputs``, the input set,
-and the absence of a state code) is a property of the shared federal class and is
-asserted once in ``programs/programs/federal/pe/tests/test_tax.py``. Proving
-``mo_ctc`` *is* that object extends those guarantees here.
+Everything else about the calculators (``pe_name``, ``pe_outputs``, the input set,
+and the absence of a state code) is a property of the shared federal classes and
+is asserted once in ``programs/programs/federal/pe/tests/test_tax.py``. Proving
+these slugs *are* those objects extends those guarantees here.
 """
 
 from django.test import TestCase

--- a/programs/programs/mo/pe/tests/test_tax.py
+++ b/programs/programs/mo/pe/tests/test_tax.py
@@ -1,9 +1,10 @@
 """
-Unit tests for the MO tax-unit PolicyEngine calculator registration (mo_ctc).
+Unit tests for the MO tax-unit PolicyEngine calculator registrations.
 
-Missouri has no state CTC and no MO-specific variance, so ``mo_ctc`` maps
-straight to the shared federal ``Ctc`` class rather than a subclass — the same
-treatment as ``ks_ctc``, ``tx_ctc``, and ``wa_ctc``.
+Missouri has no state CTC or state EITC and no MO-specific variance, so
+``mo_ctc`` and ``mo_eitc`` map straight to the shared federal ``Ctc`` and
+``Eitc`` classes rather than subclasses — the same treatment as ``ks_ctc``,
+``tx_ctc``/``tx_eitc``, and ``wa_ctc``/``wa_eitc``.
 
 That makes registration the only MO-side fact to pin, and one part of it is
 load-bearing: ``mo_tax_unit_calculators`` must be spread into the global
@@ -21,7 +22,7 @@ asserted once in ``programs/programs/federal/pe/tests/test_tax.py``. Proving
 
 from django.test import TestCase
 
-from programs.programs.federal.pe.tax import Ctc
+from programs.programs.federal.pe.tax import Ctc, Eitc
 from programs.programs.mo.pe import mo_pe_calculators, mo_tax_unit_calculators
 from programs.programs.policyengine.calculators.registry import (
     all_calculators,
@@ -41,3 +42,17 @@ class TestMoCtcWiring(TestCase):
     def test_matches_builtin_federal_registry_key(self):
         """Same calculator the federal registry serves as ``ctc`` — no MO subclass."""
         self.assertIs(all_tax_unit_calculators["mo_ctc"], all_tax_unit_calculators["ctc"])
+
+
+class TestMoEitcWiring(TestCase):
+    """mo_eitc registration against the shared federal Eitc calculator."""
+
+    def test_is_federal_eitc_everywhere(self):
+        self.assertIs(mo_tax_unit_calculators["mo_eitc"], Eitc)
+        self.assertIs(mo_pe_calculators["mo_eitc"], Eitc)
+        self.assertIs(all_tax_unit_calculators["mo_eitc"], Eitc)
+        self.assertIs(all_calculators["mo_eitc"], Eitc)
+
+    def test_matches_builtin_federal_registry_key(self):
+        """Same calculator the federal registry serves as ``eitc`` — no MO subclass."""
+        self.assertIs(all_tax_unit_calculators["mo_eitc"], all_tax_unit_calculators["eitc"])

--- a/programs/programs/tx/pe/__init__.py
+++ b/programs/programs/tx/pe/__init__.py
@@ -1,4 +1,4 @@
-from programs.programs.federal.pe.tax import Ctc
+from programs.programs.federal.pe.tax import Ctc, Eitc
 import programs.programs.tx.pe.member as member
 import programs.programs.tx.pe.spm as spm
 import programs.programs.tx.pe.tax as tax
@@ -21,7 +21,7 @@ tx_member_calculators = {
 }
 
 tx_tax_unit_calculators = {
-    "tx_eitc": tax.TxEitc,
+    "tx_eitc": Eitc,
     "tx_ctc": Ctc,
     "tx_aca": tax.TxAca,
 }

--- a/programs/programs/tx/pe/tax.py
+++ b/programs/programs/tx/pe/tax.py
@@ -1,15 +1,5 @@
-from programs.programs.federal.pe.tax import Eitc, Aca
+from programs.programs.federal.pe.tax import Aca
 import programs.programs.policyengine.calculators.dependencies as dependency
-from programs.programs.policyengine.calculators.base import PolicyEngineTaxUnitCalulator
-
-
-class TxEitc(PolicyEngineTaxUnitCalulator):
-    pe_name = "eitc"
-    pe_inputs = [
-        *Eitc.pe_inputs,
-        dependency.household.TxStateCodeDependency,
-    ]
-    pe_outputs = [dependency.tax.Eitc]
 
 
 class TxAca(Aca):

--- a/programs/programs/tx/pe/tests/test_integration.py
+++ b/programs/programs/tx/pe/tests/test_integration.py
@@ -13,7 +13,8 @@ from screener.models import Screen, HouseholdMember, WhiteLabel, Expense, Income
 from programs.programs.policyengine.policy_engine import pe_input
 from programs.programs.tx.pe.spm import TxSnap, TxLifeline, TxTanf
 from programs.programs.tx.pe.member import TxWic, TxSsi, TxCsfp, TxChip
-from programs.programs.tx.pe.tax import TxEitc, TxAca
+from programs.programs.federal.pe.tax import Eitc
+from programs.programs.tx.pe.tax import TxAca
 from programs.programs.policyengine.calculators.constants import (
     MAIN_TAX_UNIT,
     SECONDARY_TAX_UNIT,
@@ -468,11 +469,15 @@ class TestTxChipPeInput(TxPeInputTestBase):
 
 
 class TestTxEitcPeInput(TxPeInputTestBase):
-    """Tests for TxEitc calculator pe_input dependencies."""
+    """Tests for the tx_eitc calculator's pe_input dependencies.
+
+    tx_eitc is the shared federal ``Eitc`` class, so this exercises the federal
+    calculator against a TX screen.
+    """
 
     def test_includes_all_pe_input_fields(self):
-        """Test that pe_input includes all TxEitc pe_inputs dependencies."""
-        result = pe_input(self.screen, [TxEitc])
+        """Test that pe_input includes all Eitc pe_inputs dependencies."""
+        result = pe_input(self.screen, [Eitc])
         household = result["household"]
         tax_units = household["tax_units"]
         people = household["people"]
@@ -501,8 +506,8 @@ class TestTxEitcPeInput(TxPeInputTestBase):
             self.assertIn(field, people[head_id])
 
     def test_includes_pe_output_field(self):
-        """Test that pe_input includes TxEitc pe_outputs."""
-        result = pe_input(self.screen, [TxEitc])
+        """Test that pe_input includes Eitc pe_outputs."""
+        result = pe_input(self.screen, [Eitc])
         tax_units = result["household"]["tax_units"]
 
         self.assertIn(MAIN_TAX_UNIT, tax_units)
@@ -510,7 +515,7 @@ class TestTxEitcPeInput(TxPeInputTestBase):
 
     def test_tax_unit_relationships_are_correct(self):
         """Test that tax unit relationships are correctly set."""
-        result = pe_input(self.screen, [TxEitc])
+        result = pe_input(self.screen, [Eitc])
         people = result["household"]["people"]
 
         spouse_id = str(self.spouse.id)
@@ -525,7 +530,7 @@ class TestTxEitcPeInput(TxPeInputTestBase):
             self.assertTrue(people[child_id]["is_tax_unit_dependent"][period_key])
 
     def test_with_single_parent(self):
-        """Test that TxEitc handles single parent households correctly."""
+        """Test that Eitc handles single parent households correctly."""
         single_parent_screen = Screen.objects.create(
             white_label=self.white_label,
             zipcode="78701",
@@ -551,7 +556,7 @@ class TestTxEitcPeInput(TxPeInputTestBase):
             age=3,
         )
 
-        result = pe_input(single_parent_screen, [TxEitc])
+        result = pe_input(single_parent_screen, [Eitc])
         tax_units = result["household"]["tax_units"]
 
         self.assertIn(MAIN_TAX_UNIT, tax_units)
@@ -647,13 +652,13 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
         self.assertIn("snap", spm_unit)
 
     def test_eitc_and_snap_combined(self):
-        """Test that pe_input handles both TxEitc and TxSnap together."""
-        result = pe_input(self.screen, [TxEitc, TxSnap])
+        """Test that pe_input handles both Eitc and TxSnap together."""
+        result = pe_input(self.screen, [Eitc, TxSnap])
         household = result["household"]
         spm_unit = household["spm_units"]["spm_unit"]
         tax_units = household["tax_units"]
 
-        # TxEitc fields
+        # Eitc fields
         self.assertIn(MAIN_TAX_UNIT, tax_units)
         self.assertIn("eitc", tax_units[MAIN_TAX_UNIT])
 
@@ -704,7 +709,7 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
 
     def test_all_state_codes_match(self):
         """Test that state_code is TX regardless of which calculator is used."""
-        calculators = [TxSnap, TxWic, TxEitc, TxSsi, TxTanf, TxChip, TxAca]
+        calculators = [TxSnap, TxWic, Eitc, TxSsi, TxTanf, TxChip, TxAca]
 
         for calc in calculators:
             result = pe_input(self.screen, [calc])

--- a/programs/programs/tx/pe/tests/test_tax.py
+++ b/programs/programs/tx/pe/tests/test_tax.py
@@ -1,10 +1,13 @@
 """
 Unit tests for TX Tax Unit PolicyEngine calculator classes.
 
-These tests verify TX-specific tax calculator logic including:
-- Calculator registration
-- TX-specific pe_inputs (TxStateCodeDependency)
-- Inheritance from federal tax calculators
+``tx_eitc`` and ``tx_ctc`` register the shared federal ``Eitc``/``Ctc`` classes
+directly — neither federal credit has state variance — so those tests only pin
+the registration. The calculators' own properties live in
+``programs/programs/federal/pe/tests/test_tax.py``.
+
+``TxAca`` is a genuine TX subclass: ACA premiums are state-rated, so it does add
+``TxStateCodeDependency`` on top of the federal inputs.
 """
 
 from django.test import TestCase
@@ -19,82 +22,31 @@ from programs.programs.policyengine.calculators.registry import (
     all_tax_unit_calculators,
 )
 from programs.programs.tx.pe import tx_pe_calculators, tx_tax_unit_calculators
-from programs.programs.tx.pe.tax import TxEitc, TxAca
+from programs.programs.tx.pe.tax import TxAca
 
 
 class TestTxEitc(TestCase):
-    """Tests for TxEitc calculator class."""
+    """tx_eitc registration against the shared federal Eitc calculator.
 
-    def test_exists_and_is_subclass_of_policy_engine_tax_unit_calculator(self):
-        """
-        Test that TxEitc calculator class exists and is registered.
+    Texas previously registered a ``TxEitc`` subclass that appended
+    ``TxStateCodeDependency`` while still targeting the federal ``eitc``
+    variable. The federal EITC reads no state variable, so that input changed no
+    output — verified against live PE 1.779.3 across six households — and the
+    subclass was removed in favor of the shared class.
 
-        This verifies the calculator has been set up in the codebase.
-        """
-        # Verify TxEitc has the expected properties
-        self.assertEqual(TxEitc.pe_name, "eitc")
-        self.assertIsNotNone(TxEitc.pe_inputs)
-        self.assertGreater(len(TxEitc.pe_inputs), 0)
-        self.assertIsNotNone(TxEitc.pe_outputs)
-        self.assertGreater(len(TxEitc.pe_outputs), 0)
+    The calculator's own properties are asserted once in
+    ``programs/programs/federal/pe/tests/test_tax.py``.
+    """
 
-    def test_is_registered_in_tx_pe_calculators(self):
-        """Test that TX EITC is registered in the calculators dictionary."""
-        # Verify tx_eitc is in the calculators dictionary
-        self.assertIn("tx_eitc", tx_pe_calculators)
+    def test_is_federal_eitc_everywhere(self):
+        self.assertIs(tx_tax_unit_calculators["tx_eitc"], Eitc)
+        self.assertIs(tx_pe_calculators["tx_eitc"], Eitc)
+        self.assertIs(all_tax_unit_calculators["tx_eitc"], Eitc)
+        self.assertIs(all_calculators["tx_eitc"], Eitc)
 
-        # Verify it points to the correct class
-        self.assertEqual(tx_pe_calculators["tx_eitc"], TxEitc)
-
-    def test_pe_inputs_includes_all_parent_inputs_plus_tx_specific(self):
-        """
-        Test that TxEitc has all expected pe_inputs from parent and TX-specific.
-
-        TxEitc should inherit all inputs from parent Eitc class plus add
-        TX-specific dependencies like TxStateCodeDependency.
-        """
-        # TxEitc should have all parent inputs plus TxStateCodeDependency
-        self.assertGreater(len(TxEitc.pe_inputs), len(Eitc.pe_inputs))
-
-        # Verify TxStateCodeDependency is in the list
-        self.assertIn(household.TxStateCodeDependency, TxEitc.pe_inputs)
-
-        # Verify all parent inputs are present
-        for parent_input in Eitc.pe_inputs:
-            self.assertIn(parent_input, TxEitc.pe_inputs)
-
-    def test_pe_inputs_includes_tx_state_code_dependency(self):
-        """
-        Test that TxStateCodeDependency is properly added to TX EITC inputs.
-
-        This is the key TX-specific dependency that sets state_code="TX" for
-        PolicyEngine calculations.
-        """
-        # Verify TxStateCodeDependency is in pe_inputs
-        self.assertIn(TxStateCodeDependency, TxEitc.pe_inputs)
-
-        # Verify it's configured correctly
-        self.assertEqual(TxStateCodeDependency.state, "TX")
-        self.assertEqual(TxStateCodeDependency.field, "state_code")
-
-    def test_pe_name_matches_federal_eitc(self):
-        """
-        Test that TxEitc uses the same pe_name as federal EITC.
-
-        Since this is the federal EITC program for Texas residents,
-        it should use the same PolicyEngine name as the federal calculator.
-        """
-        self.assertEqual(TxEitc.pe_name, "eitc")
-        self.assertEqual(TxEitc.pe_name, Eitc.pe_name)
-
-    def test_pe_outputs_matches_federal_eitc(self):
-        """
-        Test that TxEitc uses the same pe_outputs as federal EITC.
-
-        The outputs should be the same since this is calculating
-        the federal EITC benefit amount.
-        """
-        self.assertEqual(TxEitc.pe_outputs, Eitc.pe_outputs)
+    def test_matches_builtin_federal_registry_key(self):
+        """Same calculator the federal registry serves as ``eitc`` — no TX subclass."""
+        self.assertIs(all_tax_unit_calculators["tx_eitc"], all_tax_unit_calculators["eitc"])
 
 
 class TestTxCtc(TestCase):

--- a/programs/programs/tx/pe/tests/test_tax.py
+++ b/programs/programs/tx/pe/tests/test_tax.py
@@ -28,13 +28,8 @@ from programs.programs.tx.pe.tax import TxAca
 class TestTxEitc(TestCase):
     """tx_eitc registration against the shared federal Eitc calculator.
 
-    Texas previously registered a ``TxEitc`` subclass that appended
-    ``TxStateCodeDependency`` while still targeting the federal ``eitc``
-    variable. The federal EITC reads no state variable, so that input changed no
-    output — verified against live PE 1.779.3 across six households — and the
-    subclass was removed in favor of the shared class.
-
-    The calculator's own properties are asserted once in
+    The federal EITC has no Texas variance, so the slug maps to the shared class
+    with no TX subclass. Its own properties are asserted once in
     ``programs/programs/federal/pe/tests/test_tax.py``.
     """
 
@@ -52,13 +47,9 @@ class TestTxEitc(TestCase):
 class TestTxCtc(TestCase):
     """tx_ctc registration against the shared federal Ctc calculator.
 
-    Texas previously registered a ``TxCtc`` subclass that appended
-    ``TxStateCodeDependency``. The federal CTC reads no state variable, so that
-    input changed no output — verified against live PE 1.779.3 across eight
-    households — and the subclass was removed in favor of the shared class.
-
-    The calculator's own properties (``pe_name``, ``pe_outputs``, the input set,
-    and the absence of a state code) are asserted once in
+    The federal CTC has no Texas variance, so the slug maps to the shared class
+    with no TX subclass. Its own properties (``pe_name``, ``pe_outputs``, the input
+    set, and the absence of a state code) are asserted once in
     ``programs/programs/federal/pe/tests/test_tax.py``.
     """
 

--- a/programs/programs/wa/pe/__init__.py
+++ b/programs/programs/wa/pe/__init__.py
@@ -1,4 +1,4 @@
-from programs.programs.federal.pe.tax import Ctc
+from programs.programs.federal.pe.tax import Ctc, Eitc
 import programs.programs.wa.pe.member as member
 import programs.programs.wa.pe.spm as spm
 import programs.programs.wa.pe.tax as tax
@@ -18,7 +18,7 @@ wa_spm_calculators = {
 
 wa_tax_calculators = {
     "wa_ctc": Ctc,
-    "wa_eitc": tax.WaEitc,
+    "wa_eitc": Eitc,
     "wa_wftc": tax.WaWftc,
 }
 

--- a/programs/programs/wa/pe/tax.py
+++ b/programs/programs/wa/pe/tax.py
@@ -3,15 +3,6 @@ from programs.programs.policyengine.calculators.base import PolicyEngineTaxUnitC
 import programs.programs.policyengine.calculators.dependencies as dependency
 
 
-class WaEitc(PolicyEngineTaxUnitCalulator):
-    pe_name = "eitc"
-    pe_inputs = [
-        *Eitc.pe_inputs,
-        dependency.household.WaStateCodeDependency,
-    ]
-    pe_outputs = [dependency.tax.Eitc]
-
-
 class WaWftc(PolicyEngineTaxUnitCalulator):
     """
     Washington Working Families Tax Credit — state EITC piggyback.

--- a/programs/programs/wa/pe/tests/test_tax.py
+++ b/programs/programs/wa/pe/tests/test_tax.py
@@ -2,12 +2,14 @@
 Unit tests for WA tax-level PolicyEngine calculator classes.
 
 These tests verify WA-specific calculator wiring including:
-- `wa_ctc` aliases the federal Child Tax Credit class (`programs.programs.federal.pe.tax.Ctc`)
-  with no WA-specific wrapper
+- `wa_ctc` and `wa_eitc` alias the federal `Ctc`/`Eitc` classes with no WA-specific
+  wrapper; their own properties are asserted in
+  `programs/programs/federal/pe/tests/test_tax.py`
 - WaWftc calculator registration (in wa_pe_calculators, wa_tax_calculators,
   and the global PE tax-unit registry)
-- WA-specific pe_inputs (`WaStateCodeDependency`) on `WaEitc`/`WaWftc` only;
-  federal `Eitc` inputs are inherited by those classes
+- WA-specific pe_inputs (`WaStateCodeDependency`) on `WaWftc` only — it targets the
+  *state* `wa_working_families_tax_credit` variable; the two federal aliases send
+  no state code
 
 The eligibility math itself (federal EITC phase-in/phase-out, MFJ adjustments,
 investment-income cap, the 25-64 age floor for childless filers, qualifying-
@@ -29,55 +31,31 @@ from programs.programs.policyengine.calculators.registry import (
     all_tax_unit_calculators,
 )
 from programs.programs.wa.pe import wa_pe_calculators, wa_tax_calculators
-from programs.programs.wa.pe.tax import WaEitc, WaWftc
+from programs.programs.wa.pe.tax import WaWftc
 
 
 class TestWaEitc(TestCase):
-    """Tests for WaEitc calculator class wiring."""
+    """`wa_eitc` reuses the federal Eitc calculator unchanged (same class object).
 
-    def test_exists_and_is_subclass_of_policy_engine_tax_unit_calculator(self):
-        """WaEitc is a `PolicyEngineTaxUnitCalulator` (lives in the tax-unit entity)."""
-        self.assertTrue(issubclass(WaEitc, PolicyEngineTaxUnitCalulator))
+    Washington previously registered a `WaEitc` subclass that appended
+    `WaStateCodeDependency` while still targeting the federal `eitc` variable. The
+    federal EITC reads no state variable, so that input changed no output and the
+    subclass was removed. Contrast `WaWftc` below, which targets the *state*
+    `wa_working_families_tax_credit` variable and genuinely needs the state code.
 
-    def test_pe_name_targets_eitc(self):
-        """`pe_name` resolves to PolicyEngine's `eitc` variable."""
-        self.assertEqual(WaEitc.pe_name, "eitc")
+    The calculator's own properties are asserted once in
+    `programs/programs/federal/pe/tests/test_tax.py`.
+    """
 
-    def test_is_registered_in_wa_pe_calculators(self):
-        """WaEitc is registered in the WA PE calculators dictionary as `wa_eitc`."""
-        self.assertIn("wa_eitc", wa_pe_calculators)
-        self.assertEqual(wa_pe_calculators["wa_eitc"], WaEitc)
+    def test_is_federal_eitc_everywhere(self):
+        self.assertIs(wa_tax_calculators["wa_eitc"], Eitc)
+        self.assertIs(wa_pe_calculators["wa_eitc"], Eitc)
+        self.assertIs(all_tax_unit_calculators["wa_eitc"], Eitc)
+        self.assertIs(all_calculators["wa_eitc"], Eitc)
 
-    def test_is_registered_in_wa_tax_calculators(self):
-        """WaEitc is registered in the WA tax-unit subset (not member/SPM)."""
-        self.assertIn("wa_eitc", wa_tax_calculators)
-        self.assertEqual(wa_tax_calculators["wa_eitc"], WaEitc)
-
-    def test_is_registered_in_global_tax_unit_registry(self):
-        """WaEitc flows up into the global PE tax-unit registry (so the engine sees it)."""
-        self.assertIn("wa_eitc", all_tax_unit_calculators)
-        self.assertEqual(all_tax_unit_calculators["wa_eitc"], WaEitc)
-
-    def test_pe_inputs_includes_wa_state_code_dependency(self):
-        """The WA state code is added on top of the federal Eitc inputs."""
-        self.assertIn(WaStateCodeDependency, WaEitc.pe_inputs)
-
-    def test_pe_inputs_includes_all_federal_eitc_inputs(self):
-        """All federal Eitc inputs flow through to WaEitc unchanged."""
-        for parent_input in Eitc.pe_inputs:
-            self.assertIn(parent_input, WaEitc.pe_inputs)
-
-    def test_pe_inputs_adds_exactly_one_dependency_to_eitc(self):
-        """WaEitc adds exactly one input on top of federal Eitc (the WA state code)."""
-        self.assertEqual(len(WaEitc.pe_inputs), len(Eitc.pe_inputs) + 1)
-
-    def test_pe_outputs_is_eitc(self):
-        """Output is the federal EITC dollar value."""
-        self.assertEqual(WaEitc.pe_outputs, [tax_dependency.Eitc])
-
-    def test_eitc_tax_dependency_targets_correct_field(self):
-        """The Eitc tax dependency points at PE's `eitc` field."""
-        self.assertEqual(tax_dependency.Eitc.field, "eitc")
+    def test_matches_builtin_federal_registry_key(self):
+        """Same calculator as global `eitc` — no WA-specific subclass."""
+        self.assertIs(all_tax_unit_calculators["wa_eitc"], all_tax_unit_calculators["eitc"])
 
 
 class TestWaCtc(TestCase):

--- a/programs/programs/wa/pe/tests/test_tax.py
+++ b/programs/programs/wa/pe/tests/test_tax.py
@@ -37,11 +37,9 @@ from programs.programs.wa.pe.tax import WaWftc
 class TestWaEitc(TestCase):
     """`wa_eitc` reuses the federal Eitc calculator unchanged (same class object).
 
-    Washington previously registered a `WaEitc` subclass that appended
-    `WaStateCodeDependency` while still targeting the federal `eitc` variable. The
-    federal EITC reads no state variable, so that input changed no output and the
-    subclass was removed. Contrast `WaWftc` below, which targets the *state*
-    `wa_working_families_tax_credit` variable and genuinely needs the state code.
+    The federal EITC reads no state variable, so there is no WA subclass and no
+    state code. Contrast `WaWftc` below, which targets the *state*
+    `wa_working_families_tax_credit` variable and does need the state code.
 
     The calculator's own properties are asserted once in
     `programs/programs/federal/pe/tests/test_tax.py`.


### PR DESCRIPTION
## Context & Motivation

Adds the Federal Earned Income Tax Credit to the Missouri white label, and applies the same shared-federal-class audit to EITC that [#1675](https://github.com/MyFriendBen/benefits-api/pull/1675) applied to CTC.

- Linear ticket: [MFB-1209](https://linear.app/myfriendben/issue/MFB-1209/program-mo-earned-income-tax-credit-eitc-federal)
- Discovery: [MFB-1264](https://linear.app/myfriendben/issue/MFB-1264/discovery-mo-earned-income-tax-credit-eitc-federal) (Done)

Discovery decision: **Engine PE / Tier Fed (as-is) / Δ for MO: None.**

## Changes Made

**The program:**
- `mo_eitc_initial_config.json` — category `mo_tax`, `base_program: eitc`, 5 documents, 2 navigators.
- `mo_eitc` registered against the shared federal `Eitc` class in `mo_tax_unit_calculators`.

**The audit — `TxEitc` and `WaEitc` were redundant:**

Both re-declared `pe_name = "eitc"` and `pe_outputs = [dependency.tax.Eitc]` identically to the federal `Eitc`, adding only their state code. But the federal EITC has no state term — there is no `state_code` reference anywhere under PolicyEngine's `gov/irs/credits/earned_income` variable tree.

Verified against live PE 1.779.3 on the **tx** white label across six households:

| Scenario | TxEitc | federal Eitc |
|---|---|---|
| 1 child age 5, $20k, single | $4,328 | $4,328 |
| 2 children 4 & 8, $30k, married | $7,152 | $7,152 |
| No children, $12k, single | $543 | $543 |
| No children, $0 income | $0 | $0 |
| 3 children, $45k, married | $4,985 | $4,985 |
| 1 child, $60k single (phase-out) | $0 | $0 |

`WaEitc` was byte-identical to `TxEitc` modulo the state code, so it falls to the same finding. Both subclasses removed; `tx_eitc` and `wa_eitc` now register `Eitc` directly.

**Test consolidation** — shared-class assertions moved up to `TestFederalEitc` (mirroring `TestFederalCtc`), including the generic no-state-code guard. Each state keeps the same two-test registration pair now used for CTC.

## Testing

- Migrations to run: none
- Configuration updates needed: `python manage.py import_program_config programs/management/commands/import_program_config_data/data/mo_eitc_initial_config.json`

`mo_eitc` verified end-to-end against live PE 1.779.3:

| Scenario | Eligible | Value |
|---|---|---|
| 1 child age 5, $20k wages, single | ✅ | $4,427.00 |
| 2 children 4 & 8, $30k, married | ✅ | $7,316.00 |
| 3 children, $25k, single | ✅ | $7,997.00 |
| No children, $12k, single age 35 | ✅ | $576.00 |
| No children, $12k, single age 22 | ❌ | $0.00 |
| No children, $0 income | ❌ | $0.00 |
| 1 child, $60k single (phase-out) | ❌ | $0.00 |

Full suite: **2590 tests, OK** (17 pre-existing skips). `black --check` clean.

## Deployment

- Post-deployment scripts needed: run `import_program_config` with the new JSON.
- Production config updates: program imports **inactive** (`active` deliberately absent, matching every other MO config). Flip `active = True` after QA.
- Admin updates needed: none — copy auto-translated to 18 languages at import.

## Notes for Reviewers

- **`WaWftc` keeps its state code and is untouched.** It targets the *state* `wa_working_families_tax_credit` variable, so the state code is load-bearing there. Same for `co_eitc`, `il_eitc`, `ks_total_eitc`, and `ma_eitc` — genuine state credits under `gov/states/`. Only the two subclasses pointing at the *federal* `eitc` variable were redundant.
- **The age-22 row is the 25–64 childless-filer floor working**, not a bug.
- Two deviations from the discovery config, both verified: dropped `value_type` (removed from the model in migration `0163_drop_program_value_type`; the importer warns on it), and added `tax_category: true` to the `mo_tax` category block for consistency with `mo_ctc`.
- Discovery flagged a possible PE defect: `eitc_age_eligible` uses `tax_unit.any()` over all members rather than filer/spouse only. Not addressed here — it's an upstream engine question affecting TX and WA equally, already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Missouri Child Tax Credit configuration for 2026, including eligibility details, required documents, and tax-assistance resources.
  * Added Missouri support for the federal Child Tax Credit calculator.
  * Standardized Kansas, Texas, and Washington Child Tax Credit references with the shared federal calculator.

* **Tests**
  * Expanded coverage to verify Child Tax Credit registration and cross-state calculator consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->