### PR TITLE
Add MO ACA Premium Tax Credit (mo_aca_ptc)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/mo_aca_ptc_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_aca_ptc_initial_config.json
@@ -3,10 +3,13 @@
     "code": "mo"
   },
   "program_category": {
-    "external_name": "mo_health_care"
+    "external_name": "mo_health_care",
+    "name": "Health Care",
+    "icon": "health_care"
   },
   "program": {
     "name_abbreviated": "mo_aca_ptc",
+    "active": true,
     "year": 2026,
     "base_program": "aca",
     "legal_status_required": [

--- a/programs/management/commands/import_program_config_data/data/mo_aca_ptc_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_aca_ptc_initial_config.json
@@ -1,0 +1,79 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_health_care"
+  },
+  "program": {
+    "name_abbreviated": "mo_aca_ptc",
+    "year": 2026,
+    "base_program": "aca",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission"
+    ],
+    "name": "ACA Premium Tax Credit",
+    "description": "Premium Tax Credit (PTC) can help pay for a health plan through the federal Marketplace. It can lower your monthly insurance bill. The amount depends on your household and expected income for the year.\n\nYou can use all, some, or none of the credit each month. MyFriendBen shows the estimated maximum you may receive. Your actual savings may be lower based on the plan you choose. You must enroll in a plan and pay any amount left on the monthly bill.\n\nHealth insurance offered through your job or a family member's job may affect whether you qualify. The Marketplace application will ask about any current coverage or job-based plans available to your household.\n\nSelect \"Apply Now\" to create an account and apply for coverage through HealthCare.gov.",
+    "description_short": "Health insurance marketplace and premium tax credit",
+    "learn_more_link": "https://www.healthcare.gov/lower-costs/save-on-monthly-premiums/",
+    "apply_button_link": "https://www.healthcare.gov/create-account",
+    "apply_button_description": "",
+    "estimated_application_time": "30 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "value_type": "tax_credit",
+    "value_format": null,
+    "has_calculator": true,
+    "show_on_current_benefits": true,
+    "show_in_has_benefits_step": false,
+    "website_description": "Health insurance marketplace and premium tax credit"
+  },
+  "documents": [
+    {
+      "external_name": "mo_ssn",
+      "text": "Social Security numbers for each person applying, if they have one",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_us_status",
+      "text": "Citizenship or immigration documents or numbers for each person applying, if needed",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_income_proof",
+      "text": "Income records (ex: pay stubs, tax forms, or benefit letters)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_health_insurance",
+      "text": "Current health insurance information, if applicable",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_aca_ptc_employer_coverage",
+      "text": "Information about health insurance offered through a job",
+      "link_url": "https://www.healthcare.gov/downloads/employer-coverage-tool.pdf",
+      "link_text": "Employer Coverage Tool for job-based plans"
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "mo_ma4",
+      "name": "Missouri Association of Area Agencies on Aging (ma4)",
+      "email": "info@ma4web.org",
+      "description": "ma4 provides free, unbiased help with Marketplace health coverage. A Navigator can help you compare plans and apply. Help is available in person, by phone, or online.",
+      "assistance_link": "https://www.ma4web.org/services/ma4-marketplace-navigators/",
+      "phone_number": "+14178689551",
+      "counties": [],
+      "languages": []
+    }
+  ]
+}

--- a/programs/programs/mo/aca_ptc/spec.md
+++ b/programs/programs/mo/aca_ptc/spec.md
@@ -37,7 +37,7 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 5. Determine SLCSP for the coverage family's rating area (single-person tier when dependents don't pay a marketplace premium — see Mixed-coverage households below).
 6. PTC = max(0, SLCSP − required annual contribution).
 7. Truncate to a whole dollar (this is the binding annual value).
-8. Display monthly = truncated annual ÷ 12, rounded.
+8. Display monthly = truncated annual ÷ 12, rounded **to the cent** — not to a whole dollar. (`FormattedValue.tsx` formats via `formatToUSD`, which uses two decimal places for a fractional result and none when the division lands on a whole dollar.)
 
 **This is a benchmark-based maximum, not the household's final legal credit.** The statute determines the actual credit month-by-month and caps it at the premium of the plan someone actually picks — information the screener never has pre-application. A household may end up receiving less than the estimate if their selected plan's premium is below the benchmark. `estimated_value` and all user-facing copy must say "estimated" or "up to," never a guaranteed number.
 
@@ -55,7 +55,7 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 | SLCSP (single-person tier — Scenario 3's children don't pay a premium) | $6,856.14 | $8,580.20 | $6,555.73 |
 | PTC = SLCSP − contribution | $5,006.28 | $6,730.34 | $5,017.98 |
 | **Binding annual value (whole-dollar truncated)** | **$5,006** | **$6,730** | **$5,017** |
-| **Displayed monthly (÷12, rounded)** | **$417/month** | **$561/month** | **$418/month** |
+| **Displayed monthly (÷12, to the cent)** | **$417.17/month** | **$560.83/month** | **$418.08/month** |
 
 **Sources for the two external inputs**, quoted so the numbers can't drift to the wrong year/row:
 

--- a/programs/programs/mo/aca_ptc/spec.md
+++ b/programs/programs/mo/aca_ptc/spec.md
@@ -3,10 +3,13 @@
 ## Program Details
 
 - **Program**: ACA Premium Tax Credit (PTC)
+- **name_abbreviated**: `mo_aca_ptc`
 - **State**: MO
 - **White Label**: mo
 - **Engine + Tier**: PE Federal (value varies) — eligibility and the benefit formula are federal (26 U.S.C. § 36B); nothing that governs *whether* a Missouri household qualifies differs from any other state. What varies for Missouri is the **dollar value** of the credit, driven by the household's county (which sets the benchmark Silver-plan premium) and income relative to the federal poverty line (FPL).
 - **Research Date**: 2026-07-26
+
+**`estimated_value` is the annual figure.** The API returns the whole-dollar annual credit; the frontend divides by 12 for display (`value_format: null` → "Default (Monthly)"). Test scenarios assert the **annual** value, since that is what the API exposes.
 
 Missouri uses the federal Health Insurance Marketplace (HealthCare.gov), not a state-based exchange, so there is no state agency rule to research. A Missouri-specific wiring layer is still needed on the MFB side to get county and current-coverage data to PolicyEngine (PE), but the underlying eligibility/value formula itself is not Missouri-specific.
 
@@ -80,8 +83,9 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 
 ## Implementation Coverage
 
-- ✅ Evaluable and isolated by this spec's scenarios: county-driven SLCSP variation (Scenarios 1–2), per-person mixed-coverage handling (Scenario 3), current employer-sponsored insurance wiring (Scenario 4).
-- ⚠️ Not yet built: county/FIPS derivation from ZIP, and `has_esi` (current employer-sponsored insurance) wiring to PolicyEngine — see the engineering implementation note under Acceptance Criteria below.
+- ✅ Evaluable and isolated by this spec's scenarios: county-driven SLCSP variation (Scenarios 1–2), per-person mixed-coverage handling (Scenario 3), current employer-sponsored insurance wiring (Scenario 4), independent-city county tokens (Scenario 5).
+- ✅ Built in MFB-1204: `MoAca` (registered as `mo_aca_ptc`), `MoCountyDependency` supplying `county_str`, and `HasEsiDependency` supplying `has_esi`. The county input turned out to be `county_str`, not a FIPS derivation from ZIP — PolicyEngine ignores `zip_code` for rating-area purposes, so the federal base class's `ZipCodeDependency` alone produced a state-default SLCSP.
+- ⚠️ Not asserted at the API level: the children's Medicaid eligibility in Scenario 3 (no MO Medicaid program exists to surface it — see that scenario's scope note).
 - This is a **light spec**: eligibility is federal and trusted to PolicyEngine, so the scenario suite isolates Missouri's state-specific *value* and the MFB wiring layer rather than re-testing every federal eligibility branch.
 
 ---
@@ -101,32 +105,37 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 
 ## Acceptance Criteria
 
-- [ ] Scenario 1 (single adult, $30,000/year, Jackson County): **eligible**, $5,006/year ($417/month)
-- [ ] Scenario 2 (same household, Boone County — isolates county/SLCSP variation): **eligible**, $6,730/year ($561/month)
-- [ ] Scenario 3 (single parent + 2 children, $39,000/year, Jackson County — isolates per-person mixed coverage): parent **PTC-eligible**, $5,017/year ($418/month); both children **Medicaid-eligible**, not PTC-eligible
+- [ ] Scenario 1 (single adult, $30,000/year, Jackson County): **eligible**, $5,006/year ($417.17/month)
+- [ ] Scenario 2 (same household, Boone County — isolates county/SLCSP variation): **eligible**, $6,730/year ($560.83/month)
+- [ ] Scenario 3 (single parent + 2 children, $39,000/year, Jackson County — isolates per-person mixed coverage): parent **PTC-eligible**, $5,017/year ($418.08/month); both children **Medicaid-eligible**, not PTC-eligible (PolicyEngine-internal — see the scope note on Scenario 3)
 - [ ] Scenario 4 (single adult with employer-sponsored insurance, Jackson County — MFB wiring regression check): **not eligible**
