### PR TITLE
MFB-1571: fix WIC income-blindness — send PolicyEngine's WIC income sources

### DIFF
--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -4,6 +4,32 @@ from screener.models import HouseholdMember
 
 
 class Wic(PolicyEngineMembersCalculator):
+    """
+    Federal WIC. PolicyEngine decides it with::
+
+        demographic_eligible & (meets_income_test | meets_categorical_test) & nutritional_risk
+
+    The only income input here used to be ``school_meal_countable_income``, which WIC's
+    tree never reads — ``wic_countable_income`` sums its own parameter list,
+    ``gov.usda.wic.income.sources``. Supplying none of those sources let PE substitute an
+    imputation, and because that imputation also satisfied the categorical branch, WIC came
+    back eligible at any reported income (measured: eligible at $150k/yr). ``wic_income`` is
+    that source list, as far as the screener collects it.
+
+    Adjunctive eligibility above 185% FPL is correct, not a bug: 42 U.S.C. § 1786(d)(2)(A)
+    makes SNAP/TANF/Medicaid receipt its own pathway, and the 185% figure attaches only to
+    the income-test pathway. The practical boundary is the state's Medicaid limit — in MO,
+    ~201% FPL via MO HealthNet for Pregnant Women — so QA scenarios asserting a hard 185%
+    cutoff will flag correct behavior as a bug.
+
+    Nutritional risk has no screener field and defaults True in PE, so the third term is
+    always satisfied.
+
+    The base ``wic_categories`` are all zeros; state subclasses either override them with
+    per-category amounts (CO/IL/MA/NC) or override ``member_value`` to return PE's own
+    computed benefit (MO/TX).
+    """
+
     wic_categories = {
         "NONE": 0,
         "INFANT": 0,
@@ -17,7 +43,7 @@ class Wic(PolicyEngineMembersCalculator):
         dependency.member.PregnancyDependency,
         dependency.member.ExpectedChildrenPregnancyDependency,
         dependency.member.AgeDependency,
-        dependency.spm.SchoolMealCountableIncomeDependency,
+        *dependency.wic_income,
     ]
     pe_outputs = [dependency.member.Wic, dependency.member.WicCategory]
 

--- a/programs/programs/federal/pe/tests/test_wic.py
+++ b/programs/programs/federal/pe/tests/test_wic.py
@@ -34,9 +34,11 @@ from programs.programs.policyengine.calculators.registry import all_member_calcu
 
 # PolicyEngine's gov.usda.wic.income.sources, in full (24 variables), so the coverage
 # assertions below are measured against WIC's real list rather than a subset of it.
