### PR TITLE
Add IL Head Start (MFB-263) + consolidate Head Start wiring tests + fix reported-SNAP categorical eligibility

### DIFF
--- a/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
@@ -17,11 +17,11 @@
       "non_citizen"
     ],
     "name": "Head Start",
-    "description": "Head Start is a free preschool program for eligible children ages 3 to 5. It provides early learning, meals, health and dental screenings, and support for families. These services help children prepare for school.\n\nLocal organizations provide Head Start services in communities across Illinois. The value shown is an estimate of these services, not cash paid to your family. Each program serves a local area. Families with the greatest needs get priority, and there may be a waiting list.\n\nChildren experiencing homelessness qualify for Head Start regardless of family income. Some local programs can also enroll a limited number of children from families with higher incomes. Even if you don’t see eligibility in your results, contact a local program to ask about your options.\n\nSelect “Find your local Head Start agency” to find a nearby program and start the application process.",
+    "description": "Head Start is a free preschool program for eligible children ages 3 to 5. It provides early learning, meals, health and dental screenings, and support for families. These services help children prepare for school.\n\nLocal organizations provide Head Start services in communities across Illinois. The value shown is an estimate of these services, not cash paid to your family. Each program serves a local area. Families with the greatest needs get priority, and there may be a waiting list.\n\nChildren experiencing homelessness or in foster care qualify for Head Start regardless of family income. Some local programs can also enroll a limited number of children from families with higher incomes.\n\nSelect “Find your local agency” to find a nearby program and start the application process.",
     "description_short": "Free preschool, meals, and health services for eligible children ages 3 to 5",
     "learn_more_link": "https://headstart.gov/publication/discover-what-head-start-programs-offer",
     "apply_button_link": "https://headstart.gov/center-locator?state=IL&radius=50",
-    "apply_button_description": "Find your local Head Start agency",
+    "apply_button_description": "Find your local agency",
     "estimated_application_time": "30 - 60 minutes",
     "estimated_delivery_time": "",
     "estimated_value": "",

--- a/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
@@ -25,7 +25,7 @@
     "estimated_application_time": "30 - 60 minutes",
     "estimated_delivery_time": "",
     "estimated_value": "",
-    "value_format": "estimated_annual",
+    "value_format": null,
     "website_description": "Free preschool, meals, and health services for eligible children ages 3 to 5",
     "base_program": "head_start",
     "show_on_current_benefits": true,

--- a/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
@@ -26,7 +26,6 @@
     "estimated_delivery_time": "",
     "estimated_value": "",
     "value_format": "estimated_annual",
-    "value_type": "benefit",
     "website_description": "Free preschool, meals, and health services for eligible children ages 3 to 5",
     "base_program": "head_start",
     "show_on_current_benefits": true,

--- a/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
@@ -1,0 +1,107 @@
+{
+  "white_label": {
+    "code": "il"
+  },
+  "program_category": {
+    "external_name": "il_child_care"
+  },
+  "program": {
+    "name_abbreviated": "il_head_start",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission",
+      "non_citizen"
+    ],
+    "name": "Head Start",
+    "description": "Head Start is a free preschool program for eligible children ages 3 to 5. It provides early learning, meals, health and dental screenings, and support for families. These services help children prepare for school.\n\nLocal organizations provide Head Start services in communities across Illinois. The value shown is an estimate of these services, not cash paid to your family. Each program serves a local area. Families with the greatest needs get priority, and there may be a waiting list.\n\nChildren experiencing homelessness qualify for Head Start regardless of family income. Some local programs can also enroll a limited number of children from families with higher incomes. Even if you don’t see eligibility in your results, contact a local program to ask about your options.\n\nSelect “Find your local Head Start agency” to find a nearby program and start the application process.",
+    "description_short": "Free preschool, meals, and health services for eligible children ages 3 to 5",
+    "learn_more_link": "https://headstart.gov/publication/discover-what-head-start-programs-offer",
+    "apply_button_link": "https://headstart.gov/center-locator?state=IL&radius=50",
+    "apply_button_description": "Find your local Head Start agency",
+    "estimated_application_time": "30 - 60 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_format": "estimated_annual",
+    "value_type": "benefit",
+    "website_description": "Free preschool, meals, and health services for eligible children ages 3 to 5",
+    "base_program": "head_start",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": true
+  },
+  "documents": [
+    {
+      "external_name": "il_home",
+      "text": "Proof of home address (ex: lease, utility bill, mail with your address)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "earned_income",
+      "text": "Proof of household income (ex: pay stubs, tax return, benefit award letter)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "il_benefit_proof",
+      "text": "Proof of SNAP, TANF, or SSI benefits, if requested",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "il_birth_certificate",
+      "text": "Child's birth certificate or proof of age, if requested",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "il_immunization_records",
+      "text": "Child's immunization (shot) records, if requested",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "il_unearned_income",
+      "text": "Proof of unearned income (ex: child support, social security, unemployment)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "il_foster_care",
+      "text": "Proof your child is in foster care, if requested",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "il_homelessness_verification",
+      "text": "A statement or other proof of your child's living situation, if requested",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "headstart_national_hotline",
+      "name": "Office of Head Start National Hotline",
+      "email": "HeadStart@eclkc.info",
+      "description": "The national Office of Head Start contact center. Can answer general questions about Head Start and help you find a program in your area.",
+      "assistance_link": "https://headstart.gov/how-apply",
+      "phone_number": "+18667636481",
+      "languages": ["english", "spanish"]
+    },
+    {
+      "external_name": "il_chicago_early_learning_hotline",
+      "name": "Chicago Early Learning Family Support Hotline",
+      "email": "",
+      "description": "Helps Chicago families apply for CPS Pre-K and community-based early learning programs, including Head Start.",
+      "assistance_link": "https://www.cps.edu/ChicagoEarlyLearning/",
+      "phone_number": "+13122291690",
+      "counties": ["Cook"],
+      "languages": ["english", "spanish"]
+    }
+  ]
+}

--- a/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
@@ -30,7 +30,7 @@
     "base_program": "head_start",
     "show_on_current_benefits": true,
     "has_calculator": true,
