### PR TITLE
Index Screen.uuid and enforce uniqueness

### DIFF
--- a/screener/migrations/0159_screen_uuid_unique.py
+++ b/screener/migrations/0159_screen_uuid_unique.py
@@ -1,0 +1,43 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Record the unique index on Screen.uuid.
+
+    Every screener request looks a screen up by uuid, and the column had no index:
+    Postgres sequentially scanned all ~222k rows on each one (~70ms, growing with the
+    table). The index was created on production directly, concurrently, so this
+    migration only brings Django's model state in line with the database.
+
+    Environments built from migrations still need the index, so the operation is
+    wrapped in SeparateDatabaseAndState: the state_operations half updates the model,
+    and the database_operations half creates the index only where it does not already
+    exist.
+    """
+
+    dependencies = [
+        ("screener", "0158_drop_snapshot_value_type"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="screen",
+                    name="uuid",
+                    field=models.UUIDField(default=uuid.uuid4, unique=True),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS screener_screen_uuid_uniq "
+                        "ON screener_screen (uuid);"
+                    ),
+                    reverse_sql="DROP INDEX IF EXISTS screener_screen_uuid_uniq;",
+                ),
+            ],
+        ),
+    ]

--- a/screener/models.py
+++ b/screener/models.py
@@ -66,7 +66,7 @@ class WhiteLabel(models.Model):
 # application fields like submission_date, it also contains non-individual
 # household fields. Screen -> HouseholdMember -> IncomeStream & Expense & Insurance
 class Screen(models.Model):
-    uuid = models.UUIDField(default=uuid.uuid4)
+    uuid = models.UUIDField(default=uuid.uuid4, unique=True)
     white_label = models.ForeignKey(
         WhiteLabel,
         related_name="screens",


### PR DESCRIPTION
## Why

Every screener request resolves a screen by `uuid`. The column had no index, so Postgres sequentially scanned the whole table on each lookup:

```
Seq Scan on screener_screen  (actual time=0.016..69.610 rows=1)
  Filter: (uuid = $0)
  Rows Removed by Filter: 221923
  Buffers: shared hit=7088
```

~70ms per lookup on an **idle** database, 43,905 calls in a one-hour sample. The cost scales with the table, which is why the screener has felt progressively slower.

After the index:

```
Index Scan using screener_screen_uuid_uniq  (actual time=0.045..0.046 rows=1)
```

**70ms → 0.046ms.**

## Data cleanup this required

`uuid` is meant to be unique but was never constrained, and six screens from February 2023 shared one value — so five of those households were unreachable through the API. They were six genuinely distinct households (sizes 7/2/2/2/1/1, different counties, two with users attached), not accidental resubmissions.

Handled on production before adding the constraint:

| id | Action |
|---|---|
| 4323 | kept, retains the original uuid |
| 4324, 4326, 4328 | kept, fresh uuids (real households) |
| 4325, 4327 | deleted (`is_test_data = true`) |

The newest duplicate predates all ~217k screens created since, so the underlying bug is long gone. Verified afterward: `dupes=0`, and zero orphaned snapshots, household members, or income streams.

## Migration shape

The index was created on production with `CREATE UNIQUE INDEX CONCURRENTLY` to avoid locking a live 222k-row table. This migration therefore uses `SeparateDatabaseAndState`:

- **state_operations** — records `unique=True` on the model so Django's state matches
- **database_operations** — `CREATE UNIQUE INDEX IF NOT EXISTS`, so environments built from migrations get the index and production is a no-op

Without this, a fresh environment would lack both the index and the constraint, and the sequential scan would come back.

## Verification

- `makemigrations --check` → `No changes detected in app 'screener'`
- `migrate screener 0159 --plan` → plans cleanly
- Production: `Index Scan`, 0.046ms, 221,976 screens, 0 duplicate uuids

## Note

This fixes a fixed ~70ms tax on every request. It does **not** explain the multi-second results-page loads users report — roughly a quarter of `/api/eligibility/` calls exceeded 5s in the sample, peaking near 10s. That remains unexplained and is worth separate investigation; the PolicyEngine call is a single batched request, so it is not per-program fan-out.