+# Note that capital_gains is NOT among them: wic_countable_income is
+# ``add(spm_unit, period, sources) + max_(0, capital_gains)``, so it is a separate
+# positive-only term. CAPITAL_GAINS_TERM below covers it.
 WIC_INCOME_SOURCES = {
     "alimony_income",
-    "capital_gains",
     "child_support_received",
     "disability_benefits",
     "dividend_income",
@@ -48,18 +50,21 @@ WIC_INCOME_SOURCES = {
     "military_service_income",
     "miscellaneous_income",
     "pension_income",
+    "railroad_benefits",
     "rental_income",
     "retirement_distributions",
     "self_employment_income",
     "social_security",
     "ssi",
     "strike_benefits",
+    "survivor_benefits",
     "tanf",
     "unemployment_compensation",
     "veterans_benefits",
     "workers_compensation",
-    "railroad_benefits",
 }
+
+CAPITAL_GAINS_TERM = "capital_gains"
 
 # Several sources are reached through a PE ``adds`` chain rather than by name, so the
 # field we send and the source it lands in differ. Verified one field at a time against
@@ -67,24 +72,41 @@ WIC_INCOME_SOURCES = {
 SENT_FIELD_TO_SOURCE = {
     "taxable_pension_income": "pension_income",
     "taxable_ira_distributions": "retirement_distributions",
-    "long_term_capital_gains": "capital_gains",
+    "long_term_capital_gains": CAPITAL_GAINS_TERM,
 }
 
-# WIC sources with no screener field. Adding one should fail this test until the
-# mapping is added too, rather than silently staying unreachable.
+# The 11 sources we never populate. Grouped by *why*, because "unreachable" alone is
+# misleading — for most of these the household's money is still counted, just under a
+# different source. See the wic_income comment for the full reasoning.
 UNREACHABLE_SOURCES = {
+    # Counted elsewhere. PE's social_security adds social_security_disability /
+    # _survivors / _dependents / _retirement, so the screener's SSDI, SS survivor and SS
+    # dependent income is counted there; PE's standalone disability_benefits and
+    # survivor_benefits are the non-Social-Security buckets, additive with it. Veteran
+    # income goes out as taxable_pension_income, and investment income through the
+    # capital-gains term.
     "disability_benefits",
+    "survivor_benefits",
+    "veterans_benefits",
     "dividend_income",
+    "interest_income",
+    # Not collected by the screener at all.
     "educational_assistance",
     "financial_assistance",
     "gi_cash_assistance",
-    "interest_income",
     "military_service_income",
     "railroad_benefits",
     "strike_benefits",
-    # Both collected, but folded into taxable_pension_income / social_security rather
-    # than sent under their own names.
-    "veterans_benefits",
+}
+
+# Screener income the household reports that reaches no PE income field at all, so WIC
+# genuinely undercounts it. The state disability types are what PE's disability_benefits
+# holds; boarder arguably belongs in rental_income. Pinned so the gap stays visible.
+UNSENT_SCREENER_INCOME_TYPES = {
+    "cOSDisability",
+    "stateDisability",
+    "iLStateDisability",
+    "boarder",
 }
 
 
@@ -161,14 +183,44 @@ class TestFederalWicIncomeMapping(TestCase):
         UNREACHABLE_SOURCES would otherwise silently shrink the assertion above."""
         self.assertTrue(UNREACHABLE_SOURCES <= WIC_INCOME_SOURCES)
 
+    def test_sends_the_capital_gains_term(self):
+        """``capital_gains`` is not in WIC's source list — ``wic_countable_income`` is
+        ``add(spm_unit, period, sources) + max_(0, capital_gains)``, so it is a separate
+        term. The screener's investment income reaches it via ``long_term_capital_gains``,
+        which ``capital_gains`` adds. Negative gains clamp to zero (measured)."""
+        self.assertIn(CAPITAL_GAINS_TERM, {SENT_FIELD_TO_SOURCE.get(f, f) for f in _fields(Wic)})
+        self.assertNotIn(CAPITAL_GAINS_TERM, WIC_INCOME_SOURCES)
+
     def test_irs_gross_income_alone_is_not_enough(self):
-        """``MoWic`` shipped ``irs_gross_income`` as a partial fix. It reaches eight of
-        WIC's sources, so it makes wage-type income bind, but it leaves workers' comp,
-        alimony, gifts, child support, SSI and TANF unmapped. That gap is why the bundle
-        exists as its own list."""
+        """``MoWic`` shipped ``irs_gross_income`` as a partial fix. It reaches 7 of WIC's
+        24 sources (plus the capital-gains term), so it makes wage-type income bind, but
+        it leaves workers' comp, alimony, gifts, child support, SSI and TANF unmapped.
+        That gap is why the bundle exists as its own list."""
         irs_only = {SENT_FIELD_TO_SOURCE.get(dep.field, dep.field) for dep in irs_gross_income}
-        self.assertEqual(len(irs_only & WIC_INCOME_SOURCES), 8)
+        self.assertEqual(len(irs_only & WIC_INCOME_SOURCES), 7)
         self.assertLess(irs_only & WIC_INCOME_SOURCES, _sources_reached(Wic))
+
+    def test_ssdi_is_counted_through_social_security(self):
+        """The screener's ``sSDisability`` is Social Security Disability, and PE keeps it
+        in ``social_security`` (which adds ``social_security_disability``), not in the
+        standalone ``disability_benefits`` source. So SSDI *is* counted for WIC even
+        though we never send ``disability_benefits``. Measured: the two are additive, not
+        overlapping — 40k in each yields 80k of countable income."""
+        self.assertIn(member.SocialSecurityIncomeDependency, Wic.pe_inputs)
+        self.assertIn("sSDisability", member.SocialSecurityIncomeDependency.income_types)
+        self.assertEqual(member.SocialSecurityIncomeDependency.field, "social_security")
+
+    def test_state_disability_income_reaches_no_pe_field(self):
+        """The real undercount. ``disability_benefits`` is PE's non-Social-Security
+        disability bucket, and the screener's state disability types are exactly what
+        belongs in it — but no dependency reads them, so WIC never sees that income. This
+        affects CO, IL, MA and TX. Pinned so the gap can't be mistaken for coverage."""
+        sent_income_types = set()
+        for dep in Wic.pe_inputs:
+            sent_income_types.update(getattr(dep, "income_types", []))
+
+        self.assertTrue(UNSENT_SCREENER_INCOME_TYPES.isdisjoint(sent_income_types))
+        self.assertIn("disability_benefits", UNREACHABLE_SOURCES)
 
     def test_child_support_received_is_income_not_the_paid_expense(self):
         """``SnapChildSupportDependency`` sends child support *paid* as an expense. The

--- a/programs/programs/federal/pe/tests/test_wic.py
+++ b/programs/programs/federal/pe/tests/test_wic.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for the shared federal WIC PolicyEngine calculator.
+
+PolicyEngine decides WIC with::
+
+    is_wic_eligible = demographic_eligible
+                      & (meets_wic_income_test | meets_wic_categorical_eligibility)
+                      & nutritional_risk
+
+The bug these tests guard is that neither the income term nor anything
+downstream of it was fed. ``Wic``'s only income input was
+``school_meal_countable_income``, which WIC's tree never reads —
+``wic_countable_income`` sums its own parameter list, ``gov.usda.wic.income.sources``.
+Given none of its sources PE substitutes an imputation, which also satisfies the
+categorical branch, so WIC returned eligible at any reported income. Measured against
+the private household API (MO, pregnant adult + 3yo + infant): eligible at $150k/yr
+before the fix, $0 after.
+
+Every state WIC program subclasses this calculator, so the mapping is a cross-state
+contract. The state assertions below are enumerated from the registry rather than
+listed by hand, so a new state WIC is covered the day it is registered.
+
+The eligibility math itself lives in PolicyEngine and is not duplicated here; what is
+pinned here is which inputs we send.
+"""
+
+from django.test import TestCase
+
+from programs.programs.federal.pe.member import Wic
+from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
+from programs.programs.policyengine.calculators.dependencies import irs_gross_income, member, spm, wic_income
+from programs.programs.policyengine.calculators.dependencies.household import StateCode
+from programs.programs.policyengine.calculators.registry import all_member_calculators
+
+# PolicyEngine's gov.usda.wic.income.sources, in full (24 variables), so the coverage
+# assertions below are measured against WIC's real list rather than a subset of it.
+WIC_INCOME_SOURCES = {
+    "alimony_income",
+    "capital_gains",
+    "child_support_received",
+    "disability_benefits",
+    "dividend_income",
+    "educational_assistance",
+    "employment_income",
+    "financial_assistance",
+    "gi_cash_assistance",
+    "interest_income",
+    "military_service_income",
+    "miscellaneous_income",
+    "pension_income",
+    "rental_income",
+    "retirement_distributions",
+    "self_employment_income",
+    "social_security",
+    "ssi",
+    "strike_benefits",
+    "tanf",
+    "unemployment_compensation",
+    "veterans_benefits",
+    "workers_compensation",
+    "railroad_benefits",
+}
+
+# Several sources are reached through a PE ``adds`` chain rather than by name, so the
+# field we send and the source it lands in differ. Verified one field at a time against
+# the private API: each moved ``wic_countable_income`` by the amount sent.
+SENT_FIELD_TO_SOURCE = {
+    "taxable_pension_income": "pension_income",
+    "taxable_ira_distributions": "retirement_distributions",
+    "long_term_capital_gains": "capital_gains",
+}
+
+# WIC sources with no screener field. Adding one should fail this test until the
+# mapping is added too, rather than silently staying unreachable.
+UNREACHABLE_SOURCES = {
+    "disability_benefits",
+    "dividend_income",
+    "educational_assistance",
+    "financial_assistance",
+    "gi_cash_assistance",
+    "interest_income",
+    "military_service_income",
+    "railroad_benefits",
+    "strike_benefits",
+    # Both collected, but folded into taxable_pension_income / social_security rather
+    # than sent under their own names.
+    "veterans_benefits",
+}
+
+
+def _fields(calculator: type) -> set[str]:
+    return {dep.field for dep in calculator.pe_inputs if hasattr(dep, "field")}
+
+
+def _sources_reached(calculator: type) -> set[str]:
+    reached = set()
+    for field in _fields(calculator):
+        source = SENT_FIELD_TO_SOURCE.get(field, field)
+        if source in WIC_INCOME_SOURCES:
+            reached.add(source)
+    return reached
+
+
+def _registered_state_wic_calculators() -> dict[str, type]:
+    """The state WIC programs. The federal ``Wic`` is itself registered under the bare
+    slug ``wic``, but it is the base contract rather than a shipped program — it carries
+    no state code and its ``wic_categories`` are all zeros — so it is excluded from the
+    per-state assertions it defines."""
+    return {
+        slug: calc
+        for slug, calc in all_member_calculators.items()
+        if isinstance(calc, type) and issubclass(calc, Wic) and calc is not Wic
+    }
+
+
+class TestFederalWicWiring(TestCase):
+    def test_is_a_member_calculator(self):
+        self.assertTrue(issubclass(Wic, PolicyEngineMembersCalculator))
+
+    def test_reads_the_person_level_pe_category(self):
+        """WIC is valued per member (a pregnant adult and each child under 5 qualify
+        separately), so the value must be read out of PolicyEngine's ``people``
+        bucket."""
+        self.assertEqual(Wic.pe_category, "people")
+
+    def test_pe_name(self):
+        self.assertEqual(Wic.pe_name, "wic")
+
+    def test_outputs_are_the_benefit_and_its_category(self):
+        self.assertEqual(Wic.pe_outputs, [member.Wic, member.WicCategory])
+
+    def test_sends_the_demographic_inputs(self):
+        """WIC's demographic term needs age plus the pregnancy pair — a pregnant
+        applicant qualifies in her own right, and the expected-children count sizes
+        the household for the FPG test."""
+        for dep in (member.AgeDependency, member.PregnancyDependency, member.ExpectedChildrenPregnancyDependency):
+            self.assertIn(dep, Wic.pe_inputs)
+
+
+class TestFederalWicIncomeMapping(TestCase):
+    """The income term: every WIC source the screener collects must be sent."""
+
+    def test_sends_the_wic_income_bundle(self):
+        for dep in wic_income:
+            self.assertIn(dep, Wic.pe_inputs)
+
+    def test_no_longer_sends_school_meal_countable_income(self):
+        """WIC's tree never reads it. Measured: sending $150k as
+        ``school_meal_countable_income`` left ``wic_countable_income`` at PE's imputed
+        $3,505 and WIC eligible."""
+        self.assertNotIn(spm.SchoolMealCountableIncomeDependency, Wic.pe_inputs)
+        self.assertNotIn("school_meal_countable_income", _fields(Wic))
+
+    def test_reaches_every_reachable_wic_income_source(self):
+        """The whole point of the fix. If a screener field is added for one of the
+        UNREACHABLE_SOURCES, this fails until the mapping is added."""
+        self.assertEqual(_sources_reached(Wic), WIC_INCOME_SOURCES - UNREACHABLE_SOURCES)
+
+    def test_unreachable_sources_are_a_subset_of_wic_sources(self):
+        """Guards the two constants against drifting apart — an entry misspelled into
+        UNREACHABLE_SOURCES would otherwise silently shrink the assertion above."""
+        self.assertTrue(UNREACHABLE_SOURCES <= WIC_INCOME_SOURCES)
+
+    def test_irs_gross_income_alone_is_not_enough(self):
+        """``MoWic`` shipped ``irs_gross_income`` as a partial fix. It reaches eight of
+        WIC's sources, so it makes wage-type income bind, but it leaves workers' comp,
+        alimony, gifts, child support, SSI and TANF unmapped. That gap is why the bundle
+        exists as its own list."""
+        irs_only = {SENT_FIELD_TO_SOURCE.get(dep.field, dep.field) for dep in irs_gross_income}
+        self.assertEqual(len(irs_only & WIC_INCOME_SOURCES), 8)
+        self.assertLess(irs_only & WIC_INCOME_SOURCES, _sources_reached(Wic))
+
+    def test_child_support_received_is_income_not_the_paid_expense(self):
+        """``SnapChildSupportDependency`` sends child support *paid* as an expense. The
+        two are separate PE fields and a household can report both; collapsing them
+        would count a payer's outflow as their income."""
+        self.assertIn(member.ChildSupportReceivedDependency, Wic.pe_inputs)
+        self.assertEqual(member.ChildSupportReceivedDependency.field, "child_support_received")
+        self.assertEqual(member.SnapChildSupportDependency.field, "child_support_expense")
+        self.assertNotIn(member.SnapChildSupportDependency, Wic.pe_inputs)
+
+    def test_ssi_and_tanf_are_wic_income_sources(self):
+        """Both are in WIC's source list and both are dual-role inputs: they send the
+        reported amount, or None so PE computes its own. Without them PE imputes — an
+        MO household reporting $0 still showed $3,505 of countable income, all of it
+        PE's own TANF figure."""
+        self.assertIn(member.Ssi, Wic.pe_inputs)
+        self.assertIn(spm.Tanf, Wic.pe_inputs)
+
+
+class TestStateWicCalculators(TestCase):
+    """Asserted across every registered WIC program rather than per state, so a newly
+    added state inherits the contract the moment it is registered."""
+
+    def test_states_are_registered(self):
+        """A sanity floor: if the registry lookup silently returned nothing, every
+        assertion below would vacuously pass."""
+        self.assertGreaterEqual(len(_registered_state_wic_calculators()), 6)
+
+    def test_every_state_inherits_the_income_bundle(self):
+        for slug, calculator in _registered_state_wic_calculators().items():
+            with self.subTest(program=slug):
+                for dep in wic_income:
+                    self.assertIn(dep, calculator.pe_inputs)
+
+    def test_every_state_sends_a_state_code(self):
+        """WIC's FPG table branches on AK/HI vs. contiguous US. A subclass with no state
+        code only works when a sibling program happens to put the state in the shared
+        payload, which is luck, not wiring."""
+        for slug, calculator in _registered_state_wic_calculators().items():
+            with self.subTest(program=slug):
+                state_codes = [
+                    dep for dep in calculator.pe_inputs if isinstance(dep, type) and issubclass(dep, StateCode)
+                ]
+                self.assertEqual(len(state_codes), 1)
+
+    def test_every_state_keeps_the_federal_pe_name(self):
+        for slug, calculator in _registered_state_wic_calculators().items():
+            with self.subTest(program=slug):
+                self.assertEqual(calculator.pe_name, "wic")
+
+    def test_every_state_yields_a_nonzero_value_for_an_eligible_member(self):
+        """A state either overrides ``wic_categories`` with per-category dollar amounts
+        or overrides ``member_value`` to return PE's computed benefit. Inheriting the
+        federal base unchanged gives every eligible member $0, and the frontend's
+        ``value > 0`` filter then drops the program from results entirely."""
+        for slug, calculator in _registered_state_wic_calculators().items():
+            with self.subTest(program=slug):
+                overrides_value = calculator.member_value is not Wic.member_value
+                has_amounts = any(amount > 0 for amount in calculator.wic_categories.values())
+                self.assertTrue(overrides_value or has_amounts)

--- a/programs/programs/ma/pe/member.py
+++ b/programs/programs/ma/pe/member.py
@@ -89,6 +89,13 @@ class MaWic(Wic):
         "POSTPARTUM": 91,
         "BREASTFEEDING": 124,
     }
+    # WIC's FPG table branches on AK/HI vs. contiguous US, so the state code is
+    # load-bearing. This was the only WIC subclass not sending one — it worked only
+    # because a sibling MA program put the state in the shared payload.
+    pe_inputs = [
+        *Wic.pe_inputs,
+        dependency.household.MaStateCodeDependency,
+    ]
 
 
 class MaCcdf(Ccdf):

--- a/programs/programs/mo/pe/member.py
+++ b/programs/programs/mo/pe/member.py
@@ -27,46 +27,6 @@ class MoWic(Wic):
     pe_inputs = [
         *Wic.pe_inputs,
         dependency.household.MoStateCodeDependency,
-        # PARTIAL income fix — makes wage-type income bind. See the gap note below.
-        #
-        # The federal ``Wic`` inputs carry only ``school_meal_countable_income``, the school-meals
-        # variable. PolicyEngine's WIC tree never reads it: ``wic_countable_income`` sums its own
-        # parameter list, ``gov.usda.wic.income.sources``. So with the federal inputs alone we
-        # supply *none* of WIC's income sources and PE substitutes its own imputation — it computes
-        # SSI/TANF for the household (both are in that sources list) and, seeing no earnings, also
-        # satisfies the categorical test: ``meets_wic_categorical_eligibility`` fires when PE's own
-        # *computed* snap/tanf benefit is > 0, or when it finds a member Medicaid-eligible
-        # (``medicaid_enrolled`` reduces to ``is_medicaid_eligible`` — take-up defaults True). Per
-        # ``is_wic_eligible``:
-        #
-        #     demographic_eligible & (meets_income_test | meets_categorical_test) & nutritional_risk
-        #
-        # the categorical (adjunct) branch then carries eligibility on its own, so WIC returns
-        # eligible at any reported income — verified live at $108k/yr.
-        #
-        # Adjunct eligibility above 185% FPL is correct, not a bug: 42 USC 1786(d)(2)(A) makes
-        # SNAP/TANF/Medicaid receipt its own pathway, and MO HealthNet for Pregnant Women reaches
-        # 201% FPL (196% + 5% disregard, household includes the unborn child). Verified after this
-        # fix: a pregnant applicant at ~190% FPL is still eligible via the Medicaid branch, and only
-        # falls out at ~205% once both pathways fail. Expect the boundary at MO's Medicaid limit,
-        # not at 185% — QA scenarios should assert that.
-        #
-        # NOTE: the categorical test's *reported*-enrollment inputs (``receives_snap`` /
-        # ``receives_tanf``) are never populated by our code. That is a narrow gap, not a blocker:
-        # PE computes snap/tanf/medicaid eligibility from the income we now send, so genuinely
-        # eligible households still trip the branch. It only bites where PE's computed result
-        # disagrees with reported enrollment (state rules PE doesn't model, or income risen since
-        # enrollment). Tracked in the follow-up ticket.
-        #
-        # GAP: this bundle supplies only 5 of WIC's 24 income sources (employment, self-employment,
-        # social_security, unemployment_compensation, rental); its other three fields
-        # (taxable_pension_income, taxable_ira_distributions, long_term_capital_gains) are not in
-        # WIC's list and are inert here — WIC wants pension_income and retirement_distributions.
-        # Income the screener does collect but WIC still won't see includes veterans' benefits,
-        # workers' comp, alimony, investment and pension income. Mapping those needs new dependency
-        # classes, and the federal base class must be fixed for co/nc/ma/tx_wic, which changes
-        # results for shipped programs. Both are tracked separately, not done here.
-        *dependency.irs_gross_income,
     ]
 
     def member_value(self, member: HouseholdMember):

--- a/programs/programs/mo/pe/tests/test_member.py
+++ b/programs/programs/mo/pe/tests/test_member.py
@@ -17,12 +17,12 @@ MO WIC layers:
    unchanged would value every eligible member at $0 and the frontend's ``value > 0``
    filter would drop the program from results entirely.
 
-3. **Income reaches PolicyEngine** — ``MoWic`` adds the ``irs_gross_income`` bundle the federal
-   inputs omit. Without it PE supplies none of WIC's own income sources, substitutes an
-   imputation, and returns WIC as eligible at any reported income (verified live: $108k/yr came
-   back eligible). This is a *partial* fix covering wage-type income only — see the gap note on
-   ``MoWic.pe_inputs``. co_wic / nc_wic / ma_wic / tx_wic remain affected and are tracked
-   separately.
+3. **Income reaches PolicyEngine** — WIC's income sources now come from the federal
+   ``Wic``'s ``wic_income`` bundle, which every state inherits. ``MoWic`` briefly carried a
+   partial ``irs_gross_income`` fix of its own; that is superseded and must not come back.
+   Which sources the bundle covers, and why, is pinned once in
+   ``federal/pe/tests/test_wic.py``; the assertions here only check that MO inherits it and
+   that a reported wage actually lands in the payload.
 
 MO Head Start / Early Head Start:
 
@@ -100,72 +100,31 @@ class TestMoWicWiring(TestCase):
         for dep in Wic.pe_inputs:
             self.assertIn(dep, MoWic.pe_inputs)
 
-    def test_sends_gross_income_so_wage_income_binds(self):
+    def test_inherits_the_wic_income_bundle(self):
         """
         Regression guard for WIC income-blindness.
 
-        The federal inputs carry only ``school_meal_countable_income``, which PolicyEngine's WIC
-        tree never reads — ``wic_countable_income`` sums ``gov.usda.wic.income.sources`` instead.
-        Supplying none of those sources lets PE substitute its own imputation and find the
-        household categorically (adjunct) eligible, and since ``is_wic_eligible`` is
-        ``demographic & (income_test | categorical) & nutritional_risk`` that alone returns WIC as
-        eligible at any reported income.
+        WIC's income term reads ``gov.usda.wic.income.sources``, not the school-meals
+        aggregate the federal calculator used to send. Supplying none of those sources let PE
+        substitute an imputation and find the household categorically (adjunct) eligible, and
+        since ``is_wic_eligible`` is ``demographic & (income_test | categorical) &
+        nutritional_risk`` that alone returned WIC as eligible at any reported income.
+
+        What the bundle covers is asserted in ``federal/pe/tests/test_wic.py``; this only pins
+        that MO gets it.
         """
-        for dep in dependency.irs_gross_income:
+        for dep in dependency.wic_income:
             self.assertIn(dep, MoWic.pe_inputs)
 
-    def test_wic_income_source_coverage_is_partial(self):
+    def test_does_not_re_add_a_local_income_fix(self):
         """
-        Pins the known gap so it can't drift unnoticed.
-
-        ``irs_gross_income`` supplies 5 of the 24 variables in PE's ``gov.usda.wic.income.sources``.
-        If this starts failing, either the bundle or WIC's source list changed — re-check the gap
-        note on ``MoWic.pe_inputs`` before adjusting the number.
+        ``MoWic`` shipped ``irs_gross_income`` as a partial fix while the federal calculator
+        was still blind. The federal bundle supersedes it, and re-adding a local subset here
+        would silently narrow MO's coverage relative to every other state.
         """
-        wic_income_sources = {
-            "employment_income",
-            "self_employment_income",
-            "military_service_income",
-            "dividend_income",
-            "interest_income",
-            "gi_cash_assistance",
-            "social_security",
-            "ssi",
-            "tanf",
-            "pension_income",
-            "survivor_benefits",
-            "financial_assistance",
-            "miscellaneous_income",
-            "veterans_benefits",
-            "unemployment_compensation",
-            "strike_benefits",
-            "rental_income",
-            "retirement_distributions",
-            "alimony_income",
-            "child_support_received",
-            "disability_benefits",
-            "workers_compensation",
-            "educational_assistance",
-            "railroad_benefits",
-        }
-        sent = {dep.field for dep in MoWic.pe_inputs if hasattr(dep, "field")}
-
         self.assertEqual(
-            sent & wic_income_sources,
-            {
-                "employment_income",
-                "self_employment_income",
-                "social_security",
-                "unemployment_compensation",
-                "rental_income",
-            },
-        )
-
-    def test_federal_wic_alone_would_not_send_gross_income(self):
-        """Pins *why* the bundle is added here: the federal parent omits it (unlike ``Medicaid``)."""
-        self.assertFalse(
-            any(dep in Wic.pe_inputs for dep in dependency.irs_gross_income),
-            "federal Wic now sends gross income — MoWic's override and its comment are redundant",
+            [dep for dep in MoWic.pe_inputs if dep not in Wic.pe_inputs],
+            [MoStateCodeDependency],
         )
 
     def test_keeps_federal_pe_outputs(self):
@@ -273,14 +232,31 @@ class TestMoWicPeInput(TestCase):
         spm_unit = household["spm_units"]["spm_unit"]
         people = household["people"]
 
-        # SPM-level dependency
-        self.assertIn("school_meal_countable_income", spm_unit)
+        # SPM-level dependency: TANF, a WIC income source in its own right
+        self.assertIn("tanf", spm_unit)
 
         # Member-level dependencies
         head_id = str(self.head.id)
         self.assertIn("is_pregnant", people[head_id])
         self.assertIn("current_pregnancies", people[head_id])
         self.assertIn("age", people[head_id])
+
+    def test_wic_alone_carries_every_income_source(self):
+        """
+        The payload is built from the WIC calculator *alone*, which is the only assertion
+        that catches this regression. With siblings present it passes either way — and that
+        is precisely why the bug survived: CO/MA/NC/TX screens run Medicaid and Head Start,
+        both of which send ``irs_gross_income``, so WIC borrowed their inputs. MO shipped WIC
+        as its only program and the omission became visible immediately.
+        """
+        result = pe_input(self.screen, [self._calculator()])
+        head = result["household"]["people"][str(self.head.id)]
+        spm_unit = result["household"]["spm_units"]["spm_unit"]
+
+        for dep in dependency.wic_income:
+            with self.subTest(field=dep.field):
+                unit = spm_unit if dep in (dependency.spm.Tanf,) else head
+                self.assertIn(dep.field, unit)
 
     def test_sends_reported_income_to_policyengine(self):
         """

--- a/programs/programs/policyengine/calculators/dependencies/__init__.py
+++ b/programs/programs/policyengine/calculators/dependencies/__init__.py
@@ -19,23 +19,46 @@ irs_gross_income = [
 # `school_meal_countable_income`, so a calculator sending none of these gets PE's
 # imputation instead of the household's reported income.
 #
-# `irs_gross_income` already reaches eight of the sources, several through PE `adds`
-# chains rather than by name. Measured against the private API (MO, pregnant adult +
-# 3yo + infant), each of these moves `wic_countable_income` by the amount sent:
+#     wic_countable_income = add(spm_unit, period, sources) + max_(0, capital_gains)
 #
+# Of WIC's 24 sources this reaches 13, plus the separate positive-only capital-gains
+# term. Measured one field at a time against the private API: each moved
+# `wic_countable_income` by the amount sent.
+#
+# Sent under the source's own name:
 #   employment_income, self_employment_income, rental_income, social_security,
-#   unemployment_compensation  -> read by name
+#   unemployment_compensation, ssi, tanf, workers_compensation, alimony_income,
+#   miscellaneous_income (gifts), child_support_received
+#
+# Reached through a PE `adds` chain, so the field we send and the source differ:
 #   taxable_pension_income     -> pension_income            (pension, veteran)
 #   taxable_ira_distributions  -> retirement_distributions  (deferredComp)
-#   long_term_capital_gains    -> capital_gains, a term of wic_countable_income
+#   long_term_capital_gains    -> capital_gains             (investment) -- the term,
+#                                                           not a source; negatives clamp to 0
 #
-# The rest below are the remaining sources the screener asks about. `ssi` and `tanf`
-# are dual-role: each sends the reported amount, or None so PE computes its own.
+# `ssi` and `tanf` are dual-role: each sends the reported amount, or None so PE computes
+# its own.
 #
-# WIC sources with no screener field, so still unreachable: military_service_income,
-# gi_cash_assistance, financial_assistance, strike_benefits, educational_assistance,
-# railroad_benefits, disability_benefits. (Veterans' and survivor benefits are
-# collected, but reach PE folded into taxable_pension_income / social_security.)
+# The 11 sources we never populate split into three kinds:
+#
+#   Money we do count, just under a different source. PE keeps SSDI, SS survivor and SS
+#   dependent benefits in `social_security` (which `adds` social_security_disability /
+#   _survivors / _dependents / _retirement), so the screener's sSDisability, sSSurvivor
+#   and sSDependent are counted there. PE's standalone `disability_benefits` and
+#   `survivor_benefits` are the NON-Social-Security buckets — they are additive with
+#   `social_security`, not overlapping. Likewise `veteran` income counts, but it goes out
+#   as taxable_pension_income -> pension_income rather than `veterans_benefits`, and
+#   `investment` counts through the capital-gains term rather than `dividend_income` /
+#   `interest_income`.
+#
+#   Money we collect and drop. The screener's state disability types -- cOSDisability
+#   (CO), stateDisability (TX/MA) and iLStateDisability (IL) -- are exactly what PE's
+#   `disability_benefits` holds, and no dependency reads them, so WIC never sees that
+#   income. `boarder` is the same story (it arguably belongs in rental_income). Both are
+#   real undercounts, in four of the six WIC states.
+#
+#   Money the screener never asks about: military_service_income, gi_cash_assistance,
+#   financial_assistance, strike_benefits, educational_assistance, railroad_benefits.
 wic_income = [
     *irs_gross_income,
     member.WorkersCompensationDependency,

--- a/programs/programs/policyengine/calculators/dependencies/__init__.py
+++ b/programs/programs/policyengine/calculators/dependencies/__init__.py
@@ -13,3 +13,35 @@ irs_gross_income = [
     member.InvestmentIncomeDependency,
     member.RetirementDistributionsDependency,
 ]
+
+# Every variable in PolicyEngine's `gov.usda.wic.income.sources` (7 CFR 246.7(d)(2)(ii)(A))
+# that the screener collects. WIC keeps its own source list and does NOT read
+# `school_meal_countable_income`, so a calculator sending none of these gets PE's
+# imputation instead of the household's reported income.
+#
+# `irs_gross_income` already reaches eight of the sources, several through PE `adds`
+# chains rather than by name. Measured against the private API (MO, pregnant adult +
+# 3yo + infant), each of these moves `wic_countable_income` by the amount sent:
+#
+#   employment_income, self_employment_income, rental_income, social_security,
+#   unemployment_compensation  -> read by name
+#   taxable_pension_income     -> pension_income            (pension, veteran)
+#   taxable_ira_distributions  -> retirement_distributions  (deferredComp)
+#   long_term_capital_gains    -> capital_gains, a term of wic_countable_income
+#
+# The rest below are the remaining sources the screener asks about. `ssi` and `tanf`
+# are dual-role: each sends the reported amount, or None so PE computes its own.
+#
+# WIC sources with no screener field, so still unreachable: military_service_income,
+# gi_cash_assistance, financial_assistance, strike_benefits, educational_assistance,
+# railroad_benefits, disability_benefits. (Veterans' and survivor benefits are
+# collected, but reach PE folded into taxable_pension_income / social_security.)
+wic_income = [
+    *irs_gross_income,
+    member.WorkersCompensationDependency,
+    member.AlimonyIncomeDependency,
+    member.MiscellaneousIncomeDependency,
+    member.ChildSupportReceivedDependency,
+    member.Ssi,
+    spm.Tanf,
+]

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -624,6 +624,18 @@ class AlimonyIncomeDependency(IncomeDependency):
     income_types = ["alimony"]
 
 
+class ChildSupportReceivedDependency(IncomeDependency):
+    """
+    Child support *received*, as income.
+
+    Distinct from ``SnapChildSupportDependency`` above, which sends child support
+    *paid* as an expense (``child_support_expense``). A household can report both.
+    """
+
+    field = "child_support_received"
+    income_types = ["childSupport"]
+
+
 class RetirementDistributionsDependency(IncomeDependency):
     field = "taxable_ira_distributions"
     income_types = ["deferredComp"]

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1807,3 +1807,82 @@ class TestHasEsiDependency(TestCase):
         from programs.programs.policyengine.calculators.dependencies.base import Member
 
         self.assertTrue(issubclass(member.HasEsiDependency, Member))
+
+
+class TestChildSupportReceivedDependency(TestCase):
+    """Child support *received*, sent to PolicyEngine as income (a WIC income source).
+
+    The pairing with ``SnapChildSupportDependency`` is the thing worth guarding: that one
+    sends child support *paid*, as an expense, under a different PE field. A household can
+    report both, and collapsing them would count a payer's outflow as their income.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=2,
+            completed=False,
+        )
+
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=35)
+
+    def test_value_calculates_annual_child_support_received(self):
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="childSupport",
+            amount=400,
+            frequency="monthly",
+        )
+
+        dep = member.ChildSupportReceivedDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 4800)  # $400/month * 12
+
+    def test_value_returns_zero_when_none_reported(self):
+        dep = member.ChildSupportReceivedDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 0)
+
+    def test_value_excludes_other_income_types(self):
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="childSupport",
+            amount=400,
+            frequency="monthly",
+        )
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="alimony",
+            amount=300,
+            frequency="monthly",
+        )
+
+        dep = member.ChildSupportReceivedDependency(self.screen, self.head, {})
+        self.assertEqual(dep.value(), 4800)
+
+    def test_field_name_matches_policyengine_variable(self):
+        self.assertEqual(member.ChildSupportReceivedDependency.field, "child_support_received")
+
+    def test_is_distinct_from_the_child_support_paid_expense(self):
+        """Received income and paid expense are separate PE fields, and both can be
+        non-zero for the same household."""
+        IncomeStream.objects.create(
+            screen=self.screen,
+            household_member=self.head,
+            type="childSupport",
+            amount=400,
+            frequency="monthly",
+        )
+        Expense.objects.create(screen=self.screen, type="childSupport", amount=500, frequency="monthly")
+
+        received = member.ChildSupportReceivedDependency(self.screen, self.head, {})
+        paid = member.SnapChildSupportDependency(self.screen, self.head, {})
+
+        self.assertNotEqual(received.field, paid.field)
+        self.assertEqual(received.value(), 4800)
+        self.assertEqual(paid.value(), 3000)  # $500/month * 12 / household_size(2)