+- [ ] Scenario 5 (single adult, $30,000/year, St. Louis City — independent-city county token regression check): **eligible**, $4,424/year ($368.67/month)
 
-**Engineering implementation note.** Build required, not promotion — none of this exists yet:
-- Register a Missouri-specific calculator (`MoAca`) under Missouri's `name_abbreviated` key.
-- Derive county/FIPS from the screener's ZIP code and pass it to PolicyEngine as the rating-area input.
-- Wire the screener's health-insurance field (`Employer-sponsored`) to PolicyEngine's `has_esi` input — today nothing wires this, so an otherwise-eligible household with employer coverage would incorrectly show as PTC-eligible until this is built (Scenario 4 is the regression check for it).
-- Do not set filing status from MFB — pass household relationship data (head of household, spouse, dependents) and let PolicyEngine derive filing status from it.
-- Handle mixed-eligibility households at the per-person level (see Benefit Value): a parent can be PTC-eligible while dependents are Medicaid-eligible in the same household, and the UI must reflect both statuses rather than one blanket status.
-- `value_format`: monthly (annual truncated value ÷ 12).
-- **Owner**: MFB engineering, during implementation. **Clears when**: `MoAca` is registered and all four scenarios pass through the real integrated `benefits-api` → PolicyEngine path.
+**Engineering implementation note.** Build required, not promotion — none of this existed at research time. Implemented in MFB-1204:
+- ✅ Register a Missouri-specific calculator (`MoAca`) under Missouri's `name_abbreviated` key (`mo_aca_ptc`).
+- ✅ Pass the household's county to PolicyEngine as the rating-area input. **Corrected during implementation:** the input is `county_str`, not a FIPS value derived from ZIP. The federal base class already sends `zip_code` and PolicyEngine ignores it for rating-area purposes — with ZIP alone, every Missouri county returns the same state-default SLCSP. Handled by `MoCountyDependency`, which also carries the St. Louis City carve-out (Scenario 5).
+- ✅ Wire the screener's health-insurance field (`Employer-sponsored`) to PolicyEngine's `has_esi` input, via `HasEsiDependency` (Scenario 4 is the regression check for it).
+- ✅ Do not set filing status from MFB — pass household relationship data (head of household, spouse, dependents) and let PolicyEngine derive filing status from it.
+- ✅ Handle mixed-eligibility households at the per-person level (see Benefit Value): a parent can be PTC-eligible while dependents are Medicaid-eligible in the same household. PolicyEngine evaluates this per person; MFB sends no household-wide coverage flag.
+- ✅ `value_format`: `null` ("Default (Monthly)") — the API returns the truncated annual value and the frontend divides by 12 for display.
+- **Owner**: MFB engineering, during implementation. **Clears when**: `MoAca` is registered and all five scenarios pass through the real integrated `benefits-api` → PolicyEngine path.
 
 ---
 
 ## Test Scenarios
 
 > Each eligible scenario asserts the expected **dollar value**, so a scenario breaks if Missouri's SLCSP or the calculation chain drifts. Ages are entered via birth month/year (the screener's actual fields, not a raw age field).
+>
+> **Assert the annual value.** `estimated_value` in the API response is annual; the monthly figure in parentheses is what the results page renders (annual ÷ 12, formatted to the cent — *not* rounded to a whole dollar). Both are given so a UI check and an API check agree.
+>
+> **County strings** use Missouri's "County" suffix, matching the screener's ZIP→county map. St. Louis City is the one exception — it is an independent city, not a county, and carries no suffix (Scenario 5).
 
 ### Scenario 1: Single adult, mid-income, Jackson County (Kansas City) — baseline
 **What we're checking**: Baseline PTC eligibility and value for a single adult with income in the Medicaid-expansion-to-400%-FPL band and no other coverage.
-**Expected**: Eligible — **$5,006/year ($417/month)**
+**Expected**: Eligible — estimated annual value `$5,006` (displays as $417.17/month)
 
 **Steps**:
-- **Location**: ZIP `64108`, county `Jackson`
+- **Location**: ZIP `64108`, county `Jackson County`
 - **Household**: 1 person
 - **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), no health insurance, US citizen
 
@@ -136,10 +145,10 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 
 ### Scenario 2: Same person, same income, Boone County (Columbia) — isolates county/SLCSP variation
 **What we're checking**: Whether the credit's dollar value shifts correctly with rating area alone, holding income, age, and household composition constant.
-**Expected**: Eligible — **$6,730/year ($561/month)**
+**Expected**: Eligible — estimated annual value `$6,730` (displays as $560.83/month)
 
 **Steps**:
-- **Location**: ZIP `65201`, county `Boone`
+- **Location**: ZIP `65201`, county `Boone County`
 - **Household**: 1 person
 - **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), no health insurance, US citizen
 
@@ -149,10 +158,12 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 
 ### Scenario 3: Single parent, mixed coverage — parent PTC-eligible, children Medicaid-eligible
 **What we're checking**: Whether the calculator correctly handles a mixed-coverage household, where the parent is PTC-eligible while both children are simultaneously Medicaid-eligible.
-**Expected**: Parent's PTC = **$5,017/year ($418/month)**; both children Medicaid-eligible, not PTC-eligible
+**Expected**: Eligible — estimated annual value `$5,017` (displays as $418.08/month)
+
+> **Scope note on the children's Medicaid status.** The household-level assertion above is the API-testable part. The children being *Medicaid-eligible* is a PolicyEngine-internal fact — MO's catalog has no Medicaid program (only `mo_aca_ptc`, `mo_nslp`, `mo_ssi`, `mo_wic`), so no Medicaid result surfaces in the screener response to assert against. What this scenario proves at the API level is that the presence of two Medicaid-eligible children does **not** suppress or alter the parent's PTC: the value must be the single-person SLCSP figure of `$5,017`, not a family-tier figure. Verified separately against PolicyEngine directly (both children return `medicaid > 0` and `is_aca_ptc_eligible: false`). Revisit if MO ever adds a Medicaid program.
 
 **Steps**:
-- **Location**: ZIP `64108`, county `Jackson`
+- **Location**: ZIP `64108`, county `Jackson County`
 - **Household**: 3 people
 - **Person 1**: Head of Household, birth month/year `March 1991` (age 35), employment income $3,250/month ($39,000/year), no health insurance, US citizen
 - **Person 2**: Child, birth month/year `January 2016`, no income, no health insurance
@@ -167,8 +178,21 @@ PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B
 **Expected**: Not eligible
 
 **Steps**:
-- **Location**: ZIP `64108`, county `Jackson`
+- **Location**: ZIP `64108`, county `Jackson County`
 - **Household**: 1 person
 - **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), health insurance: Employer-sponsored, US citizen
 
 **Why this matters**: confirms current employer coverage is correctly passed through and disqualifies the household — without the `has_esi` wiring (see the engineering implementation note under Acceptance Criteria), this household would incorrectly show as PTC-eligible.
+
+---
+
+### Scenario 5: St. Louis City — independent-city county token regression check
+**What we're checking**: Whether St. Louis City resolves to the correct rating area. St. Louis is an independent city (FIPS 29510), not part of St. Louis County, and PolicyEngine names it `ST_LOUIS_CITY_MO` with no `_COUNTY` insert. The shared county normalizer would otherwise produce `ST_LOUIS_CITY_COUNTY_MO`, which PolicyEngine **does not reject** — it silently falls back to a default rating area, returning a benchmark premium ~$2,846/year too high.
+**Expected**: Eligible — estimated annual value `$4,424` (displays as $368.67/month)
+
+**Steps**:
+- **Location**: ZIP `63101`, county `St. Louis City`
+- **Household**: 1 person
+- **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), no health insurance, US citizen
+
+**Why this matters**: this is the only Missouri county string that breaks the shared normalizer — all 114 others were swept against the PolicyEngine API and resolve correctly. Because PolicyEngine fails *silently* on an unknown county, a regression here surfaces as a plausible-looking wrong number rather than an error. Holding income and household constant against Scenario 1 isolates the county token: $4,424 (St. Louis City) vs $5,006 (Jackson) vs the $7,271 the unrecognized token would produce.