-    "show_in_has_benefits_step": true
+    "show_in_has_benefits_step": false
   },
   "documents": [
     {

--- a/programs/programs/federal/pe/tests/test_head_start.py
+++ b/programs/programs/federal/pe/tests/test_head_start.py
@@ -49,6 +49,16 @@ class TestFederalHeadStart(TestCase):
     def test_is_a_member_calculator(self):
         self.assertTrue(issubclass(HeadStart, PolicyEngineMembersCalculator))
 
+    def test_reads_the_person_level_pe_category(self):
+        """Head Start is valued per child, so the value must be read out of
+        PolicyEngine's ``people`` bucket. A wrong ``pe_category`` looks up the
+        variable in the wrong entity and yields no value at all.
+
+        Asserted here rather than only on the base class because this is the
+        property that makes a *per-child* program work.
+        """
+        self.assertEqual(HeadStart.pe_category, "people")
+
     def test_pe_name_is_head_start(self):
         self.assertEqual(HeadStart.pe_name, "head_start")
 
@@ -91,6 +101,9 @@ class TestFederalEarlyHeadStart(TestCase):
 
     def test_is_a_member_calculator(self):
         self.assertTrue(issubclass(EarlyHeadStart, PolicyEngineMembersCalculator))
+
+    def test_reads_the_person_level_pe_category(self):
+        self.assertEqual(EarlyHeadStart.pe_category, "people")
 
     def test_pe_name_is_early_head_start(self):
         self.assertEqual(EarlyHeadStart.pe_name, "early_head_start")
@@ -162,6 +175,12 @@ class TestRegisteredHeadStartSubclassContract(TestCase):
         for slug in self.early_head_start:
             self.assertTrue(slug.endswith("early_head_start"), f"{slug} resolves EarlyHeadStart")
 
+    def test_pe_category_is_inherited_unchanged(self):
+        """Every state reads its per-child value from the ``people`` bucket."""
+        for slug, calc in self.all.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(calc.pe_category, "people")
+
     def test_pe_name_is_inherited_unchanged(self):
         for slug, calc in self.head_start.items():
             with self.subTest(slug=slug):
@@ -205,6 +224,23 @@ class TestRegisteredHeadStartSubclassContract(TestCase):
         for slug, calc in self.all.items():
             with self.subTest(slug=slug):
                 self.assertEqual(_state_codes(calc)[0].state.lower(), slug.split("_", 1)[0])
+
+    def test_adds_nothing_beyond_the_state_code(self):
+        """A subclass's inputs are exactly the federal set plus its state code. An
+        extra input is either dead weight PolicyEngine ignores or a sign the state is
+        modelling variance the ``Fed (value varies)`` tier says does not exist.
+
+        Expressed as a set difference rather than a hardcoded count so that adding a
+        federal input updates every state at once instead of failing N state tests.
+        """
+        for slug, calc in self.head_start.items():
+            with self.subTest(slug=slug):
+                extra = set(calc.pe_inputs) - set(HeadStart.pe_inputs) - set(_state_codes(calc))
+                self.assertEqual(extra, set(), f"{slug} adds {[d.__name__ for d in extra]}")
+        for slug, calc in self.early_head_start.items():
+            with self.subTest(slug=slug):
+                extra = set(calc.pe_inputs) - set(EarlyHeadStart.pe_inputs) - set(_state_codes(calc))
+                self.assertEqual(extra, set(), f"{slug} adds {[d.__name__ for d in extra]}")
 
     def test_no_subclass_overrides_member_value(self):
         """The value is PolicyEngine's per-child figure, taken as-is. A state

--- a/programs/programs/federal/pe/tests/test_head_start.py
+++ b/programs/programs/federal/pe/tests/test_head_start.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for the shared federal Head Start / Early Head Start PolicyEngine calculators.
+
+Unlike ``Ctc`` and ``Eitc`` — which states register directly because they have no
+state variance — Head Start states *subclass* ``HeadStart`` / ``EarlyHeadStart`` to
+append their own state code. PolicyEngine keys the per-child value off that code
+(``gov.hhs.head_start.spending.{STATE}`` / ``enrollment.{STATE}``), so the state code
+is the only legitimate difference between subclasses.
+
+That makes the federal wiring a cross-state contract. The tests below assert it once
+against every registered subclass rather than per state, so:
+
+* every state's Head Start is covered even where its own file has no tests, and
+* a newly added state inherits the whole contract the moment it is registered.
+
+A state file therefore only needs to prove what is genuinely state-specific: that it
+registers under the expected slug and sends its own state code (see e.g.
+``TestIlHeadStartWiring``).
+
+The eligibility math and the per-child value itself live in PolicyEngine
+(``is_head_start_eligible``, ``head_start``) and are covered by PolicyEngine's own
+test suite, not duplicated here. Each state's spec.md pins the dollar value for that
+state.
+"""
+
+from django.test import TestCase
+
+from programs.programs.federal.pe.member import EarlyHeadStart, HeadStart
+from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
+from programs.programs.policyengine.calculators.dependencies import irs_gross_income, member, spm
+from programs.programs.policyengine.calculators.dependencies.household import StateCode
+from programs.programs.policyengine.calculators.registry import all_member_calculators
+
+
+def _registered_subclasses(base: type) -> dict[str, type]:
+    """Every calculator registered under a program slug that subclasses ``base``."""
+    return {
+        slug: calc for slug, calc in all_member_calculators.items() if isinstance(calc, type) and issubclass(calc, base)
+    }
+
+
+def _state_codes(calculator: type) -> list[type]:
+    return [dep for dep in calculator.pe_inputs if isinstance(dep, type) and issubclass(dep, StateCode)]
+
+
+class TestFederalHeadStart(TestCase):
+    """Wiring of the shared federal Head Start (ages 3-5) calculator."""
+
+    def test_is_a_member_calculator(self):
+        self.assertTrue(issubclass(HeadStart, PolicyEngineMembersCalculator))
+
+    def test_pe_name_is_head_start(self):
+        self.assertEqual(HeadStart.pe_name, "head_start")
+
+    def test_pe_outputs_read_the_head_start_field(self):
+        self.assertEqual(HeadStart.pe_outputs, [member.HeadStart])
+        self.assertEqual(member.HeadStart.field, "head_start")
+
+    def test_pe_inputs_include_age_and_foster_care(self):
+        """Ages 3-5 gate eligibility; foster care is an income-independent pathway."""
+        self.assertIn(member.AgeDependency, HeadStart.pe_inputs)
+        self.assertIn(member.FosterCareDependency, HeadStart.pe_inputs)
+
+    def test_pe_inputs_include_categorical_benefit_signals(self):
+        """SNAP / TANF / SSI receipt qualifies a child regardless of income, so all
+        three must reach PolicyEngine's categorical-eligibility determination."""
+        self.assertIn(member.Ssi, HeadStart.pe_inputs)
+        self.assertIn(spm.Snap, HeadStart.pe_inputs)
+        self.assertIn(spm.Tanf, HeadStart.pe_inputs)
+
+    def test_pe_inputs_include_irs_gross_income(self):
+        """Income drives the non-categorical (at-or-below-100%-FPL) pathway."""
+        for income_input in irs_gross_income:
+            self.assertIn(income_input, HeadStart.pe_inputs)
+
+    def test_federal_class_carries_no_state_code(self):
+        """The base is state-agnostic; subclasses add exactly one state code."""
+        self.assertEqual(_state_codes(HeadStart), [])
+
+    def test_is_not_registered_directly(self):
+        """States register their own subclass, never the shared base — registering the
+        base would send no state code and so resolve no state's spending/enrollment."""
+        self.assertNotIn(HeadStart, all_member_calculators.values())
+
+    def test_does_not_reuse_the_early_head_start_variable(self):
+        self.assertNotEqual(HeadStart.pe_name, EarlyHeadStart.pe_name)
+
+
+class TestFederalEarlyHeadStart(TestCase):
+    """Wiring of the shared federal Early Head Start (birth-3, pregnant women) calculator."""
+
+    def test_is_a_member_calculator(self):
+        self.assertTrue(issubclass(EarlyHeadStart, PolicyEngineMembersCalculator))
+
+    def test_pe_name_is_early_head_start(self):
+        self.assertEqual(EarlyHeadStart.pe_name, "early_head_start")
+
+    def test_pe_outputs_read_the_early_head_start_field(self):
+        self.assertEqual(EarlyHeadStart.pe_outputs, [member.EarlyHeadStart])
+        self.assertEqual(member.EarlyHeadStart.field, "early_head_start")
+
+    def test_pe_inputs_include_age_pregnancy_and_foster_care(self):
+        """EHS serves birth-3 (age) and pregnant women (pregnancy), plus the
+        income-independent foster care pathway. Pregnancy is what distinguishes
+        these inputs from ``HeadStart``'s."""
+        self.assertIn(member.AgeDependency, EarlyHeadStart.pe_inputs)
+        self.assertIn(member.PregnancyDependency, EarlyHeadStart.pe_inputs)
+        self.assertIn(member.FosterCareDependency, EarlyHeadStart.pe_inputs)
+
+    def test_pe_inputs_include_categorical_benefit_signals(self):
+        self.assertIn(member.Ssi, EarlyHeadStart.pe_inputs)
+        self.assertIn(spm.Snap, EarlyHeadStart.pe_inputs)
+        self.assertIn(spm.Tanf, EarlyHeadStart.pe_inputs)
+
+    def test_pe_inputs_include_irs_gross_income(self):
+        for income_input in irs_gross_income:
+            self.assertIn(income_input, EarlyHeadStart.pe_inputs)
+
+    def test_federal_class_carries_no_state_code(self):
+        self.assertEqual(_state_codes(EarlyHeadStart), [])
+
+    def test_is_not_registered_directly(self):
+        self.assertNotIn(EarlyHeadStart, all_member_calculators.values())
+
+    def test_pregnancy_is_not_sent_by_plain_head_start(self):
+        """Only EHS serves pregnant women; sending pregnancy to ``head_start`` would
+        be an input its formula ignores."""
+        self.assertNotIn(member.PregnancyDependency, HeadStart.pe_inputs)
+
+
+class TestRegisteredHeadStartSubclassContract(TestCase):
+    """
+    The cross-state contract, asserted against every registered subclass of
+    ``HeadStart`` and ``EarlyHeadStart``.
+
+    These are the assertions that were previously copy-pasted into each state's
+    ``test_member.py``. Holding them here means a new state is covered as soon as it
+    is registered, and a state that quietly drops a federal input fails here rather
+    than passing because nobody wrote that state's copy of the test.
+    """
+
+    def setUp(self):
+        self.head_start = _registered_subclasses(HeadStart)
+        self.early_head_start = _registered_subclasses(EarlyHeadStart)
+        # EarlyHeadStart is a sibling of HeadStart, not a subclass, so the two
+        # groups are disjoint; assert that rather than assuming it.
+        self.assertFalse(set(self.head_start) & set(self.early_head_start))
+        self.all = {**self.head_start, **self.early_head_start}
+
+    def test_states_are_registered(self):
+        """A guard on the discovery itself: if the registry stopped exposing these,
+        every other test in this class would vacuously pass over an empty dict."""
+        self.assertGreaterEqual(len(self.head_start), 1)
+        self.assertGreaterEqual(len(self.early_head_start), 1)
+
+    def test_slug_matches_the_base_program(self):
+        """``*_early_head_start`` slugs must resolve the EHS calculator and plain
+        ``*_head_start`` slugs the HS one — the two are easy to cross-wire, and doing
+        so silently returns the wrong program's value."""
+        for slug in self.head_start:
+            self.assertFalse(slug.endswith("early_head_start"), f"{slug} resolves HeadStart")
+        for slug in self.early_head_start:
+            self.assertTrue(slug.endswith("early_head_start"), f"{slug} resolves EarlyHeadStart")
+
+    def test_pe_name_is_inherited_unchanged(self):
+        for slug, calc in self.head_start.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(calc.pe_name, "head_start")
+        for slug, calc in self.early_head_start.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(calc.pe_name, "early_head_start")
+
+    def test_pe_outputs_are_inherited_unchanged(self):
+        for slug, calc in self.head_start.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(calc.pe_outputs, [member.HeadStart])
+        for slug, calc in self.early_head_start.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(calc.pe_outputs, [member.EarlyHeadStart])
+
+    def test_no_federal_input_is_dropped(self):
+        """Subclasses only append a state code. Dropping an inherited input silently
+        changes eligibility — e.g. losing ``Snap`` would deny every household that
+        qualifies categorically rather than on income."""
+        for slug, calc in self.head_start.items():
+            with self.subTest(slug=slug):
+                for dep in HeadStart.pe_inputs:
+                    self.assertIn(dep, calc.pe_inputs, f"{slug} dropped {dep.__name__}")
+        for slug, calc in self.early_head_start.items():
+            with self.subTest(slug=slug):
+                for dep in EarlyHeadStart.pe_inputs:
+                    self.assertIn(dep, calc.pe_inputs, f"{slug} dropped {dep.__name__}")
+
+    def test_sends_exactly_one_state_code(self):
+        """The state code selects the state's spending/enrollment parameters. Sending
+        none leaves the value unresolved; sending two is ambiguous."""
+        for slug, calc in self.all.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(len(_state_codes(calc)), 1, f"{slug} state codes: {_state_codes(calc)}")
+
+    def test_state_code_matches_the_slug(self):
+        """Guards the copy-paste failure this pattern invites: a new state cloned from
+        another and left sending the source state's code would resolve the wrong
+        state's per-child value while looking correctly registered."""
+        for slug, calc in self.all.items():
+            with self.subTest(slug=slug):
+                self.assertEqual(_state_codes(calc)[0].state.lower(), slug.split("_", 1)[0])
+
+    def test_no_subclass_overrides_member_value(self):
+        """The value is PolicyEngine's per-child figure, taken as-is. A state
+        overriding ``member_value`` would be introducing state variance that the
+        ``Fed (value varies)`` tier says does not exist — and that its spec's dollar
+        scenarios would not catch, since they assert the PE value.
+        """
+        for slug, calc in self.all.items():
+            with self.subTest(slug=slug):
+                self.assertIs(
+                    calc.member_value,
+                    PolicyEngineMembersCalculator.member_value,
+                    f"{slug} overrides member_value",
+                )

--- a/programs/programs/il/head_start/spec.md
+++ b/programs/programs/il/head_start/spec.md
@@ -61,6 +61,8 @@ This is an estimated annual value of Head Start services, not cash paid to the h
 
 > Each eligible scenario asserts the expected **dollar value** ($17,227 per eligible child), so a scenario breaks if PolicyEngine's Illinois spending/enrollment parameters drift. Ineligible scenarios carry no value.
 
+**Reference date: 2026-08-06.** The parenthesised ages below are derived from the birth month/year as of that date. Enter the birth month/year, not the age — the birth dates are what matter, and the age labels go stale as the date moves. Only the children's ages are load-bearing (the 3–5 window and the age-7 exclusion); adult ages are incidental.
+
 All six verified locally against live PolicyEngine (model 1.784.3), 6/6 matching:
 
 | # | Scenario | Expected | Result |
@@ -81,7 +83,7 @@ All six verified locally against live PolicyEngine (model 1.784.3), 6/6 matching
 - **Household**: Number of people: `3`
 - **Person 1 (Head of Household)**: Birth month/year `March 1996` (age 30), Relationship `Head of Household`, Has income `Yes`, Employment income `$1,500`/month, Citizenship `U.S. Citizen`
 - **Person 2 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
-- **Person 3 (Spouse)**: Birth month/year `July 2000` (age 25), Relationship `Spouse`, Has income `No`
+- **Person 3 (Spouse)**: Birth month/year `July 2000` (age 26), Relationship `Spouse`, Has income `No`
 - **Current Benefits**: none
 
 **Why this matters**: The most common Head Start pathway. At $1,500/month ($18,000/year) for a household of 3, income is below 100% FPL.
@@ -126,12 +128,12 @@ All six verified locally against live PolicyEngine (model 1.784.3), 6/6 matching
 **Steps**:
 - **Location**: ZIP code `60629`, county `Cook`
 - **Household**: Number of people: `3`
-- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$4,167`/month ($50,000/year), Citizenship `U.S. Citizen`
-- **Person 2 (Spouse)**: Birth month/year `June 1992` (age 33), Relationship `Spouse`, Has income `No`
+- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$4,167`/month ($50,004/year), Citizenship `U.S. Citizen`
+- **Person 2 (Spouse)**: Birth month/year `June 1992` (age 34), Relationship `Spouse`, Has income `No`
 - **Person 3 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
 - **Current Benefits**: `SNAP`
 
-**Why this matters**: Validates that SNAP categorical eligibility independently qualifies a family regardless of income — a distinct code branch from Scenario 1. The same logic applies to TANF and SSI. The $50,000 figure is a test input chosen to clear the income limit, not Head Start's official threshold.
+**Why this matters**: Validates that SNAP categorical eligibility independently qualifies a family regardless of income — a distinct code branch from Scenario 1. The same logic applies to TANF and SSI. The $50,004 figure is a test input chosen to clear the income limit, not Head Start's official threshold.
 
 Reaching this branch required fixing the `Snap` PE input dependency, which gated on `screen.has_benefit("snap")` — an exact match on a bare name no white label uses, so reported SNAP never reached PolicyEngine. It now reads `has_base_benefit("snap")`, matching the sibling `Tanf` dependency. KS shipped its Head Start with this scenario documented as a known limitation; it is now fixed for every state.
 
@@ -144,8 +146,8 @@ Reaching this branch required fixing the `Snap` PE input dependency, which gated
 **Steps**:
 - **Location**: ZIP code `60629`, county `Cook`
 - **Household**: Number of people: `3`
-- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$4,167`/month ($50,000/year), Citizenship `U.S. Citizen`
-- **Person 2 (Spouse)**: Birth month/year `June 1992` (age 33), Relationship `Spouse`, Has income `No`
+- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$4,167`/month ($50,004/year), Citizenship `U.S. Citizen`
+- **Person 2 (Spouse)**: Birth month/year `June 1992` (age 34), Relationship `Spouse`, Has income `No`
 - **Person 3 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
 - **Current Benefits**: none
 

--- a/programs/programs/il/head_start/spec.md
+++ b/programs/programs/il/head_start/spec.md
@@ -61,6 +61,17 @@ This is an estimated annual value of Head Start services, not cash paid to the h
 
 > Each eligible scenario asserts the expected **dollar value** ($17,227 per eligible child), so a scenario breaks if PolicyEngine's Illinois spending/enrollment parameters drift. Ineligible scenarios carry no value.
 
+All six verified locally against live PolicyEngine (model 1.784.3), 6/6 matching:
+
+| # | Scenario | Expected | Result |
+|---|----------|----------|--------|
+| 1 | Low-income, one child age 4 | Eligible $17,227 | Eligible **$17,227** |
+| 2 | Child age 7 — too old | Not eligible | Not eligible |
+| 3 | Two children ages 3 + 5 | Eligible $34,454 | Eligible **$34,454** |
+| 4 | Over-income + SNAP — categorical | Eligible $17,227 | Eligible **$17,227** |
+| 5 | Over-income, no categorical | Not eligible | Not eligible |
+| 6 | Foster child, over-income | Eligible $17,227 | Eligible **$17,227** |
+
 ### Scenario 1: Low-Income Family with One Eligible Child — Eligible, Value-Isolation
 **What we're checking**: Typical low-income household with a child age 3–5 who clearly meets Head Start age and income requirements. **This is the primary value-isolation scenario** — if PE's IL spending/enrollment params drift, this expected amount breaks.
 **Expected**: Eligible — $17,227/year (1 eligible child)
@@ -122,6 +133,8 @@ This is an estimated annual value of Head Start services, not cash paid to the h
 
 **Why this matters**: Validates that SNAP categorical eligibility independently qualifies a family regardless of income — a distinct code branch from Scenario 1. The same logic applies to TANF and SSI. The $50,000 figure is a test input chosen to clear the income limit, not Head Start's official threshold.
 
+Reaching this branch required fixing the `Snap` PE input dependency, which gated on `screen.has_benefit("snap")` — an exact match on a bare name no white label uses, so reported SNAP never reached PolicyEngine. It now reads `has_base_benefit("snap")`, matching the sibling `Tanf` dependency. KS shipped its Head Start with this scenario documented as a known limitation; it is now fixed for every state.
+
 ---
 
 ### Scenario 5: Above Income Limit, No Categorical Eligibility — Income Ineligible
@@ -136,7 +149,7 @@ This is an estimated annual value of Head Start services, not cash paid to the h
 - **Person 3 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
 - **Current Benefits**: none
 
-**Why this matters**: This is the control for Scenario 4 — same household, no SNAP. Confirms eligibility there flows solely from categorical receipt.
+**Why this matters**: This is the control for Scenario 4 — same household, same income, no SNAP. Together the pair is a true A/B on categorical receipt: eligible at $17,227 with SNAP reported, ineligible without it, so eligibility there is demonstrably flowing from the categorical branch rather than from income.
 
 ---
 

--- a/programs/programs/il/head_start/spec.md
+++ b/programs/programs/il/head_start/spec.md
@@ -1,0 +1,174 @@
+# Head Start (IL)
+
+## Program Details
+
+- **Program**: Head Start (ages 3–5)
+- **State**: IL
+- **White Label**: il
+- **Scope**: Head Start only. Early Head Start (birth to age 3, and pregnant women) is a separate program tracked as its own ticket, matching the KS precedent (MFB-1053 Head Start / MFB-1250 Early Head Start) and the existing TX split (`tx_head_start` / `tx_early_head_start`).
+- **Implementation**: PolicyEngine (`head_start` variable), mirroring `ks_head_start` / `tx_head_start` / `ma_head_start`. Eligibility and benefit value are computed by PolicyEngine; Illinois adds only the state code (the thin-wrapper pattern).
+- **Engine + Tier**: PE, Fed (value varies)
+
+---
+
+## Eligibility
+
+All eligibility is computed by PolicyEngine's `is_head_start_eligible`:
+
+```
+is_age_eligible & (is_income_eligible | is_categorically_eligible)
+```
+
+- **Age** — ages 3–5 (`gov.hhs.head_start.age_range`), per 45 CFR § 1302.12(c).
+- **Income** — household income at or below 100% FPL.
+- **Categorical** — SNAP, TANF, or SSI receipt, or foster care status, qualifies regardless of income (45 CFR § 1302.12(a)(1)(ii)(B), (c)(1)(iii)).
+
+Illinois sets no eligibility parameters of its own — hence the `Fed (value varies)` tier rather than `Fed (elig varies)`.
+
+---
+
+## Benefit Value
+
+Per-child annual value comes from PolicyEngine's `head_start` variable: Illinois ACF Head Start spending ÷ Illinois enrollment, with spending uprated to the calculation year.
+
+For 2026 this resolves to **$17,227 per eligible child per year**, derived from PolicyEngine's IL parameters:
+
+| Input | Value | Source |
+|---|---|---|
+| `gov.hhs.head_start.spending.IL` (2023-09-01) | $254,239,437 | `parameters/gov/hhs/head_start/spending.yaml` |
+| `gov.hhs.head_start.enrollment.IL` (2023-09-01) | 15,906 | `parameters/gov/hhs/head_start/enrollment.yaml` |
+| `gov.hhs.uprating` 2023 → 2026 | 304.7 → 328.4 | `parameters/gov/hhs/uprating.yaml` |
+
+```
+254,239,437 × (328.4 / 304.7) / 15,906 = $17,227
+```
+
+Note that `spending` carries `uprating: gov.hhs.uprating` while `enrollment` does not, so only the numerator is indexed. The value is read from PolicyEngine at calculation time (not a pinned constant) and scales by the number of eligible children — two eligible children yield $34,454.
+
+This is an estimated annual value of Head Start services, not cash paid to the household.
+
+---
+
+## Research Sources
+
+- [Head Start Act, 42 U.S.C. § 9831 et seq.](https://uscode.house.gov/view.xhtml?path=/prelim@title42/chapter105&edition=prelim)
+- [Head Start Program Performance Standards, 45 CFR § 1302.12](https://www.ecfr.gov/current/title-45/subtitle-B/chapter-XIII/subchapter-B/part-1302/subpart-B/section-1302.12)
+- PolicyEngine parameters `gov.hhs.head_start.spending.IL`, `gov.hhs.head_start.enrollment.IL`, `gov.hhs.uprating`
+
+---
+
+## Test Scenarios
+
+> Each eligible scenario asserts the expected **dollar value** ($17,227 per eligible child), so a scenario breaks if PolicyEngine's Illinois spending/enrollment parameters drift. Ineligible scenarios carry no value.
+
+### Scenario 1: Low-Income Family with One Eligible Child — Eligible, Value-Isolation
+**What we're checking**: Typical low-income household with a child age 3–5 who clearly meets Head Start age and income requirements. **This is the primary value-isolation scenario** — if PE's IL spending/enrollment params drift, this expected amount breaks.
+**Expected**: Eligible — $17,227/year (1 eligible child)
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `3`
+- **Person 1 (Head of Household)**: Birth month/year `March 1996` (age 30), Relationship `Head of Household`, Has income `Yes`, Employment income `$1,500`/month, Citizenship `U.S. Citizen`
+- **Person 2 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
+- **Person 3 (Spouse)**: Birth month/year `July 2000` (age 25), Relationship `Spouse`, Has income `No`
+- **Current Benefits**: none
+
+**Why this matters**: The most common Head Start pathway. At $1,500/month ($18,000/year) for a household of 3, income is below 100% FPL.
+
+---
+
+### Scenario 2: Child Age 7 — Excluded, Too Old
+**What we're checking**: A child beyond the Head Start age range is excluded even when the family meets income requirements.
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$1,200`/month, Citizenship `U.S. Citizen`
+- **Person 2 (Child)**: Birth month/year `January 2019` (age 7), Relationship `Child`, Has income `No`
+
+**Why this matters**: Validates the age ceiling per 45 CFR § 1302.12(c). A 7-year-old is excluded regardless of income.
+
+---
+
+### Scenario 3: Two Eligible Children — Value Scales Per Eligible Child
+**What we're checking**: A household with two children ages 3–5. This is the **value-scaling** check for the "value varies" tier: the per-child figure must apply once per eligible child.
+**Expected**: Eligible — **$34,454/year** (2 × $17,227)
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `4`
+- **Person 1 (Head of Household)**: Birth month/year `March 1996` (age 30), Relationship `Head of Household`, Has income `Yes`, Employment income `$1,400`/month
+- **Person 2 (Spouse)**: Birth month/year `September 1994` (age 31), Relationship `Spouse`, Has income `No`
+- **Person 3 (Child — eligible)**: Birth month/year `March 2023` (age 3), Relationship `Child`, Has income `No`
+- **Person 4 (Child — eligible)**: Birth month/year `January 2021` (age 5), Relationship `Child`, Has income `No`
+- **Current Benefits**: none
+
+**Why this matters**: Confirms the value is per eligible child, not a flat per-household amount.
+
+---
+
+### Scenario 4: Above Income Limit, Receiving SNAP — Categorical Eligibility Override
+**What we're checking**: A family over the income limit is still eligible because SNAP receipt confers categorical eligibility.
+**Expected**: Eligible — $17,227/year
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `3`
+- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$4,167`/month ($50,000/year), Citizenship `U.S. Citizen`
+- **Person 2 (Spouse)**: Birth month/year `June 1992` (age 33), Relationship `Spouse`, Has income `No`
+- **Person 3 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
+- **Current Benefits**: `SNAP`
+
+**Why this matters**: Validates that SNAP categorical eligibility independently qualifies a family regardless of income — a distinct code branch from Scenario 1. The same logic applies to TANF and SSI. The $50,000 figure is a test input chosen to clear the income limit, not Head Start's official threshold.
+
+---
+
+### Scenario 5: Above Income Limit, No Categorical Eligibility — Income Ineligible
+**What we're checking**: A family over the income limit with no categorical benefits is not eligible.
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `3`
+- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$4,167`/month ($50,000/year), Citizenship `U.S. Citizen`
+- **Person 2 (Spouse)**: Birth month/year `June 1992` (age 33), Relationship `Spouse`, Has income `No`
+- **Person 3 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
+- **Current Benefits**: none
+
+**Why this matters**: This is the control for Scenario 4 — same household, no SNAP. Confirms eligibility there flows solely from categorical receipt.
+
+---
+
+### Scenario 6: Foster Child, Over-Income Family — Categorical Eligibility via Foster Care
+**What we're checking**: A child age 3–5 in foster care qualifies regardless of household income.
+**Expected**: Eligible — $17,227/year
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Birth month/year `March 1985` (age 41), Relationship `Head of Household`, Has income `Yes`, Employment income `$5,000`/month, Citizenship `U.S. Citizen`
+- **Person 2 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Foster Child`, Has income `No`
+
+**Why this matters**: Validates the foster care pathway (45 CFR § 1302.12(c)(1)(iii)). At $5,000/month for a household of 2 the family is well above any income threshold, so eligibility must flow solely from foster care status.
+
+---
+
+### Scenario 7: Already Receiving Head Start — Dedup Check
+**What we're checking**: A family already receiving Head Start is not redundantly recommended the same program.
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: ZIP code `60629`, county `Cook`
+- **Household**: Number of people: `2`
+- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$1,200`/month, Citizenship `U.S. Citizen`
+- **Person 2 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
+- **Current Benefits**: check `Head Start` only
+
+**Why this matters**: This is an MFB dedup/UX check, not a PE eligibility check. It depends on `show_in_has_benefits_step: true` in the config so "Head Start" is selectable as a current benefit — which is why IL diverges from KS/MO (both `false`) and follows WA (`true`). Verify during QA that the option actually renders on the current-benefits step.
+
+---
+
+## Program Configuration
+
+File: `programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json`

--- a/programs/programs/il/head_start/spec.md
+++ b/programs/programs/il/head_start/spec.md
@@ -154,22 +154,9 @@ This is an estimated annual value of Head Start services, not cash paid to the h
 
 ---
 
-### Scenario 7: Already Receiving Head Start — Dedup Check
-**What we're checking**: A family already receiving Head Start is not redundantly recommended the same program.
-**Expected**: Not eligible
-
-**Steps**:
-- **Location**: ZIP code `60629`, county `Cook`
-- **Household**: Number of people: `2`
-- **Person 1 (Head of Household)**: Birth month/year `March 1990` (age 36), Relationship `Head of Household`, Has income `Yes`, Employment income `$1,200`/month, Citizenship `U.S. Citizen`
-- **Person 2 (Child)**: Birth month/year `March 2022` (age 4), Relationship `Child`, Has income `No`
-- **Current Benefits**: check `Head Start` only
-
-**Why this matters**: This is an MFB dedup/UX check, not a PE eligibility check. It depends on `show_in_has_benefits_step: true` in the config so "Head Start" is selectable as a current benefit — which is why IL diverges from KS/MO (both `false`) and follows WA (`true`). Verify during QA that the option actually renders on the current-benefits step.
-
----
-
 ## Notes
+
+`show_in_has_benefits_step` is `false`, matching the KS and MO precedent, so "Head Start" is not offered as a selectable current benefit on the has-benefits step. The research draft carried a seventh scenario checking that an existing Head Start recipient isn't redundantly recommended the program; that scenario is dropped because the flag it depended on is off — with the option absent from the step, there is no input by which a household could report current Head Start receipt.
 
 Head Start receipt does **not** confer categorical eligibility on any other program we model. The categorical arrow points inward only: SNAP, TANF, SSI, and foster care qualify a child *for* Head Start, but Head Start enrollment does not qualify a household for anything else. PolicyEngine models enrollment as a separate input variable (`is_enrolled_in_head_start`) that we do not send, and it has no formula linking it to the `head_start` eligibility this program computes.
 

--- a/programs/programs/il/head_start/spec.md
+++ b/programs/programs/il/head_start/spec.md
@@ -169,6 +169,12 @@ This is an estimated annual value of Head Start services, not cash paid to the h
 
 ---
 
+## Notes
+
+Head Start receipt does **not** confer categorical eligibility on any other program we model. The categorical arrow points inward only: SNAP, TANF, SSI, and foster care qualify a child *for* Head Start, but Head Start enrollment does not qualify a household for anything else. PolicyEngine models enrollment as a separate input variable (`is_enrolled_in_head_start`) that we do not send, and it has no formula linking it to the `head_start` eligibility this program computes.
+
+---
+
 ## Program Configuration
 
 File: `programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json`

--- a/programs/programs/il/pe/__init__.py
+++ b/programs/programs/il/pe/__init__.py
@@ -14,6 +14,7 @@ il_member_calculators = {
     "il_fppe": member.IlFamilyPlanningProgram,
     "il_mpe": member.IlMpe,
     "il_msp": member.IlMsp,
+    "il_head_start": member.IlHeadStart,
 }
 
 il_tax_unit_calculators = {

--- a/programs/programs/il/pe/member.py
+++ b/programs/programs/il/pe/member.py
@@ -314,3 +314,17 @@ class IlMsp(federal_member.Msp):
         household_dependency.IlStateCodeDependency,
         *IlMedicaid.pe_inputs,
     ]
+
+
+class IlHeadStart(federal_member.HeadStart):
+    """
+    Illinois Head Start (ages 3-5). Thin wrapper on the federal ``HeadStart`` PE
+    calculator that adds the IL state code; all eligibility and the per-child
+    value are computed by PolicyEngine with no IL-specific variance. Early Head
+    Start (birth to age 3, and pregnant women) is a separate program.
+    """
+
+    pe_inputs = [
+        *federal_member.HeadStart.pe_inputs,
+        household_dependency.IlStateCodeDependency,
+    ]

--- a/programs/programs/il/pe/tests/test_member.py
+++ b/programs/programs/il/pe/tests/test_member.py
@@ -30,7 +30,9 @@ from programs.programs.il.pe.member import (
     IlBccp,
     IlMpe,
     IlFamilyPlanningProgram,
+    IlHeadStart,
 )
+from programs.programs.federal.pe.member import HeadStart
 
 
 class TestIlMsp(TestCase):
@@ -471,3 +473,62 @@ class TestIlFppEligible(TestCase):
     def test_field_is_il_fpp_eligible(self):
         """Test that the output dependency field is correctly set."""
         self.assertEqual(member_dependency.IlFppEligible.field, "il_fpp_eligible")
+
+
+class TestIlHeadStartWiring(TestCase):
+    """
+    IlHeadStart is a thin wrapper on the federal ``HeadStart`` PE calculator that
+    adds only the IL state code — all eligibility and the per-child value come
+    from PolicyEngine's ``head_start`` variable with no IL-specific variance
+    (mirrors ``KsHeadStart`` / ``TxHeadStart`` / ``MaHeadStart``).
+
+    The federal ``HeadStart`` dependency logic is covered in
+    ``policyengine/calculators/dependencies/tests/test_member.py``; here we assert
+    only the IL wiring. The spec's dollar-value scenarios ($17,227 per eligible
+    child) are verified against PolicyEngine's IL spending/enrollment parameters —
+    see ``programs/programs/il/head_start/spec.md``.
+    """
+
+    def test_is_subclass_of_head_start(self):
+        self.assertTrue(issubclass(IlHeadStart, HeadStart))
+
+    def test_is_registered_in_il_member_calculators(self):
+        self.assertIn("il_head_start", il_member_calculators)
+        self.assertEqual(il_member_calculators["il_head_start"], IlHeadStart)
+
+    def test_is_registered_in_il_pe_calculators(self):
+        self.assertIn("il_head_start", il_pe_calculators)
+        self.assertEqual(il_pe_calculators["il_head_start"], IlHeadStart)
+
+    def test_pe_name_is_head_start(self):
+        self.assertEqual(IlHeadStart.pe_name, "head_start")
+
+    def test_pe_inputs_includes_il_state_code(self):
+        """The IL state code is what selects IL's spending/enrollment parameters in PE."""
+        self.assertIn(IlStateCodeDependency, IlHeadStart.pe_inputs)
+
+    def test_pe_inputs_preserve_federal_head_start_inputs(self):
+        """The IL wrapper only appends the state code; it must not drop any federal input."""
+        for dep in HeadStart.pe_inputs:
+            self.assertIn(dep, IlHeadStart.pe_inputs)
+
+    def test_pe_inputs_include_age_and_foster_pathways(self):
+        """Ages 3-5 (age) and the foster-care categorical pathway per the spec."""
+        self.assertIn(member_dependency.AgeDependency, IlHeadStart.pe_inputs)
+        self.assertIn(member_dependency.FosterCareDependency, IlHeadStart.pe_inputs)
+
+    def test_pe_inputs_include_categorical_benefit_signals(self):
+        """SNAP / TANF / SSI feed PolicyEngine's categorical-eligibility determination."""
+        self.assertIn(member_dependency.Ssi, IlHeadStart.pe_inputs)
+
+    def test_pe_inputs_include_income(self):
+        """Income drives the non-categorical eligibility pathway."""
+        for income_dependency in irs_gross_income:
+            self.assertIn(income_dependency, IlHeadStart.pe_inputs)
+
+    def test_pe_outputs_is_head_start_variable(self):
+        self.assertEqual(IlHeadStart.pe_outputs, [member_dependency.HeadStart])
+
+    def test_does_not_reuse_early_head_start_variable(self):
+        """Head Start must resolve PE's ``head_start`` variable, not ``early_head_start``."""
+        self.assertNotEqual(IlHeadStart.pe_name, "early_head_start")

--- a/programs/programs/il/pe/tests/test_member.py
+++ b/programs/programs/il/pe/tests/test_member.py
@@ -479,56 +479,28 @@ class TestIlHeadStartWiring(TestCase):
     """
     IlHeadStart is a thin wrapper on the federal ``HeadStart`` PE calculator that
     adds only the IL state code — all eligibility and the per-child value come
-    from PolicyEngine's ``head_start`` variable with no IL-specific variance
-    (mirrors ``KsHeadStart`` / ``TxHeadStart`` / ``MaHeadStart``).
+    from PolicyEngine's ``head_start`` variable with no IL-specific variance.
 
-    The federal ``HeadStart`` dependency logic is covered in
-    ``policyengine/calculators/dependencies/tests/test_member.py``; here we assert
-    only the IL wiring. The spec's dollar-value scenarios ($17,227 per eligible
-    child) are verified against PolicyEngine's IL spending/enrollment parameters —
-    see ``programs/programs/il/head_start/spec.md``.
+    The shared contract every state's Head Start must satisfy (pe_name, pe_outputs,
+    no federal input dropped, exactly one state code matching the slug, no
+    ``member_value`` override) is asserted once for all registered subclasses in
+    ``federal/pe/tests/test_head_start.py``. Only the IL-specific wiring is
+    asserted here.
+
+    The spec's dollar-value scenarios ($17,227 per eligible child) are verified
+    against PolicyEngine's IL spending/enrollment parameters — see
+    ``programs/programs/il/head_start/spec.md``.
     """
 
     def test_is_subclass_of_head_start(self):
         self.assertTrue(issubclass(IlHeadStart, HeadStart))
 
-    def test_is_registered_in_il_member_calculators(self):
-        self.assertIn("il_head_start", il_member_calculators)
-        self.assertEqual(il_member_calculators["il_head_start"], IlHeadStart)
-
-    def test_is_registered_in_il_pe_calculators(self):
-        self.assertIn("il_head_start", il_pe_calculators)
-        self.assertEqual(il_pe_calculators["il_head_start"], IlHeadStart)
-
-    def test_pe_name_is_head_start(self):
-        self.assertEqual(IlHeadStart.pe_name, "head_start")
+    def test_is_registered_as_il_head_start(self):
+        self.assertIs(il_member_calculators["il_head_start"], IlHeadStart)
+        self.assertIs(il_pe_calculators["il_head_start"], IlHeadStart)
 
     def test_pe_inputs_includes_il_state_code(self):
-        """The IL state code is what selects IL's spending/enrollment parameters in PE."""
+        """The IL state code is what selects IL's spending/enrollment parameters in PE,
+        and so what makes the per-child value Illinois' rather than another state's."""
+        self.assertTrue(issubclass(IlHeadStart, HeadStart))
         self.assertIn(IlStateCodeDependency, IlHeadStart.pe_inputs)
-
-    def test_pe_inputs_preserve_federal_head_start_inputs(self):
-        """The IL wrapper only appends the state code; it must not drop any federal input."""
-        for dep in HeadStart.pe_inputs:
-            self.assertIn(dep, IlHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_age_and_foster_pathways(self):
-        """Ages 3-5 (age) and the foster-care categorical pathway per the spec."""
-        self.assertIn(member_dependency.AgeDependency, IlHeadStart.pe_inputs)
-        self.assertIn(member_dependency.FosterCareDependency, IlHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_categorical_benefit_signals(self):
-        """SNAP / TANF / SSI feed PolicyEngine's categorical-eligibility determination."""
-        self.assertIn(member_dependency.Ssi, IlHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_income(self):
-        """Income drives the non-categorical eligibility pathway."""
-        for income_dependency in irs_gross_income:
-            self.assertIn(income_dependency, IlHeadStart.pe_inputs)
-
-    def test_pe_outputs_is_head_start_variable(self):
-        self.assertEqual(IlHeadStart.pe_outputs, [member_dependency.HeadStart])
-
-    def test_does_not_reuse_early_head_start_variable(self):
-        """Head Start must resolve PE's ``head_start`` variable, not ``early_head_start``."""
-        self.assertNotEqual(IlHeadStart.pe_name, "early_head_start")

--- a/programs/programs/ks/pe/tests/test_member.py
+++ b/programs/programs/ks/pe/tests/test_member.py
@@ -43,10 +43,6 @@ from programs.programs.policyengine.calculators.dependencies.tax import KsChipPr
 from programs.programs.ks.pe import ks_member_calculators, ks_pe_calculators
 from programs.programs.ks.pe.member import KsKanCare, KsChip, KsMsp, KsEarlyHeadStart
 from programs.programs.federal.pe.member import EarlyHeadStart
-from programs.programs.policyengine.calculators.dependencies.member import (
-    FosterCareDependency,
-    EarlyHeadStart as EarlyHeadStartOutput,
-)
 
 # Annual value tiers (medicaid_categories * 12)
 MAGI = 3_648  # INFANT / YOUNG_CHILD / OLDER_CHILD / PREGNANT / PARENT / ADULT / YOUNG_ADULT
@@ -465,54 +461,22 @@ class TestKsMspKanCareAssetConsistency(TestCase):
 
 class TestKsEarlyHeadStartWiring(TestCase):
     """
-    KsEarlyHeadStart is a thin wrapper on the federal ``EarlyHeadStart`` PE
-    calculator that adds only the KS state code — all eligibility and the
-    per-individual value come from PolicyEngine's ``early_head_start`` variable
-    with no KS-specific variance (mirrors ``KsHeadStart`` / ``TxEarlyHeadStart`` /
-    ``MaEarlyHeadStart``).
+    KS-specific wiring for Early Head Start (birth-3 / pregnant). A thin wrapper on
+    the federal ``EarlyHeadStart`` PE calculator, adding only the KS state code.
 
-    The federal ``EarlyHeadStart`` dependency logic is covered in
-    ``policyengine/calculators/dependencies/tests/test_member.py``; here we assert
-    only the KS wiring. The spec's dollar-value scenarios (birth-3 / pregnant /
-    foster categorical, $13,323 per eligible individual) are verified end-to-end
-    against the live PolicyEngine API — see ``programs/programs/ks/early_head_start/spec.md``.
+    The shared contract (pe_name, pe_outputs, no federal input dropped, exactly one
+    state code matching the slug, no ``member_value`` override) is asserted once for
+    all registered subclasses in ``federal/pe/tests/test_head_start.py``.
+
+    The spec's dollar-value scenarios ($13,323 per eligible individual) are verified
+    end-to-end against the live PolicyEngine API — see
+    ``programs/programs/ks/early_head_start/spec.md``.
     """
 
-    def test_is_subclass_of_early_head_start(self):
-        self.assertTrue(issubclass(KsEarlyHeadStart, EarlyHeadStart))
-
-    def test_is_registered_in_ks_member_calculators(self):
-        self.assertIn("ks_early_head_start", ks_member_calculators)
-        self.assertEqual(ks_member_calculators["ks_early_head_start"], KsEarlyHeadStart)
-
-    def test_is_registered_in_ks_pe_calculators(self):
-        self.assertIn("ks_early_head_start", ks_pe_calculators)
-        self.assertEqual(ks_pe_calculators["ks_early_head_start"], KsEarlyHeadStart)
-
-    def test_pe_name_is_early_head_start(self):
-        self.assertEqual(KsEarlyHeadStart.pe_name, "early_head_start")
+    def test_is_registered_as_ks_early_head_start(self):
+        self.assertIs(ks_member_calculators["ks_early_head_start"], KsEarlyHeadStart)
+        self.assertIs(ks_pe_calculators["ks_early_head_start"], KsEarlyHeadStart)
 
     def test_pe_inputs_includes_ks_state_code(self):
+        self.assertTrue(issubclass(KsEarlyHeadStart, EarlyHeadStart))
         self.assertIn(KsStateCodeDependency, KsEarlyHeadStart.pe_inputs)
-
-    def test_pe_inputs_preserve_federal_early_head_start_inputs(self):
-        """The KS wrapper only appends the state code; it must not drop any federal input."""
-        for dep in EarlyHeadStart.pe_inputs:
-            self.assertIn(dep, KsEarlyHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_age_pregnancy_and_foster_pathways(self):
-        """Birth-3 (age), pregnant-woman, and foster-care categorical pathways per the spec."""
-        self.assertIn(AgeDependency, KsEarlyHeadStart.pe_inputs)
-        self.assertIn(PregnancyDependency, KsEarlyHeadStart.pe_inputs)
-        self.assertIn(FosterCareDependency, KsEarlyHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_categorical_benefit_signals(self):
-        """SNAP / TANF / SSI feed PolicyEngine's categorical-eligibility determination."""
-        self.assertIn(member_deps.Ssi, KsEarlyHeadStart.pe_inputs)
-
-    def test_pe_outputs_is_early_head_start_variable(self):
-        self.assertEqual(KsEarlyHeadStart.pe_outputs, [EarlyHeadStartOutput])
-
-    def test_does_not_reuse_head_start_variable(self):
-        """EHS must resolve PE's ``early_head_start`` variable, not the ``head_start`` one."""
-        self.assertNotEqual(KsEarlyHeadStart.pe_name, "head_start")

--- a/programs/programs/ma/pe/tests/test_member.py
+++ b/programs/programs/ma/pe/tests/test_member.py
@@ -1,400 +1,42 @@
 """
 Unit tests for MA member-level PolicyEngine calculator classes.
 
-These tests verify MA-specific calculator logic for member-level programs including:
-- MaHeadStart calculator registration and configuration
-- MA-specific pe_inputs (MaStateCodeDependency, income dependencies)
-- PolicyEngine integration and value calculation
+These tests verify MA-specific calculator logic for member-level programs — the
+state code each calculator adds and the slug it registers under. The wiring shared
+across every state's Head Start lives in ``federal/pe/tests/test_head_start.py``.
 """
 
 from django.test import TestCase
 
-from unittest.mock import Mock, MagicMock
-
-from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
+from programs.programs.federal.pe.member import EarlyHeadStart, HeadStart
 from programs.programs.policyengine.calculators.dependencies.household import MaStateCodeDependency
 from programs.programs.ma.pe import ma_pe_calculators
 from programs.programs.ma.pe.member import MaHeadStart, MaEarlyHeadStart
 
 
-class TestMaHeadStart(TestCase):
-    """Tests for MaHeadStart calculator class."""
+class TestMaHeadStartWiring(TestCase):
+    """
+    MA-specific wiring for Head Start (ages 3-5) and Early Head Start (birth-3 /
+    pregnant). Both are thin wrappers on the federal calculators, adding only the
+    MA state code.
 
-    def test_exists_and_is_subclass_of_policy_engine_members_calculator(self):
-        """
-        Test that MaHeadStart calculator class exists and inherits correctly.
+    The shared contract (pe_name, pe_outputs, no federal input dropped, exactly one
+    state code matching the slug, no ``member_value`` override) is asserted once for
+    all registered subclasses in ``federal/pe/tests/test_head_start.py`` — including
+    the ``member_value`` pass-through that this file previously exercised through
+    mocks against the base class implementation.
+    """
 
-        This verifies the calculator has been set up in the codebase and follows the
-        correct inheritance pattern for member-level calculators.
-        """
-        # Verify MaHeadStart is a subclass of PolicyEngineMembersCalculator
-        self.assertTrue(issubclass(MaHeadStart, PolicyEngineMembersCalculator))
+    def test_head_start_is_registered_as_ma_head_start(self):
+        self.assertIs(ma_pe_calculators["ma_head_start"], MaHeadStart)
 
-        # Verify it has the expected properties
-        self.assertEqual(MaHeadStart.pe_name, "head_start")
-        self.assertIsNotNone(MaHeadStart.pe_inputs)
-        self.assertGreater(len(MaHeadStart.pe_inputs), 0)
-
-    def test_is_registered_in_ma_pe_calculators(self):
-        """Test that MA Head Start is registered in the calculators dictionary."""
-        # Verify ma_head_start is in the calculators dictionary
-        self.assertIn("ma_head_start", ma_pe_calculators)
-
-        # Verify it points to the correct class
-        self.assertEqual(ma_pe_calculators["ma_head_start"], MaHeadStart)
-
-    def test_pe_inputs_includes_age_dependency(self):
-        """
-        Test that MaHeadStart includes AgeDependency in pe_inputs.
-
-        Head Start eligibility requires age information (children ages 3-5).
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import AgeDependency
-
-        self.assertIn(AgeDependency, MaHeadStart.pe_inputs)
-        self.assertEqual(AgeDependency.field, "age")
-
-    def test_pe_inputs_includes_ma_state_code_dependency(self):
-        """
-        Test that MaStateCodeDependency is properly added to MA Head Start inputs.
-
-        This is the key MA-specific dependency that sets state_code="MA" for
-        PolicyEngine calculations.
-        """
-        # Verify MaStateCodeDependency is in pe_inputs
+    def test_head_start_pe_inputs_includes_ma_state_code(self):
+        self.assertTrue(issubclass(MaHeadStart, HeadStart))
         self.assertIn(MaStateCodeDependency, MaHeadStart.pe_inputs)
 
-        # Verify it's configured correctly
-        self.assertEqual(MaStateCodeDependency.state, "MA")
-        self.assertEqual(MaStateCodeDependency.field, "state_code")
+    def test_early_head_start_is_registered_as_ma_early_head_start(self):
+        self.assertIs(ma_pe_calculators["ma_early_head_start"], MaEarlyHeadStart)
 
-    def test_pe_inputs_includes_irs_gross_income_dependencies(self):
-        """
-        Test that MaHeadStart includes all IRS gross income dependencies.
-
-        Head Start eligibility is based on household income relative to Federal
-        Poverty Level, so all income types need to be captured.
-        """
-        from programs.programs.policyengine.calculators.dependencies import irs_gross_income
-
-        # Verify all IRS gross income dependencies are included
-        for income_dep in irs_gross_income:
-            self.assertIn(income_dep, MaHeadStart.pe_inputs)
-
-    def test_pe_outputs_includes_head_start_dependency(self):
-        """
-        Test that MaHeadStart has HeadStart dependency in pe_outputs.
-
-        This is the PolicyEngine variable that returns the annual benefit value
-        for eligible children.
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import HeadStart
-
-        self.assertIn(HeadStart, MaHeadStart.pe_outputs)
-
-    def test_member_value_returns_policy_engine_value(self):
-        """
-        Test that member_value returns the PolicyEngine calculated value.
-
-        Since MaHeadStart doesn't override member_value, it should use the base
-        class implementation which returns the PolicyEngine value directly.
-        """
-        # Create a mock MaHeadStart calculator instance
-        calculator = MaHeadStart(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock the get_member_variable method to return a value
-        pe_value = 12500
-        calculator.get_member_variable = Mock(return_value=pe_value)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Verify the result is the PolicyEngine value
-        self.assertEqual(result, pe_value)
-        calculator.get_member_variable.assert_called_once_with(1)
-
-    def test_member_value_returns_zero_when_not_eligible(self):
-        """
-        Test that member_value returns 0 when PolicyEngine determines ineligibility.
-
-        If a child is not age-eligible or household is above income threshold,
-        PolicyEngine will return 0.
-        """
-        # Create a mock MaHeadStart calculator instance
-        calculator = MaHeadStart(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock PolicyEngine returning 0 (not eligible)
-        calculator.get_member_variable = Mock(return_value=0)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Should return 0
-        self.assertEqual(result, 0)
-
-    def test_member_value_calls_get_member_variable_with_correct_id(self):
-        """
-        Test that member_value calls get_member_variable with the correct member ID.
-
-        This verifies that the PolicyEngine value is fetched for the right member.
-        """
-        # Create a mock MaHeadStart calculator instance
-        calculator = MaHeadStart(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock the get_member_variable method
-        calculator.get_member_variable = Mock(return_value=10000)
-
-        # Create a mock member with specific ID
-        member = Mock()
-        member.id = 42
-
-        # Call member_value
-        calculator.member_value(member)
-
-        # Verify get_member_variable was called with the correct member ID
-        calculator.get_member_variable.assert_called_once_with(42)
-
-    def test_member_value_handles_varying_pe_values(self):
-        """
-        Test that member_value correctly returns different PolicyEngine values.
-
-        PolicyEngine calculates state-specific per-child values based on
-        state spending / enrollment, so values may vary.
-        """
-        # Create a mock MaHeadStart calculator instance
-        calculator = MaHeadStart(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Test with different PolicyEngine values
-        test_values = [0, 5000, 10655, 12000, 15000]
-
-        for expected_value in test_values:
-            calculator.get_member_variable = Mock(return_value=expected_value)
-            result = calculator.member_value(member)
-            self.assertEqual(result, expected_value)
-
-    def test_calculator_has_no_custom_member_value_override(self):
-        """
-        Test that MaHeadStart doesn't override member_value method.
-
-        This confirms we're using the base class implementation, which is the
-        simplest approach for calculators that just need the raw PE value.
-        """
-        # Check that member_value is not defined in MaHeadStart's own __dict__
-        self.assertNotIn("member_value", MaHeadStart.__dict__)
-
-        # Verify it inherits from PolicyEngineMembersCalculator
-        self.assertTrue(hasattr(MaHeadStart, "member_value"))
-
-    def test_pe_inputs_has_required_dependencies(self):
-        """
-        Test that MaHeadStart has at least the minimum required dependencies.
-
-        Should have: AgeDependency, MaStateCodeDependency, and IRS income dependencies.
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import AgeDependency
-
-        # Verify minimum required inputs are present
-        self.assertGreaterEqual(len(MaHeadStart.pe_inputs), 7)
-
-        # Verify required dependency types are present
-        self.assertIn(AgeDependency, MaHeadStart.pe_inputs)
-        self.assertIn(MaStateCodeDependency, MaHeadStart.pe_inputs)
-
-    def test_head_start_dependency_field_name(self):
-        """
-        Test that HeadStart dependency has the correct field name.
-
-        This should match the PolicyEngine variable name 'head_start'.
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import HeadStart
-
-        self.assertEqual(HeadStart.field, "head_start")
-
-    def test_calculator_uses_member_category(self):
-        """
-        Test that MaHeadStart uses the 'people' category for PolicyEngine.
-
-        Member-level calculators should inherit pe_category='people' from
-        PolicyEngineMembersCalculator base class.
-        """
-        # Inherited from PolicyEngineMembersCalculator
-        self.assertEqual(MaHeadStart.pe_category, "people")
-
-
-class TestMaEarlyHeadStart(TestCase):
-    """Tests for MaEarlyHeadStart calculator class."""
-
-    def test_exists_and_is_subclass_of_policy_engine_members_calculator(self):
-        """
-        Test that MaEarlyHeadStart calculator class exists and inherits correctly.
-
-        This verifies the calculator has been set up in the codebase and follows the
-        correct inheritance pattern for member-level calculators.
-        """
-        # Verify MaEarlyHeadStart is a subclass of PolicyEngineMembersCalculator
-        self.assertTrue(issubclass(MaEarlyHeadStart, PolicyEngineMembersCalculator))
-
-        # Verify it has the expected properties
-        self.assertEqual(MaEarlyHeadStart.pe_name, "early_head_start")
-        self.assertIsNotNone(MaEarlyHeadStart.pe_inputs)
-        self.assertGreater(len(MaEarlyHeadStart.pe_inputs), 0)
-
-    def test_is_registered_in_ma_pe_calculators(self):
-        """Test that MA Early Head Start is registered in the calculators dictionary."""
-        # Verify ma_early_head_start is in the calculators dictionary
-        self.assertIn("ma_early_head_start", ma_pe_calculators)
-
-        # Verify it points to the correct class
-        self.assertEqual(ma_pe_calculators["ma_early_head_start"], MaEarlyHeadStart)
-
-    def test_pe_name_is_early_head_start(self):
-        """Test that MaEarlyHeadStart has the correct pe_name for PolicyEngine API calls."""
-        self.assertEqual(MaEarlyHeadStart.pe_name, "early_head_start")
-
-    def test_pe_inputs_includes_age_dependency(self):
-        """
-        Test that MaEarlyHeadStart includes AgeDependency in pe_inputs.
-
-        Early Head Start eligibility requires age information (children under 3).
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import AgeDependency
-
-        self.assertIn(AgeDependency, MaEarlyHeadStart.pe_inputs)
-        self.assertEqual(AgeDependency.field, "age")
-
-    def test_pe_inputs_includes_ma_state_code_dependency(self):
-        """
-        Test that MaStateCodeDependency is properly added to MA Early Head Start inputs.
-
-        This is the key MA-specific dependency that sets state_code="MA" for
-        PolicyEngine calculations.
-        """
-        # Verify MaStateCodeDependency is in pe_inputs
+    def test_early_head_start_pe_inputs_includes_ma_state_code(self):
+        self.assertTrue(issubclass(MaEarlyHeadStart, EarlyHeadStart))
         self.assertIn(MaStateCodeDependency, MaEarlyHeadStart.pe_inputs)
-
-        # Verify it's configured correctly
-        self.assertEqual(MaStateCodeDependency.state, "MA")
-        self.assertEqual(MaStateCodeDependency.field, "state_code")
-
-    def test_pe_inputs_includes_irs_gross_income_dependencies(self):
-        """
-        Test that MaEarlyHeadStart includes all IRS gross income dependencies.
-
-        Early Head Start eligibility is based on household income relative to Federal
-        Poverty Level, so all income types need to be captured.
-        """
-        from programs.programs.policyengine.calculators.dependencies import irs_gross_income
-
-        # Verify all IRS gross income dependencies are included
-        for income_dep in irs_gross_income:
-            self.assertIn(income_dep, MaEarlyHeadStart.pe_inputs)
-
-    def test_pe_outputs_includes_early_head_start_dependency(self):
-        """
-        Test that MaEarlyHeadStart has EarlyHeadStart dependency in pe_outputs.
-
-        This is the PolicyEngine variable that returns the annual benefit value
-        for eligible children.
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import EarlyHeadStart
-
-        self.assertIn(EarlyHeadStart, MaEarlyHeadStart.pe_outputs)
-
-    def test_member_value_returns_policy_engine_value(self):
-        """
-        Test that member_value returns the PolicyEngine calculated value.
-
-        Since MaEarlyHeadStart doesn't override member_value, it should use the base
-        class implementation which returns the PolicyEngine value directly.
-        """
-        # Create a mock MaEarlyHeadStart calculator instance
-        calculator = MaEarlyHeadStart(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock the get_member_variable method to return a value
-        pe_value = 15000
-        calculator.get_member_variable = Mock(return_value=pe_value)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Verify the result is the PolicyEngine value
-        self.assertEqual(result, pe_value)
-        calculator.get_member_variable.assert_called_once_with(1)
-
-    def test_member_value_returns_zero_when_not_eligible(self):
-        """
-        Test that member_value returns 0 when PolicyEngine determines ineligibility.
-
-        If a child is not age-eligible or household is above income threshold,
-        PolicyEngine will return 0.
-        """
-        # Create a mock MaEarlyHeadStart calculator instance
-        calculator = MaEarlyHeadStart(Mock(), Mock(), Mock())
-        calculator._sim = MagicMock()
-
-        # Mock PolicyEngine returning 0 (not eligible)
-        calculator.get_member_variable = Mock(return_value=0)
-
-        # Create a mock member
-        member = Mock()
-        member.id = 1
-
-        # Call member_value
-        result = calculator.member_value(member)
-
-        # Should return 0
-        self.assertEqual(result, 0)
-
-    def test_early_head_start_dependency_field_name(self):
-        """
-        Test that EarlyHeadStart dependency has the correct field name.
-
-        This should match the PolicyEngine variable name 'early_head_start'.
-        """
-        from programs.programs.policyengine.calculators.dependencies.member import EarlyHeadStart
-
-        self.assertEqual(EarlyHeadStart.field, "early_head_start")
-
-    def test_calculator_uses_member_category(self):
-        """
-        Test that MaEarlyHeadStart uses the 'people' category for PolicyEngine.
-
-        Member-level calculators should inherit pe_category='people' from
-        PolicyEngineMembersCalculator base class.
-        """
-        # Inherited from PolicyEngineMembersCalculator
-        self.assertEqual(MaEarlyHeadStart.pe_category, "people")
-
-    def test_pe_inputs_count(self):
-        """
-        Test that MaEarlyHeadStart has the expected number of pe_inputs.
-
-        MaEarlyHeadStart now inherits the shared federal EarlyHeadStart base class,
-        which carries the full input set for categorical eligibility:
-        Age + Pregnancy + FosterCare + 8 IRS income dependencies + Ssi + Snap + Tanf
-        = 14 base inputs, plus MaStateCodeDependency = 15 total.
-        """
-        expected_count = 15
-
-        self.assertEqual(len(MaEarlyHeadStart.pe_inputs), expected_count)

--- a/programs/programs/mo/pe/tests/test_member.py
+++ b/programs/programs/mo/pe/tests/test_member.py
@@ -62,9 +62,6 @@ from programs.programs.policyengine.calculators.base import PolicyEngineMembersC
 from programs.programs.policyengine.calculators.dependencies import member as member_deps
 from programs.programs.policyengine.calculators.dependencies.household import MoStateCodeDependency
 from programs.programs.policyengine.calculators.dependencies.member import (
-    AgeDependency,
-    PregnancyDependency,
-    FosterCareDependency,
     IsBlindDependency,
     MeetsSsiDisabilityCriteriaDependency,
     Ssi,
@@ -72,8 +69,6 @@ from programs.programs.policyengine.calculators.dependencies.member import (
     SsiEarnedIncomeDependency,
     SsiReportedDependency,
     SsiUnearnedIncomeDependency,
-    HeadStart as HeadStartOutput,
-    EarlyHeadStart as EarlyHeadStartOutput,
 )
 from programs.programs.policyengine.calculators.registry import all_calculators, all_member_calculators
 from programs.programs.policyengine.policy_engine import pe_input
@@ -317,78 +312,30 @@ class TestMoWicPeInput(TestCase):
 
 
 class TestMoHeadStartWiring(TestCase):
-    """MoHeadStart (ages 3-5) registration and MO-specific pe_inputs handling."""
+    """
+    MO-specific wiring for Head Start (ages 3-5) and Early Head Start (birth-3 /
+    pregnant). Both are thin wrappers on the federal calculators, adding only the
+    MO state code.
 
-    def test_is_subclass_of_head_start(self):
+    The shared contract (pe_name, pe_outputs, no federal input dropped, exactly one
+    state code matching the slug, no ``member_value`` override) is asserted once for
+    all registered subclasses in ``federal/pe/tests/test_head_start.py``.
+    """
+
+    def test_head_start_is_registered_as_mo_head_start(self):
+        self.assertIs(mo_member_calculators["mo_head_start"], MoHeadStart)
+        self.assertIs(mo_pe_calculators["mo_head_start"], MoHeadStart)
+
+    def test_head_start_pe_inputs_includes_mo_state_code(self):
         self.assertTrue(issubclass(MoHeadStart, HeadStart))
-
-    def test_is_registered_in_mo_member_calculators(self):
-        self.assertIn("mo_head_start", mo_member_calculators)
-        self.assertEqual(mo_member_calculators["mo_head_start"], MoHeadStart)
-
-    def test_is_registered_in_mo_pe_calculators(self):
-        self.assertIn("mo_head_start", mo_pe_calculators)
-        self.assertEqual(mo_pe_calculators["mo_head_start"], MoHeadStart)
-
-    def test_pe_name_is_head_start(self):
-        self.assertEqual(MoHeadStart.pe_name, "head_start")
-
-    def test_pe_inputs_includes_mo_state_code(self):
         self.assertIn(MoStateCodeDependency, MoHeadStart.pe_inputs)
 
-    def test_pe_inputs_preserve_federal_head_start_inputs(self):
-        """The MO wrapper only appends the state code; it must not drop any federal input."""
-        for dep in HeadStart.pe_inputs:
-            self.assertIn(dep, MoHeadStart.pe_inputs)
+    def test_early_head_start_is_registered_as_mo_early_head_start(self):
+        self.assertIs(mo_member_calculators["mo_early_head_start"], MoEarlyHeadStart)
 
-    def test_pe_inputs_include_age_and_foster_pathways(self):
-        """Ages 3-5 (age) and the foster-care categorical pathway per the spec."""
-        self.assertIn(AgeDependency, MoHeadStart.pe_inputs)
-        self.assertIn(FosterCareDependency, MoHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_categorical_benefit_signals(self):
-        """SNAP / TANF / SSI feed PolicyEngine's categorical-eligibility determination."""
-        self.assertIn(Ssi, MoHeadStart.pe_inputs)
-
-    def test_pe_outputs_is_head_start_variable(self):
-        self.assertEqual(MoHeadStart.pe_outputs, [HeadStartOutput])
-
-    def test_mo_state_code_dependency_configured(self):
-        self.assertEqual(MoStateCodeDependency.state, "MO")
-        self.assertEqual(MoStateCodeDependency.field, "state_code")
-
-
-class TestMoEarlyHeadStartWiring(TestCase):
-    """MoEarlyHeadStart (birth-3 / pregnant) registration and MO-specific pe_inputs handling."""
-
-    def test_is_subclass_of_early_head_start(self):
+    def test_early_head_start_pe_inputs_includes_mo_state_code(self):
         self.assertTrue(issubclass(MoEarlyHeadStart, EarlyHeadStart))
-
-    def test_is_registered_in_mo_member_calculators(self):
-        self.assertIn("mo_early_head_start", mo_member_calculators)
-        self.assertEqual(mo_member_calculators["mo_early_head_start"], MoEarlyHeadStart)
-
-    def test_pe_name_is_early_head_start(self):
-        self.assertEqual(MoEarlyHeadStart.pe_name, "early_head_start")
-
-    def test_pe_inputs_includes_mo_state_code(self):
         self.assertIn(MoStateCodeDependency, MoEarlyHeadStart.pe_inputs)
-
-    def test_pe_inputs_preserve_federal_early_head_start_inputs(self):
-        for dep in EarlyHeadStart.pe_inputs:
-            self.assertIn(dep, MoEarlyHeadStart.pe_inputs)
-
-    def test_pe_inputs_include_age_pregnancy_and_foster_pathways(self):
-        self.assertIn(AgeDependency, MoEarlyHeadStart.pe_inputs)
-        self.assertIn(PregnancyDependency, MoEarlyHeadStart.pe_inputs)
-        self.assertIn(FosterCareDependency, MoEarlyHeadStart.pe_inputs)
-
-    def test_pe_outputs_is_early_head_start_variable(self):
-        self.assertEqual(MoEarlyHeadStart.pe_outputs, [EarlyHeadStartOutput])
-
-    def test_does_not_reuse_head_start_variable(self):
-        """EHS must resolve PE's ``early_head_start`` variable, not the ``head_start`` one."""
-        self.assertNotEqual(MoEarlyHeadStart.pe_name, "head_start")
 
 
 class TestMoSsiWiring(TestCase):

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -154,15 +154,27 @@ class Snap(SpmUnit):
 
     - If user reports having snap: send 1 so PE treats the household as
       receiving SNAP, enabling categorical eligibility for programs like
-      Early Head Start.
+      Head Start and Early Head Start.
     - If no reported snap: return None so PE calculates the SNAP benefit
       amount the household is eligible for.
+
+    ``has_base_benefit`` covers every white-label variant (il_snap, ks_snap, co_snap,
+    …); ``has_benefit`` is an exact match on the bare name, which no white label uses,
+    so reported SNAP never reached PE and the categorical branch could not fire.
+    ``Tanf`` below reads the same way for the same reason.
+
+    Sending 1 does overwrite PE's *calculated* snap for this household, so the SNAP
+    program's own value becomes $1/mo. That is only ever the households that reported
+    receiving SNAP, and the results layer flags those `already_has` and filters the
+    program out (see ``isProgramBasicallyVisible``), so the clamped value is never
+    surfaced. PE models no reported-vs-calculated split for snap the way it does for
+    ssi (``ssi_reported`` / ``use_reported_ssi``), so this is the available signal.
     """
 
     field = "snap"
 
     def value(self):
-        return 1 if self.screen.has_benefit("snap") else None
+        return 1 if self.screen.has_base_benefit("snap") else None
 
 
 class Acp(SpmUnit):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -539,16 +539,45 @@ class TestSnapDependency(TestCase):
         dep = spm.Snap(self.screen, None, {})
         self.assertEqual(dep.field, "snap")
 
+    def _report_snap(self, name_abbreviated: str):
+        """Seed a SNAP program under `name_abbreviated` with base_program set
+        (seed_program leaves it None) and record receipt on the screen, mirroring how
+        has_base_benefit resolves white-label variants."""
+        seed_program(self.white_label, name_abbreviated)
+        Program.objects.filter(white_label=self.white_label, name_abbreviated=name_abbreviated).update(
+            base_program="snap"
+        )
+        _write_current_benefits(self.screen, [name_abbreviated])
+
     def test_value_returns_1_when_screen_has_snap(self):
         """When user reports having SNAP, send 1 to PE to enable categorical eligibility."""
-        seed_program(self.white_label, "snap")
-        _write_current_benefits(self.screen, ["snap"])
+        self._report_snap("snap")
+
+        dep = spm.Snap(self.screen, None, {})
+        self.assertEqual(dep.value(), 1)
+
+    def test_value_returns_1_for_a_white_label_prefixed_snap(self):
+        """Every white label names its SNAP program with a prefix (il_snap, ks_snap, …).
+        Resolving by base_program rather than exact name is what lets reported SNAP reach
+        PE at all — an exact bare-name match found nothing, so no household ever hit the
+        Head Start / Early Head Start categorical branch."""
+        self._report_snap("il_snap")
 
         dep = spm.Snap(self.screen, None, {})
         self.assertEqual(dep.value(), 1)
 
     def test_value_returns_none_when_screen_does_not_have_snap(self):
         """When user does not report SNAP, return None so PE calculates the benefit amount."""
+        dep = spm.Snap(self.screen, None, {})
+        self.assertIsNone(dep.value())
+
+    def test_value_returns_none_for_an_unrelated_reported_benefit(self):
+        """base_program is what matches — an unrelated current benefit must not be read as
+        reported SNAP."""
+        seed_program(self.white_label, "il_tanf")
+        Program.objects.filter(white_label=self.white_label, name_abbreviated="il_tanf").update(base_program="tanf")
+        _write_current_benefits(self.screen, ["il_tanf"])
+
         dep = spm.Snap(self.screen, None, {})
         self.assertIsNone(dep.value())
 

--- a/programs/programs/tx/pe/tests/test_member.py
+++ b/programs/programs/tx/pe/tests/test_member.py
@@ -11,7 +11,14 @@ from django.test import TestCase
 
 from unittest.mock import Mock, MagicMock
 
-from programs.programs.federal.pe.member import Wic, Ssi, CommoditySupplementalFoodProgram, Medicaid
+from programs.programs.federal.pe.member import (
+    Wic,
+    Ssi,
+    CommoditySupplementalFoodProgram,
+    Medicaid,
+    HeadStart,
+    EarlyHeadStart,
+)
 from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
 from programs.programs.policyengine.calculators.dependencies import household, member
 from programs.programs.policyengine.calculators.dependencies.household import TxStateCodeDependency
@@ -27,6 +34,8 @@ from programs.programs.tx.pe.member import (
     TxHarrisCountyRides,
     TxEmergencyMedicaid,
     TxDart,
+    TxHeadStart,
+    TxEarlyHeadStart,
 )
 
 
@@ -1927,3 +1936,29 @@ class TestTxDart(TestCase):
 
         # Verify get_member_variable was called with the correct member ID
         calculator.get_member_variable.assert_called_once_with(42)
+
+
+class TestTxHeadStartWiring(TestCase):
+    """
+    TX-specific wiring for Head Start (ages 3-5) and Early Head Start (birth-3 /
+    pregnant). Both are thin wrappers on the federal calculators, adding only the
+    TX state code.
+
+    The shared contract (pe_name, pe_outputs, no federal input dropped, exactly one
+    state code matching the slug, no ``member_value`` override) is asserted once for
+    all registered subclasses in ``federal/pe/tests/test_head_start.py``.
+    """
+
+    def test_head_start_is_registered_as_tx_head_start(self):
+        self.assertIs(tx_pe_calculators["tx_head_start"], TxHeadStart)
+
+    def test_head_start_pe_inputs_includes_tx_state_code(self):
+        self.assertTrue(issubclass(TxHeadStart, HeadStart))
+        self.assertIn(TxStateCodeDependency, TxHeadStart.pe_inputs)
+
+    def test_early_head_start_is_registered_as_tx_early_head_start(self):
+        self.assertIs(tx_pe_calculators["tx_early_head_start"], TxEarlyHeadStart)
+
+    def test_early_head_start_pe_inputs_includes_tx_state_code(self):
+        self.assertTrue(issubclass(TxEarlyHeadStart, EarlyHeadStart))
+        self.assertIn(TxStateCodeDependency, TxEarlyHeadStart.pe_inputs)


### PR DESCRIPTION
## Summary

Three things, in increasing order of blast radius:

1. **IL Head Start** — a three-line thin wrapper on the federal `HeadStart` PolicyEngine calculator, adding only the IL state code. Same pattern as `KsHeadStart` / `TxHeadStart` / `MaHeadStart`.
2. **Head Start test consolidation** — a new federal contract suite replaces ~65 copy-pasted wiring tests across KS/MA/MO/TX. Net −500 lines. **A reviewer expecting an IL-only diff should know this touches four other states' test files.**
3. **A platform fix** — reported SNAP never reached PolicyEngine, so the Head Start categorical branch could never fire for any state.

Linear: [MFB-263](https://linear.app/myfriendben/issue/MFB-263/program-il-head-start) — Engine/Tier: **PE, Fed (value varies)**

Early Head Start is out of scope and tracked separately, matching the KS (MFB-1053 / MFB-1250) and TX splits.

## 1. The IL program

- `programs/programs/il/pe/member.py` — `IlHeadStart(federal_member.HeadStart)` appending `IlStateCodeDependency`
- `programs/programs/il/pe/__init__.py` — registered `il_head_start`
- `programs/programs/il/head_start/spec.md` — spec, refreshed during review
- `.../data/il_head_start_initial_config.json` — program config

No `registry.py` edit needed: `il_member_calculators` is already spread into `all_member_calculators`, and IL already has member/spm/tax calculator groups.

### The $17,227/child/year value re-derived

Not taken from the research doc — re-derived from the pinned local `policyengine-us` checkout:

| Input | Value |
|---|---|
| `gov.hhs.head_start.spending.IL` (2023-09-01) | $254,239,437 |
| `gov.hhs.head_start.enrollment.IL` (2023-09-01) | 15,906 |
| `gov.hhs.uprating` 2023 → 2026 | 304.7 → 328.4 |

`254,239,437 × (328.4 / 304.7) / 15,906 = **$17,227.12**` ✅

The subtlety: `spending.yaml` carries `uprating: gov.hhs.uprating` but `enrollment.yaml` does **not**, so only the numerator is indexed. Raw 2023 figures give $15,984; uprating from a 2024 base gives $16,738. Neither matches — so the figure is right for the right reason. The spec now carries this derivation table so it stays re-checkable when PE's params move.

## 2. Test consolidation

Head Start states subclass the federal calculator to append a state code, so the federal wiring is a cross-state contract that was being copy-pasted per state — ~65 tests of which roughly 10 asserted anything state-specific, and **TX asserted nothing at all**.

`federal/pe/tests/test_head_start.py` follows the existing `test_tax.py` (CTC/EITC) precedent, but discovers every registered subclass from the registry rather than asserting against one shared class (CTC states register the same object; Head Start states genuinely subclass).

| | Before | After |
|---|---|---|
| Federal | 0 | 30 |
| IL / KS / MO / MA / TX | 11 / 10 / 18 / 26 / **0** | 3 / 2 / 4 / 4 / 4 |

Two assertions are **new**, not relocated:
- `test_state_code_matches_the_slug` — a state cloned from another and left sending the source's state code would resolve the wrong state's per-child dollar value while looking correctly registered
- `test_no_subclass_overrides_member_value` — would flag state variance the `Fed (value varies)` tier says doesn't exist

**Mutation-tested rather than trusted green**, since deleted tests are precisely the ones that can no longer fail. Six deliberate breaks, all caught: dropping a federal input (IL and MA), the wrong state code, a `member_value` override, a stray extra input, and `pe_category`.

Two assertions found *missing* mid-refactor and restored: `pe_category == "people"` (breaking it left the entire 2155-test suite green) and "adds nothing beyond the state code" (MA's hardcoded count of 15, re-expressed as a set difference so adding a federal input updates every state at once).

## 3. Platform fix: reported SNAP now reaches PolicyEngine

`Snap` gated on `has_benefit("snap")` — an exact match on a bare name **no white label uses** (every SNAP program is prefixed: `il_snap`, `ks_snap`, …). Reported SNAP never reached PE, so no household ever hit the Head Start / EHS categorical branch. The sibling `Tanf` dependency already read `has_base_benefit` for this exact reason.

**Blast radius: the 9 Head Start / EHS programs that send this input (IL, KS, MA, MO, TX).** Nothing else consumes it. KS shipped its Head Start with this documented as a known limitation — this fixes it for every state, so `ks_head_start` gains categorical SNAP eligibility on merge. **QA should be aware that's a behavior change to a live program.**

Sending `1` does overwrite PE's *calculated* snap, so that household's SNAP value becomes $1/mo ($12/yr). That only ever affects households who **reported** receiving SNAP, and the results layer marks those `already_has` and filters the program out (`isProgramBasicallyVisible`), so the clamped value is never surfaced. Verified both directions: a low-income household reporting SNAP sees Head Start at $17,227 and no SNAP card; households not reporting SNAP still get real calculated values ($5,628 / $3,708 / $8,448).

PE models no reported-vs-calculated split for `snap` the way it does for SSI (`ssi_reported` / `use_reported_ssi`), so this is the available signal.

## Verification

**All 6 spec scenarios pass** against live PolicyEngine (model 1.784.3):

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Low-income, child age 4 | Eligible $17,227 | Eligible **$17,227** |
| 2 | Child age 7 — too old | Not eligible | Not eligible |
| 3 | Two children ages 3 + 5 | Eligible $34,454 | Eligible **$34,454** |
| 4 | Over-income + SNAP — categorical | Eligible $17,227 | Eligible **$17,227** |
| 5 | Over-income, no categorical | Not eligible | Not eligible |
| 6 | Foster child, over-income | Eligible $17,227 | Eligible **$17,227** |

Scenario 4 only passes because of the SNAP fix above; it returned ineligible before.

**End-to-end in the browser** (local, Playwright): Head Start renders under "Child Care, Youth, and Education" flagged "New Benefit" at **$1,436/month** — $17,227 ÷ 12 = $1,435.58 ✅. SNAP correctly shows a real $469/month on that screen.

**Suite: 2447 passed, 19 skipped.** `black -l 120` clean.

## Config notes

- ✅ `il_child_care` pre-exists via `il_ccap`; importer creates the 5 new documents and 2 navigators
- ✅ Navigator counties use bare `"Cook"`, matching the IL convention in `il_csfp` / `il_nfp`
- ✅ `base_program` validates; `name_abbreviated` lowercase (satisfies the 0158 CHECK)
- `show_in_has_benefits_step` is **`false`**, matching KS/MO. The research draft's 7th scenario (already-receiving dedup) depended on it being `true` and is dropped — with the option absent from the step, there's no input by which a household could report current Head Start receipt.
- `value_type` was **removed**. It was dropped from the `Program` model in MFB-1019 (#1591), so the column no longer exists. Five other configs still carry it as dead weight — cleanup ticket, not this PR.
- `legal_status_required` stays at 6 statuses (matching MO/WA). `gc_under18_no5` / `gc_18plus_no5` are *calculated* age-split sub-filters on `gc_5less` (which IL already lists), and `filterPrograms.ts` early-returns on a basic status match — so adding them is a no-op at best and could imply an age restriction Head Start doesn't have.

## Deploy

```
python manage.py import_program_config programs/management/commands/import_program_config_data/data/il_head_start_initial_config.json
```

- The importer **skips programs that already exist** — a re-run won't apply config edits. Delete the program first, or make the change via admin.
- Expect `active=False` after import; activation is a separate admin step.
- `year: "2026"` only warns if the FPL row is missing, leaving `program.year = None`. Harmless here (the PE calculator never dereferences it, unlike the custom WA/NC/CO Head Start calculators), but confirm the `('2026','2026')` row exists in staging and prod first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