--- a/programs/programs/tx/pe/tests/test_integration.py
+++ b/programs/programs/tx/pe/tests/test_integration.py
@@ -281,14 +281,17 @@ class TestTxWicPeInput(TxPeInputTestBase):
         spm_unit = household["spm_units"]["spm_unit"]
         people = household["people"]
 
-        # SPM-level dependency
-        self.assertIn("school_meal_countable_income", spm_unit)
+        # SPM-level dependency: TANF, a WIC income source in its own right
+        self.assertIn("tanf", spm_unit)
 
         # Member-level dependencies
         head_id = str(self.head.id)
         self.assertIn("is_pregnant", people[head_id])
         self.assertIn("current_pregnancies", people[head_id])
         self.assertIn("age", people[head_id])
+        # WIC's own income sources, which replaced school_meal_countable_income
+        self.assertIn("employment_income", people[head_id])
+        self.assertIn("child_support_received", people[head_id])
 
     def test_includes_pe_output_fields(self):
         """Test that pe_input includes TxWic pe_outputs."""
@@ -644,8 +647,8 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
         head_id = str(self.head.id)
 
         # TxWic fields
-        self.assertIn("school_meal_countable_income", spm_unit)
         self.assertIn("wic", people[head_id])
+        self.assertIn("employment_income", people[head_id])
 
         # TxSnap fields
         self.assertIn("snap_assets", spm_unit)