--- a/programs/programs/mo/aca_ptc/spec.md
+++ b/programs/programs/mo/aca_ptc/spec.md
@@ -1,0 +1,174 @@
+# Implement ACA Premium Tax Credit (MO) Program
+
+## Program Details
+
+- **Program**: ACA Premium Tax Credit (PTC)
+- **State**: MO
+- **White Label**: mo
+- **Engine + Tier**: PE Federal (value varies) — eligibility and the benefit formula are federal (26 U.S.C. § 36B); nothing that governs *whether* a Missouri household qualifies differs from any other state. What varies for Missouri is the **dollar value** of the credit, driven by the household's county (which sets the benchmark Silver-plan premium) and income relative to the federal poverty line (FPL).
+- **Research Date**: 2026-07-26
+
+Missouri uses the federal Health Insurance Marketplace (HealthCare.gov), not a state-based exchange, so there is no state agency rule to research. A Missouri-specific wiring layer is still needed on the MFB side to get county and current-coverage data to PolicyEngine (PE), but the underlying eligibility/value formula itself is not Missouri-specific.
+
+---
+
+## Federal Eligibility Scope
+
+PolicyEngine implements federal ACA PTC eligibility nationwide (26 U.S.C. § 36B). Missouri households are subject to the same filing-status, MAGI-to-FPL, Medicaid-coordination, immigration-status, and coverage tests as any other state. This light spec does not reimplement or exhaustively test federal eligibility; its scenarios isolate Missouri's state-specific benefit value (see Benefit Value and Implementation Coverage below), except for Scenario 4, which is an MFB wiring regression check (see Implementation Coverage).
+
+- **Immigration status**: MFB's `legal_status_required` schema bundles DACA recipients into the same `otherWithWorkPermission` bucket as TPS/asylee/parolee holders, even though the ACA excludes DACA recipients specifically. Committed handling: accept this over-inclusion (DACA recipients will be shown as potentially eligible when they are not) — consistent with how other MFB programs handle this same schema limitation. No screener change is being made for this.
+- **Filing status** is never set directly by MFB — it is derived from household relationship data (who is the head of household, spouse, dependents). No MFB calculator sets it explicitly, and this program's test scenarios don't either.
+- **Framing**: this estimates *potential* eligibility, not a completed coverage month. The statute requires actual enrollment, no disqualifying coverage, and premium payment for at least one month — facts a pre-application screener cannot know. Any household that clears the income/status/coverage checks is shown as potential/estimated eligibility, never a guaranteed determination. The program description must use "estimated maximum" framing, not a guaranteed dollar amount.
+
+---
+
+## Benefit Value
+
+**Formula**: `PTC = max(0, SLCSP − required contribution)`, computed annually per tax unit, where `SLCSP` (Second Lowest Cost Silver Plan) is the benchmark Silver-plan premium for the coverage family's rating area and the required contribution is an income-to-FPL sliding-scale percentage of MAGI (Modified Adjusted Gross Income).
+
+**Calculation chain**:
+1. Determine tax-unit size and the applicable FPL amount (see FPL source below).
+2. Compute MAGI ÷ FPL as a percentage.
+3. Look up the applicable-percentage bracket for that FPL percentage (IRS Revenue Procedure 2025-25 §3.01, table below) and interpolate within the bracket.
+4. Required annual contribution = MAGI × applicable percentage.
+5. Determine SLCSP for the coverage family's rating area (single-person tier when dependents don't pay a marketplace premium — see Mixed-coverage households below).
+6. PTC = max(0, SLCSP − required annual contribution).
+7. Truncate to a whole dollar (this is the binding annual value).
+8. Display monthly = truncated annual ÷ 12, rounded.
+
+**This is a benchmark-based maximum, not the household's final legal credit.** The statute determines the actual credit month-by-month and caps it at the premium of the plan someone actually picks — information the screener never has pre-application. A household may end up receiving less than the estimate if their selected plan's premium is below the benchmark. `estimated_value` and all user-facing copy must say "estimated" or "up to," never a guaranteed number.
+
+**Worked example**, showing the calculation for the three test-scenario households below (values are calculated, not citable program amounts):
+
+| Step | Scenario 1 (Jackson, single) | Scenario 2 (Boone, single) | Scenario 3 (Jackson, parent + 2 kids) |
+|---|---|---|---|
+| FPL guideline used | 2025 HHS guideline (2026 coverage uses the prior year's published guideline) | same | same |
+| Tax-unit size / FPL amount | 1 → $15,650 (contiguous US) | 1 → $15,650 | 3 → $15,650 + 2×$5,500 = $26,650 |
+| MAGI | $30,000 | $30,000 | $39,000 |
+| MAGI ÷ FPL | 191% | 191% | 146% |
+| Applicable-percentage bracket | 150–200% | 150–200% | 133–150% |
+| Applicable figure (interpolated within bracket) | 6.1662% | 6.1662% | 3.9429% |
+| Required annual contribution | $1,849.86 | $1,849.86 | $1,537.75 |
+| SLCSP (single-person tier — Scenario 3's children don't pay a premium) | $6,856.14 | $8,580.20 | $6,555.73 |
+| PTC = SLCSP − contribution | $5,006.28 | $6,730.34 | $5,017.98 |
+| **Binding annual value (whole-dollar truncated)** | **$5,006** | **$6,730** | **$5,017** |
+| **Displayed monthly (÷12, rounded)** | **$417/month** | **$561/month** | **$418/month** |
+
+**Sources for the two external inputs**, quoted so the numbers can't drift to the wrong year/row:
+
+- **FPL guideline — use the 2025 HHS poverty guideline** (2026 coverage relies on the prior year's published guideline), per the Federal Register notice (90 FR 5917, 2025-01-17): for "the 48 contiguous states and the District of Columbia," the guideline table lists **"$15,650"** for a household size of 1, with instructions to **"add $5,500 for each additional person."** (The 2026 guideline, $15,960/$5,680, is a different row and does not apply to a 2026 coverage year.)
+- **Applicable-percentage table — use the 2026 table**, IRS Revenue Procedure 2025-25 §3.01:
+
+  | Household income as % of FPL | Initial percentage | Final percentage |
+  |---|---|---|
+  | At least 133% but less than 150% | 3.14% | 4.19% |
+  | At least 150% but less than 200% | 4.19% | 6.60% |
+
+  (The same Revenue Procedure separately sets a 9.96% "Required Contribution Percentage" — that is the employer-coverage affordability threshold covered under Federal Eligibility Scope, not part of this value calculation.)
+
+**Geographic variation**: the SLCSP — not the formula — is the one input that genuinely varies by Missouri geography. Holding income/age/household size constant and changing only county: Jackson County (rating area 3) → $6,856.14 SLCSP; Boone County (rating area 5) → $8,580.20 SLCSP — a $1,724/year swing in the benchmark premium alone. **Scenarios 1 and 2 below isolate exactly this**, holding every other input constant and varying only county.
+
+**Known limitation — PolicyEngine's SLCSP runs slightly below the CMS-filed benchmark.** For Jackson County, PolicyEngine's modeled SLCSP is about 1.6% below the true CMS second-lowest Silver premium ($571.35/mo modeled vs. $580.77/mo actual), understating the annual PTC estimate by roughly $108–113/year. Boone County's gap is much smaller (about $0.36/month, ~$5/year) because its lowest and second-lowest plans happen to be priced close together this year. Committed treatment: the calculator displays PolicyEngine's own computed value as-is; this is a known nationwide PolicyEngine model limitation, not something to correct per state.
+
+**Mixed-coverage households are evaluated per person, not per household.** Eligibility and Medicaid status are computed per person. A parent can be PTC-eligible (on a single-person SLCSP, since dependents don't pay a marketplace premium) while children are simultaneously Medicaid-eligible (Scenario 3 below isolates this). The calculator must not describe the whole household as uniformly "on Medicaid" or "PTC-ineligible."
+
+**Cadence and display**: annual value, displayed monthly (truncated annual ÷ 12). Refundable federal tax credit — eligible households can receive it regardless of tax liability.
+
+**12-month assumption**: every value in this spec assumes 12 months of unchanged eligibility, income, and household composition. The real legal credit can differ month to month if any of those change — an inherent limitation of a point-in-time screener, shared by every other MFB annual-value calculator, not specific to this program.
+
+---
+
+## Implementation Coverage
+
+- ✅ Evaluable and isolated by this spec's scenarios: county-driven SLCSP variation (Scenarios 1–2), per-person mixed-coverage handling (Scenario 3), current employer-sponsored insurance wiring (Scenario 4).
+- ⚠️ Not yet built: county/FIPS derivation from ZIP, and `has_esi` (current employer-sponsored insurance) wiring to PolicyEngine — see the engineering implementation note under Acceptance Criteria below.
+- This is a **light spec**: eligibility is federal and trusted to PolicyEngine, so the scenario suite isolates Missouri's state-specific *value* and the MFB wiring layer rather than re-testing every federal eligibility branch.
+
+---
+
+## Research Sources
+
+**Statute & regulations**
+- [26 U.S.C. § 36B](https://www.law.cornell.edu/uscode/text/26/36B) — Premium Tax Credit statute
+- [26 CFR § 1.36B-1 et seq.](https://www.law.cornell.edu/cfr/text/26/1.36B-1) — PTC regulations
+- [IRS Instructions for Form 8962 (2025)](https://www.irs.gov/instructions/i8962) — "not more than 400%" income eligibility language
+- [IRS Revenue Procedure 2025-25](https://www.irs.gov/pub/irs-drop/rp-25-25.pdf) — 2026 applicable-percentage (required-contribution) table
+
+**Agency data**
+- CMS 2026 Exchange Public Use Files (rate, plan-attributes, service-area) — basis for the CMS cross-check on SLCSP accuracy noted under Benefit Value
+
+---
+
+## Acceptance Criteria
+
+- [ ] Scenario 1 (single adult, $30,000/year, Jackson County): **eligible**, $5,006/year ($417/month)
+- [ ] Scenario 2 (same household, Boone County — isolates county/SLCSP variation): **eligible**, $6,730/year ($561/month)
+- [ ] Scenario 3 (single parent + 2 children, $39,000/year, Jackson County — isolates per-person mixed coverage): parent **PTC-eligible**, $5,017/year ($418/month); both children **Medicaid-eligible**, not PTC-eligible
+- [ ] Scenario 4 (single adult with employer-sponsored insurance, Jackson County — MFB wiring regression check): **not eligible**
+
+**Engineering implementation note.** Build required, not promotion — none of this exists yet:
+- Register a Missouri-specific calculator (`MoAca`) under Missouri's `name_abbreviated` key.
+- Derive county/FIPS from the screener's ZIP code and pass it to PolicyEngine as the rating-area input.
+- Wire the screener's health-insurance field (`Employer-sponsored`) to PolicyEngine's `has_esi` input — today nothing wires this, so an otherwise-eligible household with employer coverage would incorrectly show as PTC-eligible until this is built (Scenario 4 is the regression check for it).
+- Do not set filing status from MFB — pass household relationship data (head of household, spouse, dependents) and let PolicyEngine derive filing status from it.
+- Handle mixed-eligibility households at the per-person level (see Benefit Value): a parent can be PTC-eligible while dependents are Medicaid-eligible in the same household, and the UI must reflect both statuses rather than one blanket status.
+- `value_format`: monthly (annual truncated value ÷ 12).
+- **Owner**: MFB engineering, during implementation. **Clears when**: `MoAca` is registered and all four scenarios pass through the real integrated `benefits-api` → PolicyEngine path.
+
+---
+
+## Test Scenarios
+
+> Each eligible scenario asserts the expected **dollar value**, so a scenario breaks if Missouri's SLCSP or the calculation chain drifts. Ages are entered via birth month/year (the screener's actual fields, not a raw age field).
+
+### Scenario 1: Single adult, mid-income, Jackson County (Kansas City) — baseline
+**What we're checking**: Baseline PTC eligibility and value for a single adult with income in the Medicaid-expansion-to-400%-FPL band and no other coverage.
+**Expected**: Eligible — **$5,006/year ($417/month)**
+
+**Steps**:
+- **Location**: ZIP `64108`, county `Jackson`
+- **Household**: 1 person
+- **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), no health insurance, US citizen
+
+**Why this matters**: the baseline happy-path case confirming a clearly eligible applicant is correctly identified with the right value.
+
+---
+
+### Scenario 2: Same person, same income, Boone County (Columbia) — isolates county/SLCSP variation
+**What we're checking**: Whether the credit's dollar value shifts correctly with rating area alone, holding income, age, and household composition constant.
+**Expected**: Eligible — **$6,730/year ($561/month)**
+
+**Steps**:
+- **Location**: ZIP `65201`, county `Boone`
+- **Household**: 1 person
+- **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), no health insurance, US citizen
+
+**Why this matters**: isolates the rating-area/SLCSP effect — the scenario that most directly demonstrates that only the value, not eligibility, varies by county.
+
+---
+
+### Scenario 3: Single parent, mixed coverage — parent PTC-eligible, children Medicaid-eligible
+**What we're checking**: Whether the calculator correctly handles a mixed-coverage household, where the parent is PTC-eligible while both children are simultaneously Medicaid-eligible.
+**Expected**: Parent's PTC = **$5,017/year ($418/month)**; both children Medicaid-eligible, not PTC-eligible
+
+**Steps**:
+- **Location**: ZIP `64108`, county `Jackson`
+- **Household**: 3 people
+- **Person 1**: Head of Household, birth month/year `March 1991` (age 35), employment income $3,250/month ($39,000/year), no health insurance, US citizen
+- **Person 2**: Child, birth month/year `January 2016`, no income, no health insurance
+- **Person 3**: Child, birth month/year `January 2019`, no income, no health insurance
+
+**Why this matters**: this isolates the common real-world shape for a working single parent in Missouri (adult income above the Medicaid-expansion ceiling, children's Medicaid/CHIP ceiling much higher at the same income). Verifies the calculator picks the correct single-person SLCSP for the parent and doesn't describe the household as uniformly one eligibility status.
+
+---
+
+### Scenario 4: Current employer-sponsored insurance — MFB wiring regression check
+**What we're checking**: Whether current employer-sponsored insurance correctly disqualifies an otherwise-eligible household once `has_esi` is wired to PolicyEngine.
+**Expected**: Not eligible
+
+**Steps**:
+- **Location**: ZIP `64108`, county `Jackson`
+- **Household**: 1 person
+- **Person 1**: Head of Household, birth month/year `March 1986` (age 40), employment income $2,500/month ($30,000/year), health insurance: Employer-sponsored, US citizen
+
+**Why this matters**: confirms current employer coverage is correctly passed through and disqualifies the household — without the `has_esi` wiring (see the engineering implementation note under Acceptance Criteria), this household would incorrectly show as PTC-eligible.

--- a/programs/programs/mo/pe/__init__.py
+++ b/programs/programs/mo/pe/__init__.py
@@ -1,6 +1,7 @@
 from programs.programs.federal.pe.tax import Ctc, Eitc
 import programs.programs.mo.pe.member as member
 import programs.programs.mo.pe.spm as spm
+import programs.programs.mo.pe.tax as tax
 from programs.programs.policyengine.calculators.base import PolicyEngineCalulator
 
 mo_member_calculators = {
@@ -17,6 +18,7 @@ mo_spm_calculators = {
 mo_tax_unit_calculators = {
     "mo_ctc": Ctc,
     "mo_eitc": Eitc,
+    "mo_aca_ptc": tax.MoAca,
 }
 
 mo_pe_calculators: dict[str, type[PolicyEngineCalulator]] = {

--- a/programs/programs/mo/pe/tax.py
+++ b/programs/programs/mo/pe/tax.py
@@ -1,0 +1,45 @@
+from programs.programs.federal.pe.tax import Aca
+import programs.programs.policyengine.calculators.dependencies as dependency
+
+
+class MoAca(Aca):
+    """
+    Missouri ACA Premium Tax Credit — the federal ``Aca`` PE calculator plus the two
+    inputs Missouri's value depends on.
+
+    Nothing about *whether* a Missouri household qualifies is state-specific: Missouri
+    uses HealthCare.gov rather than a state-based exchange, so eligibility is federal end
+    to end (26 U.S.C. 36B) and lives entirely in PolicyEngine. What varies is the dollar
+    value, and it varies by county.
+
+    Two inputs beyond the federal base class:
+
+    - ``MoCountyDependency`` — the benchmark premium (SLCSP) is set per *rating area*, and
+      PolicyEngine keys that off ``county_str``, not ``zip_code``. The federal base already
+      sends ``zip_code``, but PE ignores it for this purpose: holding everything else
+      constant, Jackson and Boone counties both return an SLCSP of $9,362 on zip alone.
+      With county supplied they correctly diverge to $6,856 (Jackson) and $8,580 (Boone) —
+      a $1,724/year swing in the benchmark, which is the whole of Missouri's state-specific
+      variance. See ``MoCountyDependency`` for the St. Louis City special case.
+    - ``HasEsiDependency`` — employer-sponsored coverage is a statutory disqualifier that
+      PolicyEngine applies only if we tell it. Nothing else in our codebase wires the
+      screener's health-insurance field to PE, so without this an applicant with job-based
+      coverage is scored as PTC-eligible.
+
+    Both gaps also affect ``TxAca``/``NcAca``/``IlAca``/``MaAca``, which pass neither input.
+    Fixing them changes results for four already-shipped programs, so that is deliberately
+    out of scope here and tracked separately.
+
+    Known limitation, not corrected here: PolicyEngine's modeled SLCSP runs slightly below
+    the CMS-filed benchmark (about 1.6% low in Jackson County, ~$110/year), and the credit
+    is a benchmark-based *maximum* rather than the household's final legal credit — the
+    statute caps it at the premium of the plan actually chosen. The program copy frames the
+    result as an estimated maximum accordingly.
+    """
+
+    pe_inputs = [
+        *Aca.pe_inputs,
+        dependency.household.MoStateCodeDependency,
+        dependency.household.MoCountyDependency,
+        dependency.member.HasEsiDependency,
+    ]

--- a/programs/programs/mo/pe/tests/test_tax.py
+++ b/programs/programs/mo/pe/tests/test_tax.py
@@ -6,6 +6,10 @@ Missouri has no state CTC or state EITC and no MO-specific variance, so
 ``Eitc`` classes rather than subclasses — the same treatment as ``ks_ctc``,
 ``tx_ctc``/``tx_eitc``, and ``wa_ctc``/``wa_eitc``.
 
+``mo_aca_ptc`` is the exception: ACA PTC eligibility is federal, but its dollar
+value is county-driven, so ``MoAca`` is a real subclass carrying the two extra
+inputs Missouri's value depends on.
+
 That makes registration the only MO-side fact to pin, and one part of it is
 load-bearing: ``mo_tax_unit_calculators`` must be spread into the global
 ``all_tax_unit_calculators`` in ``registry.py``. ``screener.views`` resolves
@@ -20,8 +24,11 @@ these slugs *are* those objects extends those guarantees here.
 
 from django.test import TestCase
 
-from programs.programs.federal.pe.tax import Ctc, Eitc
+import programs.programs.policyengine.calculators.dependencies as dependency
+from programs.programs.federal.pe.tax import Aca, Ctc, Eitc
 from programs.programs.mo.pe import mo_pe_calculators, mo_tax_unit_calculators
+from programs.programs.mo.pe.tax import MoAca
+from programs.programs.policyengine.calculators.base import PolicyEngineTaxUnitCalulator
 from programs.programs.policyengine.calculators.registry import (
     all_calculators,
     all_tax_unit_calculators,
@@ -54,3 +61,65 @@ class TestMoEitcWiring(TestCase):
     def test_matches_builtin_federal_registry_key(self):
         """Same calculator the federal registry serves as ``eitc`` — no MO subclass."""
         self.assertIs(all_tax_unit_calculators["mo_eitc"], all_tax_unit_calculators["eitc"])
+
+
+class TestMoAcaWiring(TestCase):
+    """mo_aca_ptc registration and the MO-specific inputs on MoAca."""
+
+    def test_registered_under_config_name_abbreviated(self):
+        """The registry key must equal the program's ``name_abbreviated`` in
+        ``mo_aca_ptc_initial_config.json`` — ``screener.views`` resolves calculators by
+        that string, so a mismatch silently returns no value."""
+        self.assertIs(mo_tax_unit_calculators["mo_aca_ptc"], MoAca)
+        self.assertIs(mo_pe_calculators["mo_aca_ptc"], MoAca)
+        self.assertIs(all_tax_unit_calculators["mo_aca_ptc"], MoAca)
+        self.assertIs(all_calculators["mo_aca_ptc"], MoAca)
+
+    def test_subclasses_federal_aca(self):
+        self.assertTrue(issubclass(MoAca, Aca))
+        self.assertTrue(issubclass(MoAca, PolicyEngineTaxUnitCalulator))
+
+    def test_pe_name_is_federal_aca_ptc(self):
+        """Eligibility and the formula are federal (26 U.S.C. 36B) — MO reads the same
+        PolicyEngine variable, it just feeds it more inputs."""
+        self.assertEqual(MoAca.pe_name, "aca_ptc")
+        self.assertEqual(MoAca.pe_name, Aca.pe_name)
+
+    def test_pe_outputs_unchanged_from_federal(self):
+        self.assertEqual(MoAca.pe_outputs, Aca.pe_outputs)
+
+    def test_sends_mo_state_code(self):
+        self.assertIn(dependency.household.MoStateCodeDependency, MoAca.pe_inputs)
+
+    def test_sends_county(self):
+        """PolicyEngine keys the benchmark premium (SLCSP) off ``county_str``, not
+        ``zip_code``: without county, Jackson and Boone return the same SLCSP and both
+        scenario values are wrong."""
+        self.assertIn(dependency.household.MoCountyDependency, MoAca.pe_inputs)
+
+    def test_sends_has_esi(self):
+        """Employer coverage is a statutory disqualifier PolicyEngine applies only if we
+        send ``has_esi``; without it a household with job-based coverage scores eligible."""
+        self.assertIn(dependency.member.HasEsiDependency, MoAca.pe_inputs)
+
+    def test_preserves_every_federal_input(self):
+        """MO adds inputs, it never drops one."""
+        for federal_input in Aca.pe_inputs:
+            self.assertIn(federal_input, MoAca.pe_inputs)
+
+    def test_adds_exactly_the_three_mo_inputs(self):
+        added = [dep for dep in MoAca.pe_inputs if dep not in Aca.pe_inputs]
+        self.assertCountEqual(
+            added,
+            [
+                dependency.household.MoStateCodeDependency,
+                dependency.household.MoCountyDependency,
+                dependency.member.HasEsiDependency,
+            ],
+        )
+
+    def test_county_gates_calculation(self):
+        """``MoCountyDependency`` declares ``county`` as a dependency, so a screen with no
+        county is skipped by ``can_calc()`` instead of raising inside ``pe_input()`` and
+        taking down every PolicyEngine program on the screen."""
+        self.assertIn("county", dependency.household.MoCountyDependency.dependencies)

--- a/programs/programs/policyengine/calculators/dependencies/household.py
+++ b/programs/programs/policyengine/calculators/dependencies/household.py
@@ -49,6 +49,20 @@ class CountyDependency(Household):
     dependencies: ClassVar[list[str]] = ["county"]
     state_dependency_class: ClassVar[Optional[Type]] = None  # Override in subclasses
 
+    # Normalized county tokens that PolicyEngine names WITHOUT the "_COUNTY" insert —
+    # county-equivalents that aren't counties: independent cities (St. Louis MO,
+    # Baltimore MD, Carson City NV, and Virginia's 38), and, if we ever ship those
+    # states, Louisiana parishes and Alaska boroughs / census areas.
+    #
+    # This matters because PolicyEngine does NOT reject an unknown county_str. It
+    # silently falls back to a default rating area, so a bad token surfaces as a
+    # plausible-but-wrong benefit value rather than an error. For MO ACA PTC the
+    # unrecognized ST_LOUIS_CITY_COUNTY_MO returned an SLCSP of $9,121 instead of
+    # $6,275 — a ~$2,846/year overstatement that nothing would have flagged.
+    #
+    # Empty by default: no behavior change for any state that doesn't set it.
+    independent_cities: ClassVar[tuple[str, ...]] = ()
+
     def value(self):
         if self.state_dependency_class is None:
             raise ValueError(f"{self.__class__.__name__} must define state_dependency_class")
@@ -64,6 +78,10 @@ class CountyDependency(Household):
         county_token = re.sub(r"[^\w\s]", "", county_str)  # Remove non-alphanumeric except spaces
         county_token = re.sub(r"\s+", "_", county_token.strip())  # Replace whitespace with underscores
         county_token = county_token.upper()  # Uppercase
+
+        # County-equivalents PolicyEngine names without the "_COUNTY" insert
+        if county_token in self.independent_cities:
+            return f"{county_token}_{state_code}"
 
         # Don't append COUNTY if it's already in the county token
         if county_token.endswith("COUNTY"):
@@ -98,32 +116,18 @@ class MoCountyDependency(CountyDependency):
 
     Missouri has one independent city — St. Louis — which is its own county-equivalent
     (FIPS 29510) and is *not* part of St. Louis County. The screener's ZIP map stores it
-    as the literal string ``"St. Louis City"``, and the base normalizer would append
-    ``_COUNTY`` to produce ``ST_LOUIS_CITY_COUNTY_MO``. PolicyEngine doesn't define that
-    token: it silently falls back to a default rating area rather than erroring, which
-    for ACA PTC returns an SLCSP of $9,121 instead of the correct $6,275 — overstating
-    the credit by roughly $2,846/year for the state's second-largest jurisdiction.
+    as the literal string ``"St. Louis City"``, which the base normalizer would otherwise
+    turn into ``ST_LOUIS_CITY_COUNTY_MO``. PolicyEngine's own token is
+    ``ST_LOUIS_CITY_MO`` (verified against ``county_fips`` 29510, which returns the same
+    value); see ``CountyDependency.independent_cities`` for why the mismatch is dangerous.
 
-    PolicyEngine's own token is ``ST_LOUIS_CITY_MO`` (verified against ``county_fips``
-    29510, which returns the same value), so drop the ``_COUNTY`` insert for it. Every
-    other one of Missouri's 114 counties resolves correctly through the base normalizer —
-    checked by sweeping the full ``counties_by_zipcode`` list against the PE API.
+    Every other one of Missouri's 114 counties resolves correctly through the base
+    normalizer — checked by sweeping the full ``counties_by_zipcode`` list against the
+    PE API.
     """
 
     state_dependency_class = MoStateCodeDependency
-
-    # Screener county strings (normalized, pre-suffix) that PolicyEngine names without
-    # the "_COUNTY" insert. Missouri has exactly one independent city.
     independent_cities = ("ST_LOUIS_CITY",)
-
-    def value(self):
-        county_token = super().value()
-
-        for city in self.independent_cities:
-            if county_token == f"{city}_COUNTY_{self.state_dependency_class.state}":
-                return f"{city}_{self.state_dependency_class.state}"
-
-        return county_token
 
 
 class ZipCodeDependency(Household):

--- a/programs/programs/policyengine/calculators/dependencies/household.py
+++ b/programs/programs/policyengine/calculators/dependencies/household.py
@@ -92,6 +92,40 @@ class KsCountyDependency(CountyDependency):
     state_dependency_class = KsStateCodeDependency
 
 
+class MoCountyDependency(CountyDependency):
+    """
+    Missouri county token, with the St. Louis City special case handled.
+
+    Missouri has one independent city — St. Louis — which is its own county-equivalent
+    (FIPS 29510) and is *not* part of St. Louis County. The screener's ZIP map stores it
+    as the literal string ``"St. Louis City"``, and the base normalizer would append
+    ``_COUNTY`` to produce ``ST_LOUIS_CITY_COUNTY_MO``. PolicyEngine doesn't define that
+    token: it silently falls back to a default rating area rather than erroring, which
+    for ACA PTC returns an SLCSP of $9,121 instead of the correct $6,275 — overstating
+    the credit by roughly $2,846/year for the state's second-largest jurisdiction.
+
+    PolicyEngine's own token is ``ST_LOUIS_CITY_MO`` (verified against ``county_fips``
+    29510, which returns the same value), so drop the ``_COUNTY`` insert for it. Every
+    other one of Missouri's 114 counties resolves correctly through the base normalizer —
+    checked by sweeping the full ``counties_by_zipcode`` list against the PE API.
+    """
+
+    state_dependency_class = MoStateCodeDependency
+
+    # Screener county strings (normalized, pre-suffix) that PolicyEngine names without
+    # the "_COUNTY" insert. Missouri has exactly one independent city.
+    independent_cities = ("ST_LOUIS_CITY",)
+
+    def value(self):
+        county_token = super().value()
+
+        for city in self.independent_cities:
+            if county_token == f"{city}_COUNTY_{self.state_dependency_class.state}":
+                return f"{city}_{self.state_dependency_class.state}"
+
+        return county_token
+
+
 class ZipCodeDependency(Household):
     field = "zip_code"
     dependencies = ["zipcode"]

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -715,6 +715,26 @@ class ReceivesMedicaidDependency(Member):
         return self.member.has_insurance_types(("medicaid", "chp", "family_planning"))
 
 
+class HasEsiDependency(Member):
+    """
+    Sends whether the member currently has employer-sponsored insurance.
+    Matches PolicyEngine's ``has_esi`` input variable.
+
+    Load-bearing for ACA PTC: 26 U.S.C. 36B(c)(2)(C) disqualifies anyone enrolled in an
+    eligible employer plan, and PolicyEngine reads exactly this field to apply it. Without
+    it an otherwise-eligible household with job-based coverage is scored as PTC-eligible.
+
+    Sending ``False`` is equivalent to omitting the field (verified against the PE API), so
+    this is safe to send unconditionally rather than returning ``None`` for the negative
+    case the way ``IsMedicareEligibleDependency`` does.
+    """
+
+    field = "has_esi"
+
+    def value(self):
+        return self.member.has_insurance_types(("employer",))
+
+
 class HasBccQualifyingCoverageDependency(Member):
     """
     Determines whether the member has disqualifying insurance coverage for IL BCC program.

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
@@ -217,6 +217,60 @@ class TestCountyDependency(TestCase):
             dep.value()
         self.assertIn("must define state_dependency_class", str(context.exception))
 
+    # --- independent_cities (county-equivalents PE names without the "_COUNTY" insert) ---
+
+    def test_independent_cities_defaults_to_empty(self):
+        """Opt-in: states that don't set it keep the blanket "_COUNTY" behavior."""
+        self.assertEqual(household.CountyDependency.independent_cities, ())
+
+    def test_states_that_do_not_opt_in_are_unaffected(self):
+        for dependency_class in (
+            household.NcCountyDependency,
+            household.IlCountyDependency,
+            household.MaCountyDependency,
+            household.TxCountyDependency,
+            household.KsCountyDependency,
+        ):
+            with self.subTest(dependency_class=dependency_class.__name__):
+                self.assertEqual(dependency_class.independent_cities, ())
+
+    def test_independent_city_omits_county_insert(self):
+        """A token listed in independent_cities gets the state suffix and nothing else."""
+
+        class FakeCountyDependency(household.CountyDependency):
+            state_dependency_class = household.TxStateCodeDependency
+            independent_cities = ("CARSON_CITY",)
+
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="89701", county="Carson City", household_size=1, completed=False
+        )
+        self.assertEqual(FakeCountyDependency(screen, None, {}).value(), "CARSON_CITY_TX")
+
+    def test_independent_cities_matches_after_normalization_not_before(self):
+        """The list holds normalized tokens, so punctuation and casing in the screener
+        string still match — "st. louis  city" must hit the same entry as "St. Louis City"."""
+
+        class FakeCountyDependency(household.CountyDependency):
+            state_dependency_class = household.TxStateCodeDependency
+            independent_cities = ("ST_LOUIS_CITY",)
+
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="63101", county="st. louis  city", household_size=1, completed=False
+        )
+        self.assertEqual(FakeCountyDependency(screen, None, {}).value(), "ST_LOUIS_CITY_TX")
+
+    def test_non_listed_county_still_gets_county_insert(self):
+        """An opted-in subclass only special-cases what it lists — everything else is normal."""
+
+        class FakeCountyDependency(household.CountyDependency):
+            state_dependency_class = household.TxStateCodeDependency
+            independent_cities = ("ST_LOUIS_CITY",)
+
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="78701", county="Travis", household_size=1, completed=False
+        )
+        self.assertEqual(FakeCountyDependency(screen, None, {}).value(), "TRAVIS_COUNTY_TX")
+
 
 class TestMoCountyDependency(TestCase):
     """

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_household.py
@@ -145,6 +145,9 @@ class TestCountyDependency(TestCase):
     def test_ks_county_dependency_state_dependency_class(self):
         self.assertIs(household.KsCountyDependency.state_dependency_class, household.KsStateCodeDependency)
 
+    def test_mo_county_dependency_state_dependency_class(self):
+        self.assertIs(household.MoCountyDependency.state_dependency_class, household.MoStateCodeDependency)
+
     def test_ma_county_dependency_value_formats_correctly(self):
         screen = Screen.objects.create(
             white_label=self.white_label, zipcode="02101", county="Suffolk", household_size=1, completed=False
@@ -213,6 +216,48 @@ class TestCountyDependency(TestCase):
         with self.assertRaises(ValueError) as context:
             dep.value()
         self.assertIn("must define state_dependency_class", str(context.exception))
+
+
+class TestMoCountyDependency(TestCase):
+    """
+    Tests for MoCountyDependency, which adds the St. Louis City carve-out.
+
+    St. Louis is an independent city (FIPS 29510), separate from St. Louis County. The
+    screener's ZIP map stores it as "St. Louis City", and the base normalizer's blanket
+    "_COUNTY" insert produces a token PolicyEngine doesn't define — PE then silently falls
+    back to a default rating area, overstating the ACA PTC benchmark premium rather than
+    raising. These tests pin the correct token so that regression can't return unnoticed.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+
+    def _dep(self, county, zipcode="63101"):
+        screen = Screen.objects.create(
+            white_label=self.white_label, zipcode=zipcode, county=county, household_size=1, completed=False
+        )
+        return household.MoCountyDependency(screen, None, {})
+
+    def test_st_louis_city_omits_county_insert(self):
+        self.assertEqual(self._dep("St. Louis City").value(), "ST_LOUIS_CITY_MO")
+
+    def test_st_louis_county_keeps_county_insert(self):
+        """The county and the independent city are distinct jurisdictions — don't conflate them."""
+        self.assertEqual(self._dep("St. Louis County", zipcode="63105").value(), "ST_LOUIS_COUNTY_MO")
+
+    def test_ordinary_county_uses_base_normalization(self):
+        self.assertEqual(self._dep("Jackson County", zipcode="64108").value(), "JACKSON_COUNTY_MO")
+
+    def test_county_without_suffix_gets_county_insert(self):
+        self.assertEqual(self._dep("Boone", zipcode="65201").value(), "BOONE_COUNTY_MO")
+
+    def test_county_with_period_is_normalized(self):
+        """ "Ste. Genevieve County" -> the period is stripped, not turned into a separator."""
+        self.assertEqual(self._dep("Ste. Genevieve County", zipcode="63670").value(), "STE_GENEVIEVE_COUNTY_MO")
+
+    def test_field_and_dependencies(self):
+        self.assertEqual(household.MoCountyDependency.field, "county_str")
+        self.assertEqual(household.MoCountyDependency.dependencies, ["county"])
 
 
 class TestZipCodeDependency(TestCase):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1745,3 +1745,65 @@ class TestSsiEarnedAndUnearnedIncomeDependencies(TestCase):
     def test_both_return_zero_with_no_income(self):
         self.assertEqual(member.SsiEarnedIncomeDependency(self.screen, self.head, {}).value(), 0)
         self.assertEqual(member.SsiUnearnedIncomeDependency(self.screen, self.head, {}).value(), 0)
+
+
+class TestHasEsiDependency(TestCase):
+    """
+    Tests for HasEsiDependency, which maps the screener's employer-insurance checkbox to
+    PolicyEngine's ``has_esi``.
+
+    This is the statutory employer-coverage disqualifier for the ACA Premium Tax Credit
+    (26 U.S.C. 36B(c)(2)(C)). PolicyEngine only applies it if we send the field, so the
+    False case matters as much as the True case: a member with *some other* coverage must
+    not be scored as having job-based coverage.
+    """
+
+    def setUp(self):
+        from screener.models import Insurance
+
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="64108",
+            county="Jackson County",
+            household_size=1,
+            completed=False,
+        )
+
+        self.with_employer = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=40)
+        Insurance.objects.create(household_member=self.with_employer, employer=True, none=False)
+
+        self.uninsured = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=38)
+        Insurance.objects.create(household_member=self.uninsured, none=True)
+
+        self.with_medicaid = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=10)
+        Insurance.objects.create(household_member=self.with_medicaid, medicaid=True, none=False)
+
+        # No Insurance row at all — has_insurance_types() short-circuits to False.
+        self.no_insurance_record = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=7)
+
+    def test_value_true_when_member_has_employer_coverage(self):
+        self.assertTrue(member.HasEsiDependency(self.screen, self.with_employer, {}).value())
+
+    def test_value_false_when_member_is_uninsured(self):
+        self.assertFalse(member.HasEsiDependency(self.screen, self.uninsured, {}).value())
+
+    def test_value_false_for_non_employer_coverage(self):
+        """Medicaid is not employer-sponsored — it must not trip the ESI disqualifier."""
+        self.assertFalse(member.HasEsiDependency(self.screen, self.with_medicaid, {}).value())
+
+    def test_value_false_when_no_insurance_record_exists(self):
+        self.assertFalse(member.HasEsiDependency(self.screen, self.no_insurance_record, {}).value())
+
+    def test_returns_bool_not_none(self):
+        """False must be sent, not None — the field is safe to send unconditionally."""
+        for household_member in (self.with_employer, self.uninsured, self.no_insurance_record):
+            self.assertIsInstance(member.HasEsiDependency(self.screen, household_member, {}).value(), bool)
+
+    def test_field_name_matches_policyengine_variable(self):
+        self.assertEqual(member.HasEsiDependency.field, "has_esi")
+
+    def test_is_member_level_dependency(self):
+        from programs.programs.policyengine.calculators.dependencies.base import Member
+
+        self.assertTrue(issubclass(member.HasEsiDependency, Member))


