### PR TITLE
KS SNAP: qualify navigator counties with the "County" suffix

### DIFF
--- a/programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_snap_initial_config.json
@@ -83,7 +83,15 @@
       "phone_number": "+13162836743",
       "description": "Helps Kansas residents in the Wichita and KC areas apply for Food Assistance and understand their eligibility.",
       "assistance_link": "https://www.dcf.ks.gov/services/ees/pages/Food-Assistance-Application-Assistance-(SNAP-Outreach).aspx",
-      "counties": ["Johnson", "Shawnee", "Harvey", "Sedgwick", "Douglas", "Barber", "Harper"]
+      "counties": [
+        "Johnson County",
+        "Shawnee County",
+        "Harvey County",
+        "Sedgwick County",
+        "Douglas County",
+        "Barber County",
+        "Harper County"
+      ]
     },
     {
       "external_name": "ks_harvesters",
@@ -92,7 +100,25 @@
       "phone_number": "+18776539522",
       "description": "Helps Kansas City-area Kansas residents apply for Food Assistance by phone — no need to visit a government office.",
       "assistance_link": "https://www.harvesters.org/get-food-assistance/snap-assistance",
-      "counties": ["Washington", "Marshall", "Nemaha", "Clay", "Riley", "Pottawatomie", "Jackson", "Jefferson", "Shawnee", "Wabaunsee", "Douglas", "Johnson", "Leavenworth", "Wyandotte", "Osage", "Franklin", "Miami"]
+      "counties": [
+        "Washington County",
+        "Marshall County",
+        "Nemaha County",
+        "Clay County",
+        "Riley County",
+        "Pottawatomie County",
+        "Jackson County",
+        "Jefferson County",
+        "Shawnee County",
+        "Wabaunsee County",
+        "Douglas County",
+        "Johnson County",
+        "Leavenworth County",
+        "Wyandotte County",
+        "Osage County",
+        "Franklin County",
+        "Miami County"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the `County` suffix to all 24 county entries across the two navigators in `ks_snap_initial_config.json` (`ks_mirror_inc`, `ks_harvesters`). Values only — no other keys change.

## Why

The results endpoint filters navigators by county in `screener/views.py`:

```python
if len(counties) == 0 or (county is not None and any(county in c.name for c in counties)):
```

The test is `Screen.county in navigator_county.name`. Kansas always writes county as `"<Name> County"` (see `configuration/white_labels/ks.py`, e.g. `"66732": {"Allen County": "Allen County"}`), so the seeded bare name `"Sedgwick"` can never contain `"Sedgwick County"`. Every KS SNAP navigator was filtered out, in every county, for every user — the "Get Help Applying" section rendered empty.

Verified in prod: after correcting the county values, `Mirror Inc.` renders on the KS SNAP results card with website, email, and phone.

## Scope

These configs seed data rather than update it, so this does not change prod — KS SNAP is already seeded and has been corrected directly. The value here is the artifact itself: these files get copied between states when standing up a new white label (KS SNAP was built by copying another state's SNAP config), so leaving the bare names in place propagates the bug to the next state.

`ks_snap_initial_config.json` was the only KS config with bare county names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigator county values to use complete county names, including the “County” suffix, for improved accuracy in Mirror Inc. and Harvesters configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->