--- a/programs/programs/tx/pe/tests/test_member.py
+++ b/programs/programs/tx/pe/tests/test_member.py
@@ -118,12 +118,19 @@ class TestTxWic(TestCase):
         self.assertIn(AgeDependency, TxWic.pe_inputs)
         self.assertEqual(AgeDependency.field, "age")
 
-    def test_pe_inputs_includes_school_meal_countable_income_dependency(self):
-        """Test that TxWic inherits SchoolMealCountableIncomeDependency from parent Wic class."""
+    def test_pe_inputs_includes_the_wic_income_bundle(self):
+        """TxWic inherits the WIC income sources from the parent Wic class.
+
+        These replaced ``school_meal_countable_income``, which WIC's tree never read: TX WIC
+        returned eligible at any reported income until the bundle landed. What the bundle
+        covers is pinned in ``federal/pe/tests/test_wic.py``.
+        """
+        from programs.programs.policyengine.calculators.dependencies import wic_income
         from programs.programs.policyengine.calculators.dependencies.spm import SchoolMealCountableIncomeDependency
 
-        self.assertIn(SchoolMealCountableIncomeDependency, TxWic.pe_inputs)
-        self.assertEqual(SchoolMealCountableIncomeDependency.field, "school_meal_countable_income")
+        for dep in wic_income:
+            self.assertIn(dep, TxWic.pe_inputs)
+        self.assertNotIn(SchoolMealCountableIncomeDependency, TxWic.pe_inputs)
 
     def test_has_same_pe_outputs_as_parent(self):
         """Test that TxWic has the same pe_outputs as parent Wic class."""


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes **MFB-1571** — WIC calculators are income-blind: the federal `Wic` sends none of PolicyEngine's WIC income sources
- Related PR: #1674 — the previous attempt at this ticket. It accumulated work from two other investigations (income capture from #1659, and the dead-`has_benefit()` cleanup that has since landed on `main` as #1681 / MFB-1604). **This branch replaces it and is WIC-only.** #1674 should be closed.
- Related: **MFB-1213** (MO WIC), where the bug surfaced