### PR DESCRIPTION
## Context & Motivation

Missouri needs the ACA Premium Tax Credit (Marketplace subsidy) on the MO white label. Missouri uses HealthCare.gov rather than a state-based exchange, so eligibility is federal end to end (26 U.S.C. § 36B) and already lives in PolicyEngine's `aca_ptc`. What is Missouri-specific is the **dollar value**, which is driven by the household's county.

- Linear ticket: [MFB-1204 — + Program: MO ACA Premium Tax Credit (Marketplace Subsidy)](https://linear.app/myfriendben/issue/MFB-1204/program-mo-aca-premium-tax-credit-marketplace-subsidy)
- Discovery sub-issue: [MFB-1272](https://linear.app/myfriendben/issue/MFB-1272/discovery-mo-aca-premium-tax-credit-marketplace-subsidy)
- Engine/Tier: **PE · Fed (value varies)**

Two gaps had to be closed for the value to come out right — neither was previously wired anywhere in the codebase:

1. **PolicyEngine keys the benchmark premium (SLCSP) off `county_str`, not `zip_code`.** The federal `Aca` class sends `zip_code`, which PE ignores for this purpose. Verified live against the private PE API (v1.784.3): with zip alone, Jackson and Boone counties both return an SLCSP of $9,362. With county supplied they correctly diverge to $6,856 and $8,580 — a $1,724/yr swing in the benchmark, which is the whole of Missouri's state-specific variance.
2. **Employer-sponsored coverage is a statutory disqualifier (§ 36B(c)(2)(C)) that PE applies only if we send `has_esi`.** Nothing wired the screener's health-insurance field to PE, so an applicant with job-based coverage was scored PTC-eligible.

## Changes Made

**New program class**
- `programs/programs/mo/pe/tax.py` — `MoAca`, a subclass of the federal `Aca` tax-unit calculator adding `MoStateCodeDependency`, `MoCountyDependency`, and `HasEsiDependency`. Every federal input is preserved; MO only adds.
- `programs/programs/mo/pe/__init__.py` — registers `mo_aca_ptc` in `mo_tax_unit_calculators` (already spread into the global registry, so `screener.views` resolves it).

**New dependencies**
- `MoCountyDependency` (`policyengine/calculators/dependencies/household.py`) — supplies `county_str`, **with a carve-out for St. Louis City** (implemented via the shared `CountyDependency.independent_cities` hook, below). St. Louis is Missouri's one independent city (FIPS 29510) and is not part of St. Louis County. The screener's ZIP map stores it as the literal string `"St. Louis City"`, and the shared normalizer's blanket `_COUNTY` insert produced `ST_LOUIS_CITY_COUNTY_MO` — a token PE doesn't define. PE **does not error** on an unknown county; it silently falls back to a default rating area, returning SLCSP $9,121 instead of the correct $6,275 and **overstating the credit by ~$2,846/yr** for the state's second-largest jurisdiction. The correct token is `ST_LOUIS_CITY_MO` (confirmed against `county_fips` 29510). I swept all 115 MO county strings in `counties_by_zipcode` against the PE API — St. Louis City is the only mismatch.
- `CountyDependency.independent_cities` (same file) — a new opt-in tuple on the **shared base**, holding normalized tokens that PE names without the `_COUNTY` insert. Checked inside the normalization rather than post-processing the wrong token. Defaults to empty, so `NcCountyDependency` / `IlCountyDependency` / `MaCountyDependency` / `TxCountyDependency` / `KsCountyDependency` are provably unaffected (there's a test asserting exactly that). This is deliberately on the base and not on MO: the blanket `_COUNTY` insert breaks the same way for Baltimore MD, Carson City NV, Virginia's 38 independent cities, Louisiana parishes, and Alaska boroughs — so the next state gets the fix for free.
- `HasEsiDependency` (`policyengine/calculators/dependencies/member.py`) — maps the screener's `Insurance.employer` checkbox to PE's `has_esi`. Sending `False` is a verified no-op (identical to omitting the field), so it's safe to send unconditionally rather than returning `None` for the negative case.

**Research artifacts**
- `programs/programs/mo/aca_ptc/spec.md` — from the ticket attachment, then corrected after the QA pass (see below).
- `.../import_program_config_data/data/mo_aca_ptc_initial_config.json` — verbatim from the ticket, plus three import fixes in a separate commit:
  - Added `name`/`icon` to `program_category`: `mo_health_care` doesn't exist yet and `import_program_config` hard-errors on an unknown category without them. Uses `"Health Care"` / `health_care`, matching `ma_health_care` and `ks_health_care`.
  - Added `"active": true` — without it the program imports **inactive** and never surfaces.
  - Left `"value_type": "tax_credit"` alone: it isn't a `Program` field and is silently dropped on import. `value_format: null` already means "Default (Monthly)", which is exactly the spec's "annual ÷ 12" requirement and matches `tx_aca`/`nc_aca`/`il_aca`/`ma_aca`.

**Spec corrections after the QA pass** (`6309e202`) — the scenarios as originally written would have produced false failures:
- **Monthly figures were rounded whole dollars.** `FormattedValue.tsx:128` divides the annual value by 12 and `formatToUSD` renders cents on non-integers, so Scenario 2 displays **$560.83**, not $561. Corrected all four, and the scenarios now assert the **annual** value — that's what `estimated_value` exposes.
- **Scenario 3's children-Medicaid assertion isn't checkable via the screener.** MO's catalog has no Medicaid program, so nothing surfaces to assert against. Rescoped to the API-testable claim: two Medicaid-eligible children must not alter the parent's single-person SLCSP value of $5,017. The children's status was confirmed separately against PE directly.
- **Added Scenario 5** (St. Louis City), plus `name_abbreviated` in Program Details and "County"-suffixed county strings matching the ZIP map. Marked the engineering-note items done and corrected "derive county/FIPS from ZIP" → `county_str`, which was wrong.

**Tests** (+43 assertions, no new fixtures)
- `mo/pe/tests/test_tax.py` — `MoAca` registry wiring under the config's `name_abbreviated`, subclass chain, `pe_name` parity with federal, and that MO adds *exactly* the three expected inputs and drops none.
- `dependencies/tests/test_household.py` — the shared `independent_cities` hook (empty default, the five existing subclasses unaffected, normalization-order matching, non-listed counties still get the insert), plus `MoCountyDependency`'s state-class binding and the St. Louis City / St. Louis County distinction, so that regression can't return silently.
- `dependencies/tests/test_member.py` — `HasEsiDependency` across employer / uninsured / non-employer coverage / no-insurance-row, and that it always returns a `bool` rather than `None`.

## Testing

- **Migrations to run:** none — no model changes.
- **Configuration updates needed:**
  ```bash
  venv/bin/python manage.py import_program_config \
    programs/management/commands/import_program_config_data/data/mo_aca_ptc_initial_config.json
  ```
  Creates the `mo_health_care` category, the program (active), 3 new documents, and the `mo_ma4` navigator. Add `--skip-translation` locally if `GOOGLE_APPLICATION_CREDENTIALS` isn't set.
- **Environment variables/settings to add:** none. Uses the existing `POLICY_ENGINE_CLIENT_ID` / `POLICY_ENGINE_CLIENT_SECRET` private-API credentials.
- **Unit tests:** `venv/bin/python -m pytest programs/` → **2,195 passed, 19 skipped**.
- **API QA pass — 5 / 5 PASS.** Every spec scenario was executed against a local server through the full `POST /api/screens/` → `GET /api/eligibility/{uuid}` path (not a direct calculator call), so the screener input layer is covered end to end.

  | # | Scenario | Expected | Actual | Exp. Value | Act. Value | Result | Screen UUID |
  |---|---|---|---|---|---|---|---|
  | 1 | Single adult, $30k/yr, ZIP 64108 Jackson County | Eligible | Eligible | $5,006 | $5,006 | **PASS** | `a2f25999-dc9e-45c5-98d0-2d04ab414422` |
  | 2 | Same household, ZIP 65201 Boone County | Eligible | Eligible | $6,730 | $6,730 | **PASS** | `b3d9fd77-213f-4295-978c-6a55ac1257be` |
  | 3 | Single parent + 2 children, $39k/yr, Jackson County | Eligible | Eligible | $5,017 | $5,017 | **PASS** | `56c18bd8-8fed-4e57-8709-da730b53ecf2` |
  | 4 | Single adult with employer-sponsored insurance | Not eligible | Not eligible | — | $0 | **PASS** | `57e3d644-eac1-4298-b6b0-98540e6d070f` |
  | 5 | Single adult, $30k/yr, St. Louis City (regression) | Eligible | Eligible | $4,424 | $4,424 | **PASS** | `5594c2e1-880f-415a-8ec8-f814a3d8fefe` |

  `failed_tests` empty on every eligible scenario. Confirmed the run genuinely exercised the input layer rather than bypassing it: `birth_year: 1986, birth_month: 3` resolves to age 40 (the spec requires birth month/year, "not a raw age field"), `$2,500/month` resolves to `$30,000/year`, and the serialized payload carries `value_format: null`, all five `legal_status_required` statuses, 5 documents, and the `mo_ma4` navigator.

- **Not covered — needs a browser pass.** `legal_status_required` is returned by the API as a pass-through list and filtered client-side in `filterPrograms.ts`, so the "US citizen" line in every scenario is structurally untestable via API. The rendered monthly value is the same: the API returns the annual figure and `FormattedValue.tsx` divides by 12.

- **To reproduce in the screener:** MO white label → the ZIP/county pairs above, birth month/year per the spec, employment income entered monthly, health insurance = None (or Employer-sponsored for #4).

## Deployment

- **Post-deployment scripts needed:** run `import_program_config` for `mo_aca_ptc_initial_config.json` on staging and again on production. Import is transactional and skips (does not overwrite) an existing program unless `--override` is passed.
- **Production config updates:** none beyond the import. The import sets `active: true` directly.
- **Admin updates needed:** none required. The category name, program copy, documents, and navigator all come from the config. Worth an admin spot-check that the auto-translated copy for the new `mo_health_care` category and the 3 new documents reads correctly in non-English languages.
- **Notify team/users of:** MO gets a new Health Care category on the results page — this is the first program in it, so the category itself is new to MO users.

## Notes for Reviewers

**Please focus on:** the change to the shared `CountyDependency`. PE failing *silently* on an unknown county token is the sharp edge here — a wrong benefit value reads as a formula bug rather than a mapping miss, which is why the fix went on the base class rather than staying MO-local. The hook is opt-in and defaults to empty, so the five existing state subclasses are behaviorally unchanged; `test_states_that_do_not_opt_in_are_unaffected` pins that. Worth confirming you agree the base is the right home.

Considered and rejected: migrating MO to `county_fips`, which is unambiguous and which I verified returns the correct value for 29510. It needs a county→FIPS map we don't have, and `dependencies/base.py` already flags `county_str -> county_fips` as a known future migration tracked as **MFB-1104** — so it belongs to that ticket, not this one.

- **Known limitations:**
  - PolicyEngine's modeled SLCSP runs slightly below the CMS-filed benchmark — about 1.6% low in Jackson County (~$110/yr); Boone's gap is ~$5/yr. Per the spec this is a nationwide PE model limitation and is deliberately **not** corrected per state; we display PE's own computed value.
  - The credit is a benchmark-based **maximum**, not the household's final legal credit — the statute caps it at the premium of the plan actually chosen, which a pre-application screener can't know. Program copy is framed as an estimated maximum accordingly.
  - MFB's `legal_status_required` schema buckets DACA recipients into `otherWithWorkPermission` alongside TPS/asylee/parolee holders, even though the ACA excludes DACA specifically. This over-inclusion is accepted per the spec, consistent with how other MFB programs handle the same schema limitation.
  - Values assume 12 months of unchanged eligibility, income, and household composition — the same point-in-time assumption every other MFB annual-value calculator makes.

- **Future considerations:**
  - **`TxAca` / `NcAca` / `IlAca` / `MaAca` have both of the gaps fixed here** — they pass neither county (so they get a wrong state-default SLCSP) nor `has_esi` (so households with employer coverage show as PTC-eligible). Scoped out of this PR deliberately, since fixing them changes results for four already-shipped programs and needs its own QA pass. Worth a follow-up ticket.
  - `show_in_has_benefits_step` is intentionally `false`. Verified both directions: nothing in the codebase keys off ACA receipt except `nc_medicare_savings` (NC-only; MO has no MSP), and PTC receipt neither confers nor removes eligibility for anything in MO's catalog — SNAP/WIC benefits aren't even counted in MAGI.
  - The `check_pe_support` pre-flight command isn't on `main` (it only exists on the unmerged `david/mfb-1030`), and PE's public metadata endpoint was returning HTTP 500 during this work. PE support was confirmed directly instead — `aca_ptc` is already implemented in `federal/pe/tax.py` and shipped for four states. Might be worth landing that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Missouri’s 2026 ACA Premium Tax Credit, including Missouri-specific eligibility and benefit calculations.
  * Added Missouri county-based benchmark plan pricing behavior and St. Louis City independent-city handling.
  * Added Missouri program configuration with application details, required documents, eligibility statuses, and Marketplace Navigator contact information.
* **Documentation**
  * Added a Missouri ACA Premium Tax Credit specification covering calculation rules, known limitations, acceptance criteria, and integration scenarios.
* **Tests**
  * Expanded coverage for Missouri calculator registration and county/ESI dependency behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->