PolicyEngine decides WIC with

```
is_wic_eligible = demographic_eligible & (meets_income_test | meets_categorical_test) & nutritional_risk
```

and the income term was never fed. The federal `Wic`'s only income input was `school_meal_countable_income`, which WIC's tree never reads — `wic_countable_income` sums its own parameter list, `gov.usda.wic.income.sources` (24 variables), and the school-meals variable is not among them.

Given none of its sources, PE substitutes an imputation. Two things follow: the imputation itself is nonzero (a $0-income MO household shows ~$3,505 of countable income, all of it PE's own computed TANF), and seeing no earnings PE also satisfies the categorical branch via its computed SNAP/TANF and Medicaid eligibility. Since the two branches are OR'd, the categorical branch carried eligibility on its own and the income test never bound. **WIC returned eligible at any reported income** in all six states.

`mo_wic` shipped a partial fix (`irs_gross_income` on the subclass only), so wage-type income bound there; `co_wic` / `il_wic` / `ma_wic` / `nc_wic` / `tx_wic` were fully affected.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

- **New `wic_income` bundle** (`dependencies/__init__.py`) — every source in `gov.usda.wic.income.sources` the screener actually collects: `irs_gross_income` plus `workers_compensation`, `alimony_income`, `miscellaneous_income` (gifts), `child_support_received`, and reported `ssi` / `tanf`. The comment records the `adds` chains so the next reader doesn't have to re-derive them.
- **`ChildSupportReceivedDependency`** (`dependencies/member.py`) — child support *received*, as income. Distinct from the existing `SnapChildSupportDependency`, which sends child support *paid* as an expense (`child_support_expense`); a household can report both, and collapsing them would count a payer's outflow as their income. Asserted side by side in tests so an edit can't merge them.
- **Federal `Wic`** now sends `wic_income` and no longer sends `school_meal_countable_income`. All six state WIC calculators inherit the fix. The class docstring explains the eligibility tree and warns that the practical boundary is the state's Medicaid limit, not 185% FPL.
- **`MoWic`** trimmed to just `MoStateCodeDependency` — its partial fix and ~40-line gap note are superseded by the federal bundle.
- **`MaWic`** now sends `MaStateCodeDependency`. It was the only WIC subclass sending no state code, and worked only because a sibling MA program happened to put the state in the shared payload. WIC's FPG table branches on AK/HI vs. contiguous US, so it shouldn't be inherited by luck.
- **Tests** — new `federal/pe/tests/test_wic.py` (20 tests) is the authoritative coverage: it pins our mapping against WIC's real 24-source list and the separate capital-gains term, accounting for the `adds` chains, and asserts *every* state WIC calculator inherits the bundle and sends exactly one state code — enumerated from the registry, so a new state program is covered the day it's added. It also pins the two routing facts that are easy to get backwards: that SSDI counts through `social_security` rather than `disability_benefits`, and that the screener's state disability income reaches no PE field at all. Plus 5 dependency tests for `ChildSupportReceivedDependency`, and a WIC-only payload test in the MO suite (see reviewer notes).
- Updated the MO and TX tests that encoded the old behavior, including MO's `test_wic_income_source_coverage_is_partial`, whose "5 of 24" assertion was never right (see below).

### Correction to the ticket's analysis

The ticket's "Work required" item 2 states that `irs_gross_income` covers **5 of 24** WIC sources and that three of its fields are inert for WIC. Neither holds — PE resolves several sources through `adds` chains, and each of these moves `wic_countable_income` by the amount sent:

| Field we send | Reaches | Screener income types |
| -- | -- | -- |
| `taxable_pension_income` | → `pension_income` | pension, veteran |
| `taxable_ira_distributions` | → `retirement_distributions` | deferredComp |
| `long_term_capital_gains` | → `capital_gains` | investment |

The counts are **7 of 24** through `irs_gross_income` and **13 of 24** for the full bundle, plus the capital-gains term. Note that `capital_gains` is *not* one of WIC's sources: `wic_countable_income` is `add(spm_unit, period, sources) + max_(0, capital_gains)`, so it is a separate positive-only term (negatives clamp to zero — measured). PR #1674 counted it as a source and reported "8"; these figures are taken from `gov/usda/wic/income/sources.yaml` itself.

**`disability_benefits` is not SSDI, and this is the one most likely to be read backwards.** PE's `social_security` is a pure `adds` variable over `social_security_{disability,survivors,dependents,retirement}`, so the screener's `sSDisability` / `sSSurvivor` / `sSDependent` are counted for WIC there. PE's standalone `disability_benefits` and `survivor_benefits` are the *non*-Social-Security buckets — measured as additive with `social_security` (40k in each → 80k countable), not overlapping. So SSDI income counts; we simply never populate those two fields.

Also measured: the ~$3,505 of phantom income PE imputes for a $0-income MO household is **TANF**, not SSI — sending `ssi: 0` changes nothing, `tanf: 0` zeroes it.

## Testing

<!-- Steps needed to test this PR locally -->

- **Migrations to run:** none.
- **Configuration updates needed:** none.
- **Environment variables/settings to add:** none.
- **Automated tests:** `python manage.py test programs screener configuration` → **2895 pass, 0 failures** locally. `black --check programs/` clean.
- **The source list and every `adds` chain were read out of policyengine-us itself** (`gov/usda/wic/income/sources.yaml`, `wic_countable_income.py`, and the `social_security` / `pension_income` / `retirement_distributions` / `capital_gains` variable definitions), not inferred from variable names. That is what caught the `capital_gains`-vs-`survivor_benefits` and `disability_benefits`-vs-SSDI mistakes.
- **Verified against the live private API.** Household: MO, pregnant adult + 3yo + infant.
  - Each of the 14 mapped fields was sent one at a time; every one moved `wic_countable_income` by the amount sent. `school_meal_countable_income` did not — at $150k it left countable income at PE's imputed $3,505 and WIC eligible, confirming it was inert and safe to drop.
  - `child_support_received` is a valid field on PE's `current`, and the whole bundle sent at once returns 200. **No `min_pe_version` gate is needed for anything in this PR.**
  - Routing checks, with `tanf` zeroed so the imputation didn't mask the delta: `social_security_disability` and `social_security` each moved countable income by the full amount, and `social_security` + `disability_benefits` together summed rather than overlapped — confirming SSDI counts and that `disability_benefits` is a distinct bucket. `dividend_income`, `interest_income`, `survivor_benefits` and `veterans_benefits` are all live WIC sources we don't populate; a negative `long_term_capital_gains` clamped to 0.
  - End-to-end through the real `pe_input` payload with `MoWic` as the *only* program: **$150k/yr → $0 (not eligible)**, where before this PR it returned eligible; **$31.2k/yr → eligible**, with `wic_countable_income` binding at exactly 31,200.
- **Manual testing steps:**
  1. **Income now binds.** A WIC-eligible household (pregnant applicant, or a child under 5) at ~$150k/yr should now be **not eligible** for WIC in CO / IL / MA / MO / NC / TX. Before this PR it returned eligible at every income.
  2. **The adjunctive band still holds, and this is the step most likely to be misread as a bug.** A pregnant applicant *above* 185% FPL but under the state's Medicaid limit should still be **eligible**, carried by the Medicaid branch. In MO that band runs to ~201% FPL (MO HealthNet for Pregnant Women, 196% + 5% disregard, household includes the unborn child). Only above *both* thresholds does WIC drop out. Asserting a hard 185% cutoff will flag correct behavior as a bug.
  3. **Newly counted income types.** Enter child support received, workers' comp, alimony, or gifts — these now reach PE and reduce WIC eligibility at the margin. See the reviewer note, because they reach more than WIC.
  4. **State disability income still won't bind — that's pre-existing, not a regression from this PR.** A CO/IL/MA/TX household whose only income is state disability (`cOSDisability` / `stateDisability` / `iLStateDisability`) will still show WIC at any amount, because no dependency sends that income to PolicyEngine. Worth knowing before it gets filed as a bug against this change. SSDI, by contrast, *does* bind — it goes out as `social_security`.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- **Post-deployment scripts needed:** none. No migrations, no config or translation changes.
- **Production config updates:** none.
- **Admin updates needed:** none.
- **Notify team/users of:** eligibility changes in **six** states, before this reaches prod.
  - WIC stops showing for high-income households in CO, IL, MA, MO, NC and TX. This is the intended correction, but it removes a program from results for real users.
  - Households reporting child support, workers' comp, alimony or gifts may see **SNAP, SSI, state TANF and childcare-subsidy** values fall — see the reviewer note. That is a wider surface than WIC and deserves its own QA pass.
  - QA should cover CO, IL, MA, MO, NC and TX, and must not assert a hard 185% FPL cutoff (see manual testing step 2) or expect state disability income to bind (step 4).

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- **The blast radius is wider than WIC, and that's the thing to scrutinize.** PolicyEngine gets one merged household per request, not one per program, so the four newly-sent income fields are visible to every calculator in that request. Checking PE's parameter files: `child_support_received`, `workers_compensation` and `alimony_income` appear in `gov/usda/snap/income/sources/unearned.yaml`, `gov/ssa/ssi/income/sources/unearned.yaml`, the CO/IL/NC/TX state TANF unearned lists, MA CCFA, NC SCCA, IL AABD/HBWD and Denver property tax relief; `miscellaneous_income` appears in the SNAP, school-meals and several state TANF lists. A household reporting any of them will see those benefits fall. That is more correct — the income is legally countable and we were hiding it — but it changes shipped values beyond this ticket. Say the word if you'd rather those four moved to their own ticket, leaving this PR to `irs_gross_income` + `ssi`/`tanf`.
- **Why the WIC-only payload test matters.** `TestMoWicPeInput.test_wic_alone_carries_every_income_source` builds the payload from the WIC calculator *alone*. With sibling programs present it passes either way — which is precisely why this bug survived: CO/MA/NC/TX screens run Medicaid and Head Start, both of which send `irs_gross_income`, so WIC borrowed their inputs. MO shipped WIC as its only program and the omission became visible immediately. A WIC-only payload is the only assertion that catches a regression here.
- **What this PR deliberately does *not* carry**, relative to #1674:
  - `receives_snap` / `receives_tanf` (reported-receipt booleans) stay with **MFB-1312**. They're a real gap but a narrow one — `Snap`/`Tanf` already resolve receipt through `has_base_benefit` on `main`, so a reporting household already trips the categorical branch via PE's computed benefit. Deferring them also sidesteps #1674's stated merge blocker: both are policyengine-us 1.779.3 fields carrying no `min_pe_version`, and an unknown input 400s the *entire* request, taking down every PE program in it.
  - The dead-`has_benefit()`-base-name cleanup, which landed independently as #1681 (MFB-1604).
  - The `wa_snap` `base_program` backfill migration, which existed only to serve `ReceivesSnapDependency`. With the receipt inputs deferred, nothing here needs it.
- **Known limitations:**
  - **The bundle reaches 13 of WIC's 24 sources, plus the capital-gains term.** The other 11 split three ways, and "unreachable" is misleading for most of them — the household's money is usually still counted, just under a different source:
    - *Counted elsewhere:* `disability_benefits`, `survivor_benefits`, `veterans_benefits`, `dividend_income`, `interest_income`. PE's `social_security` adds `social_security_disability` / `_survivors` / `_dependents` / `_retirement`, so the screener's SSDI, SS survivor and SS dependent income all count there; PE's standalone `disability_benefits` and `survivor_benefits` are the *non*-Social-Security buckets (measured as additive with `social_security`, not overlapping). Veteran income counts via `taxable_pension_income` → `pension_income`, and investment income via the capital-gains term.
    - *Collected and dropped — a real undercount:* the screener's state disability types (`cOSDisability` in CO, `stateDisability` in TX/MA, `iLStateDisability` in IL) are exactly what PE's `disability_benefits` holds, and **no dependency reads them at all**, so that income reaches no PE field and WIC never sees it. Affects four of the six WIC states. `boarder` is the same story. Both are pre-existing and left alone here, but `UNSENT_SCREENER_INCOME_TYPES` in the new test file pins the gap so it stays visible.
    - *Never asked about:* `military_service_income`, `gi_cash_assistance`, `financial_assistance`, `strike_benefits`, `educational_assistance`, `railroad_benefits`.
  - **`veteran` income maps to `taxable_pension_income`.** That makes it count for WIC (correct — veterans' benefits are countable), but VA benefits aren't taxable, so the mapping is questionable for the tax programs reading the same field. Pre-existing; not touched here.
  - PE's imputed TANF still adds ~$3,505/yr of phantom income to a $0-income household's WIC countable income, because `spm.Tanf` sends `None` when nothing is reported and PE computes its own. It never changes an outcome — such households pass categorically — so the `Tanf` contract is left alone; MFB-1312 owns it.
  - Nutritional risk defaults to `True` in PE and the screener doesn't ask, so `is_wic_eligible`'s third term is always satisfied. Unchanged here.
  - The federal `Wic` is itself registered under the bare slug `wic`, with all-zero `wic_categories` and no `member_value` override — so a white label enabling it directly would get $0 for every member. Pre-existing and out of scope; the new test excludes it from the per-state assertions with a comment saying why.
- **Future considerations:**
  - `receives_snap` / `receives_tanf` are also read by Head Start's and SNAP's own categorical tests, and by Medicaid community-engagement. Wiring them in would close the same reported-vs-computed gap the KS Head Start spec documents as a known limitation — MFB-1312.
  - The federal `Wic` has no `spec.md` ("Fed (as-is)" tier). The eligibility logic now lives in the class docstring instead; if WIC ever gets a spec, the 185%-vs-Medicaid boundary is the thing that most needs writing down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved WIC eligibility calculations by including comprehensive income sources such as received child support, SSI, TANF, alimony, and workers’ compensation.
  - Added state-specific handling for Massachusetts and Missouri state codes.
  - Improved Texas WIC integration for employment, child-support, and TANF income.
  - Added clearer documentation of WIC eligibility and income requirements.

- **Bug Fixes**
  - Corrected income mapping and removed reliance on school-meal income data.

- **Tests**
  - Added comprehensive federal and state validation for WIC income, eligibility, and state-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

