### PR TITLE
MFB-1312: adopt PolicyEngine's actual-receipt contract for SSI / TANF / SNAP / WIC

### DIFF
--- a/programs/programs/co/pe/member.py
+++ b/programs/programs/co/pe/member.py
@@ -29,7 +29,9 @@ class AidToTheNeedyAndDisabled(PolicyEngineMembersCalculator):
     pe_name = "co_state_supplement"
     pe_inputs = [
         dependency.member.SsiCountableResourcesDependency,
-        dependency.member.SsiReportedDependency,
+        # co_state_supplement tops up SSI, so it reads the `ssi` amount the receipt
+        # contract supplies (reported where reported, simulated-and-suppressed otherwise).
+        *dependency.receipt_contract,
         dependency.member.IsBlindDependency,
         dependency.member.IsDisabledDependency,
         dependency.member.SsiEarnedIncomeDependency,

--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -38,9 +38,7 @@ class Wic(PolicyEngineMembersCalculator):
         "POSTPARTUM": 0,
         "BREASTFEEDING": 0,
     }
-    # The would-be output, since every WIC subclass gates on this being positive and the
-    # receipt-gated `wic` is zeroed by any take-up suppression.
-    pe_name = "wic_if_takes_up"
+    pe_name = "wic"
     pe_inputs = [
         dependency.member.PregnancyDependency,
         dependency.member.ExpectedChildrenPregnancyDependency,
@@ -49,7 +47,7 @@ class Wic(PolicyEngineMembersCalculator):
         # WIC's adjunct test reads SNAP/TANF receipt.
         *dependency.receipt_contract,
     ]
-    pe_outputs = [dependency.member.WicIfTakesUp, dependency.member.WicCategory]
+    pe_outputs = [dependency.member.Wic, dependency.member.WicCategory]
 
     def member_value(self, member: HouseholdMember):
         if self.get_member_variable(member.id) <= 0:
@@ -168,8 +166,10 @@ class PellGrant(PolicyEngineMembersCalculator):
 
 
 class Ssi(PolicyEngineMembersCalculator):
-    # The would-be output: `ssi` is zeroed for non-reporters and merely echoes back the
-    # reported amount for reporters, so neither reflects what the program is worth.
+    # PolicyEngine gates `ssi` on the take-up flag, so it reads 0 for anyone reporting no SSI —
+    # exactly the people this program should be recommended to — and for reporters it just
+    # echoes back the amount they told us. Neither is the entitlement worth showing; the
+    # ungated output is.
     pe_name = "ssi_if_takes_up"
     pe_inputs = [
         dependency.member.SsiCountableResourcesDependency,

--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -38,14 +38,22 @@ class Wic(PolicyEngineMembersCalculator):
         "POSTPARTUM": 0,
         "BREASTFEEDING": 0,
     }
-    pe_name = "wic"
+    # wic_if_takes_up rather than wic. WIC has no take-up flag of its own here, but the
+    # receipt-gated `wic` is zeroed by any downstream take-up suppression, and every WIC
+    # subclass gates on this value being positive — CO/IL/MA/NC map the category to a
+    # hardcoded amount, MO/TX return PolicyEngine's computed benefit. The would-be output
+    # is the same number today and stays correct if a take-up flag is ever added.
+    pe_name = "wic_if_takes_up"
     pe_inputs = [
         dependency.member.PregnancyDependency,
         dependency.member.ExpectedChildrenPregnancyDependency,
         dependency.member.AgeDependency,
         *dependency.wic_income,
+        # WIC's adjunct test reads SNAP/TANF receipt, so it needs the receipt contract to
+        # stop qualifying households off a SNAP or TANF benefit PolicyEngine only modelled.
+        *dependency.receipt_contract,
     ]
-    pe_outputs = [dependency.member.Wic, dependency.member.WicCategory]
+    pe_outputs = [dependency.member.WicIfTakesUp, dependency.member.WicCategory]
 
     def member_value(self, member: HouseholdMember):
         if self.get_member_variable(member.id) <= 0:
@@ -63,6 +71,10 @@ class Medicaid(PolicyEngineMembersCalculator):
         dependency.member.SsiCountableResourcesDependency,
         dependency.member.IsDisabledDependency,
         *dependency.irs_gross_income,
+        # medicaid_category has an SSI-recipient pathway. Without the receipt contract it
+        # fires off SSI PolicyEngine merely simulates, auto-enrolling people who don't
+        # receive SSI at all.
+        *dependency.receipt_contract,
     ]
     pe_outputs = [
         dependency.member.AgeDependency,
@@ -161,10 +173,15 @@ class PellGrant(PolicyEngineMembersCalculator):
 
 
 class Ssi(PolicyEngineMembersCalculator):
-    pe_name = "ssi"
+    # ssi_if_takes_up rather than ssi: takes_up_ssi_if_eligible is False for anyone who
+    # doesn't report receiving SSI, which zeroes `ssi` for exactly the people this program
+    # should be recommended to. It also side-steps the input/output collision on `ssi` —
+    # for a member who *does* report an amount, `ssi` echoes back what they told us while
+    # ssi_if_takes_up is PolicyEngine's own computation.
+    pe_name = "ssi_if_takes_up"
     pe_inputs = [
         dependency.member.SsiCountableResourcesDependency,
-        dependency.member.SsiReportedDependency,
+        *dependency.receipt_contract,
         dependency.member.IsBlindDependency,
         dependency.member.IsDisabledDependency,
         dependency.member.MeetsSsiDisabilityCriteriaDependency,
@@ -175,7 +192,7 @@ class Ssi(PolicyEngineMembersCalculator):
         dependency.member.TaxUnitHeadDependency,
         dependency.member.TaxUnitDependentDependency,
     ]
-    pe_outputs = [dependency.member.Ssi]
+    pe_outputs = [dependency.member.SsiIfTakesUp]
 
 
 class CommoditySupplementalFoodProgram(PolicyEngineMembersCalculator):
@@ -216,7 +233,7 @@ class HeadStart(PolicyEngineMembersCalculator):
     Federal Head Start (ages 3-5). Eligibility and per-child value are computed by
     PolicyEngine's ``head_start`` variable. State subclasses add their state-code
     dependency; the rest of the inputs are shared. Categorical eligibility is fed
-    by the SSI/SNAP/TANF inputs plus foster care.
+    by the receipt contract (SSI/SNAP/TANF) plus foster care.
     """
 
     pe_name = "head_start"
@@ -224,9 +241,7 @@ class HeadStart(PolicyEngineMembersCalculator):
         dependency.member.AgeDependency,
         dependency.member.FosterCareDependency,
         *dependency.irs_gross_income,
-        dependency.member.Ssi,
-        dependency.spm.Snap,
-        dependency.spm.Tanf,
+        *dependency.receipt_contract,
     ]
     pe_outputs = [dependency.member.HeadStart]
 
@@ -245,9 +260,7 @@ class EarlyHeadStart(PolicyEngineMembersCalculator):
         dependency.member.PregnancyDependency,
         dependency.member.FosterCareDependency,
         *dependency.irs_gross_income,
-        dependency.member.Ssi,
-        dependency.spm.Snap,
-        dependency.spm.Tanf,
+        *dependency.receipt_contract,
     ]
     pe_outputs = [dependency.member.EarlyHeadStart]
 
@@ -290,6 +303,9 @@ class Msp(PolicyEngineMembersCalculator):
         dependency.spm.CashAssetsDependency,
         dependency.member.MedicareQuartersOfCoverageDependency,
         dependency.member.IsMedicaidEligibleDependency,
+        # msp_countable_income uses SSI methodology and msp_category has an SSI pathway,
+        # both of which should follow reported receipt rather than simulated SSI.
+        *dependency.receipt_contract,
     ]
     pe_outputs = [
         dependency.member.MspEligible,

--- a/programs/programs/federal/pe/member.py
+++ b/programs/programs/federal/pe/member.py
@@ -38,19 +38,15 @@ class Wic(PolicyEngineMembersCalculator):
         "POSTPARTUM": 0,
         "BREASTFEEDING": 0,
     }
-    # wic_if_takes_up rather than wic. WIC has no take-up flag of its own here, but the
-    # receipt-gated `wic` is zeroed by any downstream take-up suppression, and every WIC
-    # subclass gates on this value being positive — CO/IL/MA/NC map the category to a
-    # hardcoded amount, MO/TX return PolicyEngine's computed benefit. The would-be output
-    # is the same number today and stays correct if a take-up flag is ever added.
+    # The would-be output, since every WIC subclass gates on this being positive and the
+    # receipt-gated `wic` is zeroed by any take-up suppression.
     pe_name = "wic_if_takes_up"
     pe_inputs = [
         dependency.member.PregnancyDependency,
         dependency.member.ExpectedChildrenPregnancyDependency,
         dependency.member.AgeDependency,
         *dependency.wic_income,
-        # WIC's adjunct test reads SNAP/TANF receipt, so it needs the receipt contract to
-        # stop qualifying households off a SNAP or TANF benefit PolicyEngine only modelled.
+        # WIC's adjunct test reads SNAP/TANF receipt.
         *dependency.receipt_contract,
     ]
     pe_outputs = [dependency.member.WicIfTakesUp, dependency.member.WicCategory]
@@ -71,9 +67,8 @@ class Medicaid(PolicyEngineMembersCalculator):
         dependency.member.SsiCountableResourcesDependency,
         dependency.member.IsDisabledDependency,
         *dependency.irs_gross_income,
-        # medicaid_category has an SSI-recipient pathway. Without the receipt contract it
-        # fires off SSI PolicyEngine merely simulates, auto-enrolling people who don't
-        # receive SSI at all.
+        # medicaid_category has an SSI-recipient pathway, which must not fire off
+        # simulated SSI.
         *dependency.receipt_contract,
     ]
     pe_outputs = [
@@ -173,11 +168,8 @@ class PellGrant(PolicyEngineMembersCalculator):
 
 
 class Ssi(PolicyEngineMembersCalculator):
-    # ssi_if_takes_up rather than ssi: takes_up_ssi_if_eligible is False for anyone who
-    # doesn't report receiving SSI, which zeroes `ssi` for exactly the people this program
-    # should be recommended to. It also side-steps the input/output collision on `ssi` —
-    # for a member who *does* report an amount, `ssi` echoes back what they told us while
-    # ssi_if_takes_up is PolicyEngine's own computation.
+    # The would-be output: `ssi` is zeroed for non-reporters and merely echoes back the
+    # reported amount for reporters, so neither reflects what the program is worth.
     pe_name = "ssi_if_takes_up"
     pe_inputs = [
         dependency.member.SsiCountableResourcesDependency,
@@ -303,8 +295,7 @@ class Msp(PolicyEngineMembersCalculator):
         dependency.spm.CashAssetsDependency,
         dependency.member.MedicareQuartersOfCoverageDependency,
         dependency.member.IsMedicaidEligibleDependency,
-        # msp_countable_income uses SSI methodology and msp_category has an SSI pathway,
-        # both of which should follow reported receipt rather than simulated SSI.
+        # msp_countable_income uses SSI methodology and msp_category has an SSI pathway.
         *dependency.receipt_contract,
     ]
     pe_outputs = [

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -33,7 +33,9 @@ SNAP_BASE_INPUTS = [
 
 
 class Snap(PolicyEngineSpmCalulator):
-    # The would-be output: `snap` is zeroed for every household not already receiving it.
+    # PolicyEngine gates `snap` on the take-up flag, so it reads 0 for any household reporting
+    # no SNAP — exactly the households this program should be recommended to. The ungated
+    # output is what they'd receive if they applied, which is the number worth showing them.
     pe_name = "snap_if_takes_up"
     pe_inputs = [
         *SNAP_BASE_INPUTS,
@@ -73,7 +75,7 @@ class SchoolLunch(PolicyEngineSpmCalulator):
 
 
 class Tanf(PolicyEngineSpmCalulator):
-    # The would-be output, for the same reason as Snap above.
+    # The ungated output, for the same reason as Snap above.
     pe_name = "tanf_if_takes_up"
     pe_inputs = [
         dependency.member.AgeDependency,

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -10,12 +10,8 @@ SNAP_BASE_INPUTS = [
     dependency.member.AgeDependency,
     dependency.member.MedicalExpenseDependency,
     dependency.member.IsDisabledDependency,
-    # SNAP's categorical eligibility bypasses the income and asset tests for households
-    # receiving SSI or TANF, and PolicyEngine now keys that off actual receipt: the
-    # reported amount, or receives_ssi / receives_tanf where the household reports receipt
-    # we have no amount for. The take-up flags in the same bundle stop a household PE
-    # merely *models* as SSI/TANF-eligible from picking up categorical eligibility, and
-    # stop that phantom benefit counting as income in SNAP's own income test.
+    # SNAP's categorical eligibility bypasses the income and asset tests for SSI/TANF
+    # recipients, which PolicyEngine keys off actual receipt rather than simulated benefits.
     *dependency.receipt_contract,
     # Disabled treatment (uncapped shelter deduction, $4,500 asset limit) requires disability-
     # program receipt via is_usda_disabled, not the generic is_disabled flag: SsdiReportedDependency
@@ -37,9 +33,7 @@ SNAP_BASE_INPUTS = [
 
 
 class Snap(PolicyEngineSpmCalulator):
-    # The value is snap_if_takes_up, not snap: takes_up_snap_if_eligible is False for every
-    # household that doesn't already report receiving SNAP, which zeroes `snap` for exactly
-    # the households this program should be recommended to.
+    # The would-be output: `snap` is zeroed for every household not already receiving it.
     pe_name = "snap_if_takes_up"
     pe_inputs = [
         *SNAP_BASE_INPUTS,
@@ -79,8 +73,7 @@ class SchoolLunch(PolicyEngineSpmCalulator):
 
 
 class Tanf(PolicyEngineSpmCalulator):
-    # tanf_if_takes_up rather than tanf, for the same reason as Snap above: the
-    # receipt-gated field is 0 for every household that isn't already on TANF.
+    # The would-be output, for the same reason as Snap above.
     pe_name = "tanf_if_takes_up"
     pe_inputs = [
         dependency.member.AgeDependency,
@@ -109,9 +102,7 @@ class Lifeline(PolicyEngineSpmCalulator):
         # supplement (TX, WA) are unaffected since their value doesn't depend on it.
         dependency.spm.PhoneCostDependency,
         *dependency.irs_gross_income,
-        # Lifeline is categorically eligible off SNAP / TANF / SSI receipt, so it needs the
-        # receipt contract to distinguish a household on those programs from one PE merely
-        # models as eligible for them.
+        # Categorically eligible off SNAP / TANF / SSI receipt.
         *dependency.receipt_contract,
     ]
     pe_outputs = [dependency.spm.Lifeline]

--- a/programs/programs/federal/pe/spm.py
+++ b/programs/programs/federal/pe/spm.py
@@ -10,16 +10,13 @@ SNAP_BASE_INPUTS = [
     dependency.member.AgeDependency,
     dependency.member.MedicalExpenseDependency,
     dependency.member.IsDisabledDependency,
-    # TANF cash receipt drives SNAP categorical eligibility (income/asset tests bypassed):
-    # send the reported tanf amount directly as the tanf value. TANF has no reported/toggle
-    # seam, so a positive tanf value is what confers categorical eligibility.
-    #
-    # SSI categorical eligibility is deliberately NOT wired here. It requires
-    # use_reported_ssi, which is global per PE request (flips applicable_ssi for every
-    # program in the request — SNAP, IL AABD, KS TANF, TX CEAP), so it's a federal
-    # all-state change with cross-program effects (verified IL AABD $0->$10k swing).
-    # That work lives in MFB-1312 with all-consumer QA, not in this KS SNAP PR.
-    dependency.spm.Tanf,
+    # SNAP's categorical eligibility bypasses the income and asset tests for households
+    # receiving SSI or TANF, and PolicyEngine now keys that off actual receipt: the
+    # reported amount, or receives_ssi / receives_tanf where the household reports receipt
+    # we have no amount for. The take-up flags in the same bundle stop a household PE
+    # merely *models* as SSI/TANF-eligible from picking up categorical eligibility, and
+    # stop that phantom benefit counting as income in SNAP's own income test.
+    *dependency.receipt_contract,
     # Disabled treatment (uncapped shelter deduction, $4,500 asset limit) requires disability-
     # program receipt via is_usda_disabled, not the generic is_disabled flag: SsdiReportedDependency
     # feeds the SSDI amount, MeetsSsiDisabilityCriteriaDependency the SSI-disability input PE needs
@@ -40,7 +37,10 @@ SNAP_BASE_INPUTS = [
 
 
 class Snap(PolicyEngineSpmCalulator):
-    pe_name = "snap"
+    # The value is snap_if_takes_up, not snap: takes_up_snap_if_eligible is False for every
+    # household that doesn't already report receiving SNAP, which zeroes `snap` for exactly
+    # the households this program should be recommended to.
+    pe_name = "snap_if_takes_up"
     pe_inputs = [
         *SNAP_BASE_INPUTS,
         dependency.member.FullTimeCollegeStudentDependency,
@@ -48,7 +48,7 @@ class Snap(PolicyEngineSpmCalulator):
         dependency.member.SnapWorkExceptionDependency,
         dependency.member.SnapJobTrainingStudentDependency,
     ]
-    pe_outputs = [dependency.spm.Snap]
+    pe_outputs = [dependency.spm.SnapIfTakesUp]
     pe_period_month = "01"
 
     @property
@@ -79,12 +79,15 @@ class SchoolLunch(PolicyEngineSpmCalulator):
 
 
 class Tanf(PolicyEngineSpmCalulator):
-    pe_name = "tanf"
+    # tanf_if_takes_up rather than tanf, for the same reason as Snap above: the
+    # receipt-gated field is 0 for every household that isn't already on TANF.
+    pe_name = "tanf_if_takes_up"
     pe_inputs = [
         dependency.member.AgeDependency,
         dependency.member.FullTimeCollegeStudentDependency,
+        *dependency.receipt_contract,
     ]
-    pe_outputs = [dependency.spm.Tanf]
+    pe_outputs = [dependency.spm.TanfIfTakesUp]
 
 
 class Acp(PolicyEngineSpmCalulator):
@@ -106,5 +109,9 @@ class Lifeline(PolicyEngineSpmCalulator):
         # supplement (TX, WA) are unaffected since their value doesn't depend on it.
         dependency.spm.PhoneCostDependency,
         *dependency.irs_gross_income,
+        # Lifeline is categorically eligible off SNAP / TANF / SSI receipt, so it needs the
+        # receipt contract to distinguish a household on those programs from one PE merely
+        # models as eligible for them.
+        *dependency.receipt_contract,
     ]
     pe_outputs = [dependency.spm.Lifeline]

--- a/programs/programs/federal/pe/tests/test_head_start.py
+++ b/programs/programs/federal/pe/tests/test_head_start.py
@@ -27,7 +27,7 @@ from django.test import TestCase
 
 from programs.programs.federal.pe.member import EarlyHeadStart, HeadStart
 from programs.programs.policyengine.calculators.base import PolicyEngineMembersCalculator
-from programs.programs.policyengine.calculators.dependencies import irs_gross_income, member, spm
+from programs.programs.policyengine.calculators.dependencies import irs_gross_income, member, receipt_contract, spm
 from programs.programs.policyengine.calculators.dependencies.household import StateCode
 from programs.programs.policyengine.calculators.registry import all_member_calculators
 
@@ -72,11 +72,16 @@ class TestFederalHeadStart(TestCase):
         self.assertIn(member.FosterCareDependency, HeadStart.pe_inputs)
 
     def test_pe_inputs_include_categorical_benefit_signals(self):
-        """SNAP / TANF / SSI receipt qualifies a child regardless of income, so all
-        three must reach PolicyEngine's categorical-eligibility determination."""
-        self.assertIn(member.Ssi, HeadStart.pe_inputs)
-        self.assertIn(spm.Snap, HeadStart.pe_inputs)
-        self.assertIn(spm.Tanf, HeadStart.pe_inputs)
+        """
+        SNAP / TANF / SSI receipt qualifies a child regardless of income, so all three must
+        reach PolicyEngine's categorical-eligibility determination — as *receipt*, not as a
+        benefit PolicyEngine simulated the household as eligible for.
+        """
+        for dep in receipt_contract:
+            self.assertIn(dep, HeadStart.pe_inputs)
+        self.assertIn(spm.ReceivesSnapDependency, HeadStart.pe_inputs)
+        self.assertIn(spm.ReceivesTanfDependency, HeadStart.pe_inputs)
+        self.assertIn(member.ReceivesSsiDependency, HeadStart.pe_inputs)
 
     def test_pe_inputs_include_irs_gross_income(self):
         """Income drives the non-categorical (at-or-below-100%-FPL) pathway."""
@@ -121,9 +126,11 @@ class TestFederalEarlyHeadStart(TestCase):
         self.assertIn(member.FosterCareDependency, EarlyHeadStart.pe_inputs)
 
     def test_pe_inputs_include_categorical_benefit_signals(self):
-        self.assertIn(member.Ssi, EarlyHeadStart.pe_inputs)
-        self.assertIn(spm.Snap, EarlyHeadStart.pe_inputs)
-        self.assertIn(spm.Tanf, EarlyHeadStart.pe_inputs)
+        for dep in receipt_contract:
+            self.assertIn(dep, EarlyHeadStart.pe_inputs)
+        self.assertIn(spm.ReceivesSnapDependency, EarlyHeadStart.pe_inputs)
+        self.assertIn(spm.ReceivesTanfDependency, EarlyHeadStart.pe_inputs)
+        self.assertIn(member.ReceivesSsiDependency, EarlyHeadStart.pe_inputs)
 
     def test_pe_inputs_include_irs_gross_income(self):
         for income_input in irs_gross_income:

--- a/programs/programs/il/pe/member.py
+++ b/programs/programs/il/pe/member.py
@@ -86,11 +86,8 @@ class IlAabd(PolicyEngineMembersCalculator):
         # il_aabd_countable_income - unearned income types
         member_dependency.SocialSecurityIncomeDependency,
         member_dependency.SsdiReportedDependency,
-        # AABD counts SSI as unearned income, and PolicyEngine's simulated SSI used to
-        # count here whether or not the applicant received it — an applicant PE modelled as
-        # SSI-eligible was blocked from AABD by income they never got. The receipt contract
-        # supplies the reported amount and suppresses the simulated one (member_dependency.Ssi
-        # travels in the bundle).
+        # AABD counts SSI as unearned income, so simulated SSI would block an applicant
+        # with income they never received. Supplies member_dependency.Ssi.
         *pe_dependency.receipt_contract,
         member_dependency.WorkersCompensationDependency,
         member_dependency.UnemploymentIncomeDependency,

--- a/programs/programs/il/pe/member.py
+++ b/programs/programs/il/pe/member.py
@@ -82,12 +82,16 @@ class IlAabd(PolicyEngineMembersCalculator):
         member_dependency.IsBlindDependency,
         member_dependency.IsDisabledDependency,
         member_dependency.SsiEarnedIncomeDependency,
-        member_dependency.SsiReportedDependency,
         member_dependency.SsiCountableResourcesDependency,
         # il_aabd_countable_income - unearned income types
         member_dependency.SocialSecurityIncomeDependency,
         member_dependency.SsdiReportedDependency,
-        member_dependency.Ssi,
+        # AABD counts SSI as unearned income, and PolicyEngine's simulated SSI used to
+        # count here whether or not the applicant received it — an applicant PE modelled as
+        # SSI-eligible was blocked from AABD by income they never got. The receipt contract
+        # supplies the reported amount and suppresses the simulated one (member_dependency.Ssi
+        # travels in the bundle).
+        *pe_dependency.receipt_contract,
         member_dependency.WorkersCompensationDependency,
         member_dependency.UnemploymentIncomeDependency,
         member_dependency.RetirementDistributionsDependency,

--- a/programs/programs/ks/pe/spm.py
+++ b/programs/programs/ks/pe/spm.py
@@ -40,7 +40,9 @@ class KsTanf(Tanf):
         dependency.household.KsStateCodeDependency,
         dependency.household.KsCountyDependency,
         dependency.member.PregnancyDependency,
-        dependency.member.Ssi,
+        # ks_tanf_is_assistance_unit_member excludes SSI recipients from the assistance
+        # unit, which should follow reported receipt rather than simulated SSI.
+        *dependency.receipt_contract,
         dependency.spm.CashAssetsDependency,
         dependency.spm.ChildCareDependency,
         dependency.spm.PreSubsidyChildcareExpensesDependency,

--- a/programs/programs/mo/pe/tests/test_member.py
+++ b/programs/programs/mo/pe/tests/test_member.py
@@ -82,8 +82,9 @@ class TestMoWicWiring(TestCase):
         self.assertTrue(issubclass(MoWic, PolicyEngineMembersCalculator))
 
     def test_uses_federal_wic_pe_name(self):
-        """The would-be output, inherited from the federal calculator — see ``Wic``."""
-        self.assertEqual(MoWic.pe_name, "wic_if_takes_up")
+        """Inherited from the federal calculator, which stays on the ungated ``wic`` — see
+        ``Wic``."""
+        self.assertEqual(MoWic.pe_name, "wic")
 
     def test_registered_as_mo_wic(self):
         self.assertIs(mo_member_calculators["mo_wic"], MoWic)
@@ -130,7 +131,7 @@ class TestMoWicWiring(TestCase):
 
     def test_keeps_federal_pe_outputs(self):
         self.assertEqual(MoWic.pe_outputs, Wic.pe_outputs)
-        self.assertIn(member_deps.WicIfTakesUp, MoWic.pe_outputs)
+        self.assertIn(member_deps.Wic, MoWic.pe_outputs)
         self.assertIn(member_deps.WicCategory, MoWic.pe_outputs)
 
 
@@ -284,7 +285,7 @@ class TestMoWicPeInput(TestCase):
 
         for member in (self.head, self.child, self.infant):
             member_id = str(member.id)
-            self.assertIn("wic_if_takes_up", people[member_id])
+            self.assertIn("wic", people[member_id])
             self.assertIn("wic_category", people[member_id])
 
 

--- a/programs/programs/mo/pe/tests/test_member.py
+++ b/programs/programs/mo/pe/tests/test_member.py
@@ -67,7 +67,7 @@ from programs.programs.policyengine.calculators.dependencies.member import (
     Ssi,
     SsiCountableResourcesDependency,
     SsiEarnedIncomeDependency,
-    SsiReportedDependency,
+    SsiIfTakesUp,
     SsiUnearnedIncomeDependency,
 )
 from programs.programs.policyengine.calculators.registry import all_calculators, all_member_calculators
@@ -82,7 +82,8 @@ class TestMoWicWiring(TestCase):
         self.assertTrue(issubclass(MoWic, PolicyEngineMembersCalculator))
 
     def test_uses_federal_wic_pe_name(self):
-        self.assertEqual(MoWic.pe_name, "wic")
+        """The would-be output, inherited from the federal calculator — see ``Wic``."""
+        self.assertEqual(MoWic.pe_name, "wic_if_takes_up")
 
     def test_registered_as_mo_wic(self):
         self.assertIs(mo_member_calculators["mo_wic"], MoWic)
@@ -129,7 +130,7 @@ class TestMoWicWiring(TestCase):
 
     def test_keeps_federal_pe_outputs(self):
         self.assertEqual(MoWic.pe_outputs, Wic.pe_outputs)
-        self.assertIn(member_deps.Wic, MoWic.pe_outputs)
+        self.assertIn(member_deps.WicIfTakesUp, MoWic.pe_outputs)
         self.assertIn(member_deps.WicCategory, MoWic.pe_outputs)
 
 
@@ -283,7 +284,7 @@ class TestMoWicPeInput(TestCase):
 
         for member in (self.head, self.child, self.infant):
             member_id = str(member.id)
-            self.assertIn("wic", people[member_id])
+            self.assertIn("wic_if_takes_up", people[member_id])
             self.assertIn("wic_category", people[member_id])
 
 
@@ -321,8 +322,8 @@ class TestMoSsiWiring(TestCase):
         self.assertTrue(issubclass(MoSsi, FederalSsi))
         self.assertTrue(issubclass(MoSsi, PolicyEngineMembersCalculator))
 
-    def test_pe_name_is_ssi(self):
-        self.assertEqual(MoSsi.pe_name, "ssi")
+    def test_pe_name_is_the_would_be_ssi_variable(self):
+        self.assertEqual(MoSsi.pe_name, "ssi_if_takes_up")
 
     def test_is_registered_as_mo_ssi(self):
         self.assertIs(mo_member_calculators["mo_ssi"], MoSsi)
@@ -363,10 +364,14 @@ class TestMoSsiWiring(TestCase):
         self.assertIn(SsiCountableResourcesDependency, MoSsi.pe_inputs)
         self.assertIn(SsiEarnedIncomeDependency, MoSsi.pe_inputs)
         self.assertIn(SsiUnearnedIncomeDependency, MoSsi.pe_inputs)
-        self.assertIn(SsiReportedDependency, MoSsi.pe_inputs)
+        self.assertIn(Ssi, MoSsi.pe_inputs)
 
-    def test_pe_outputs_is_ssi_variable(self):
-        self.assertEqual(MoSsi.pe_outputs, [Ssi])
+    def test_pe_outputs_is_the_would_be_ssi_variable(self):
+        """
+        ssi_if_takes_up, not ssi: takes_up_ssi_if_eligible is False for anyone not
+        reporting SSI, which zeroes ``ssi`` for exactly the people mo_ssi is for.
+        """
+        self.assertEqual(MoSsi.pe_outputs, [SsiIfTakesUp])
 
     def test_does_not_override_member_value(self):
         """
@@ -417,7 +422,7 @@ class TestMoSsiPeInput(TestCase):
         people = pe_input(self.screen, [self._calculator()])["household"]["people"]
         head = people[str(self.head.id)]
 
-        for field in ("age", "is_blind", "is_disabled", "ssi_countable_resources", "ssi_reported"):
+        for field in ("age", "is_blind", "is_disabled", "ssi_countable_resources", "ssi"):
             self.assertIn(field, head)
 
     def test_splits_household_assets_into_countable_resources(self):

--- a/programs/programs/policyengine/calculators/dependencies/__init__.py
+++ b/programs/programs/policyengine/calculators/dependencies/__init__.py
@@ -68,3 +68,25 @@ wic_income = [
     member.Ssi,
     spm.Tanf,
 ]
+
+# PolicyEngine's actual-receipt contract (policyengine-us 1.779.3): countable income and
+# categorical eligibility follow the benefits a household reports receiving, not the ones
+# PolicyEngine simulates them as eligible for. See dependencies/receipt.py for the
+# reasoning; the amount inputs travel with the flags so a program adopting the contract
+# sends a coherent picture of each benefit.
+#
+# The set moves as a unit on purpose. Suppressing simulated SSI while leaving simulated
+# SNAP in place would just shift categorical eligibility onto the other phantom benefit,
+# and PE requests are a single shared payload — every program in a request sees these
+# inputs — so a partial adoption is a per-white-label inconsistency rather than a
+# narrower change.
+receipt_contract = [
+    member.Ssi,
+    member.ReceivesSsiDependency,
+    member.TakesUpSsiIfEligibleDependency,
+    spm.Tanf,
+    spm.ReceivesTanfDependency,
+    spm.TakesUpTanfIfEligibleDependency,
+    spm.ReceivesSnapDependency,
+    spm.TakesUpSnapIfEligibleDependency,
+]

--- a/programs/programs/policyengine/calculators/dependencies/__init__.py
+++ b/programs/programs/policyengine/calculators/dependencies/__init__.py
@@ -69,26 +69,17 @@ wic_income = [
     spm.Tanf,
 ]
 
-# PolicyEngine's actual-receipt contract (policyengine-us 1.779.3): countable income and
-# categorical eligibility follow the benefits a household reports receiving, not the ones
-# PolicyEngine simulates them as eligible for. See dependencies/receipt.py for the
-# reasoning; the amount inputs travel with the flags so a program adopting the contract
-# sends a coherent picture of each benefit.
+# PolicyEngine's actual-receipt contract: countable income and categorical eligibility follow
+# the benefits a household reports receiving, not the ones PolicyEngine simulates them as
+# eligible for. See dependencies/receipt.py.
 #
-# The set moves as a unit across *calculators* on purpose. Suppressing simulated SSI while
-# leaving simulated SNAP in place would just shift categorical eligibility onto the other
-# phantom benefit, and PE requests are a single shared payload — every program in a request
-# sees these inputs — so a partial adoption is a per-white-label inconsistency rather than a
-# narrower change.
+# Adopt it whole per calculator — suppressing one simulated benefit while leaving another just
+# shifts categorical eligibility onto the phantom that remains.
 #
-# The version gating within the bundle is deliberately NOT uniform: `ssi` and `tanf` predate
-# the contract by years and stay ungated, while the six receipt/take-up fields are floored at
-# 1.779.3. Flooring the amounts too would stop sending reported SSI/TANF to any older model —
-# a regression, since those amounts are load-bearing today (TX CEAP's income tier, SNAP
-# categorical from a reported amount). The asymmetry is safe because the *suppressing* half is
-# the gated half: below the floor we send amounts without take-up flags, which is exactly the
-# pre-contract behavior, and there is no version at which we suppress a benefit without also
-# sending the evidence for it. test_receipt_contract.py pins that direction.
+# The version gating is deliberately mixed: the amount inputs predate the contract and stay
+# ungated, so flooring them would stop sending reported SSI/TANF to older models. That is safe
+# because the gated half is the *suppressing* half — below the floor we send amounts without
+# take-up flags, never the reverse. test_receipt_contract.py pins that direction.
 receipt_contract = [
     member.Ssi,
     member.ReceivesSsiDependency,

--- a/programs/programs/policyengine/calculators/dependencies/__init__.py
+++ b/programs/programs/policyengine/calculators/dependencies/__init__.py
@@ -76,10 +76,11 @@ wic_income = [
 # Adopt it whole per calculator — suppressing one simulated benefit while leaving another just
 # shifts categorical eligibility onto the phantom that remains.
 #
-# The version gating is deliberately mixed: the amount inputs predate the contract and stay
-# ungated, so flooring them would stop sending reported SSI/TANF to older models. That is safe
-# because the gated half is the *suppressing* half — below the floor we send amounts without
-# take-up flags, never the reverse. test_receipt_contract.py pins that direction.
+# The version gating is deliberately mixed: the amount inputs stay ungated, since every
+# supported model reads them and flooring them would withhold reported SSI/TANF from older
+# ones. That is safe because the gated half is the *suppressing* half — below the floor we
+# send amounts without take-up flags, never the reverse. test_receipt_contract.py pins that
+# direction.
 receipt_contract = [
     member.Ssi,
     member.ReceivesSsiDependency,

--- a/programs/programs/policyengine/calculators/dependencies/__init__.py
+++ b/programs/programs/policyengine/calculators/dependencies/__init__.py
@@ -75,11 +75,20 @@ wic_income = [
 # reasoning; the amount inputs travel with the flags so a program adopting the contract
 # sends a coherent picture of each benefit.
 #
-# The set moves as a unit on purpose. Suppressing simulated SSI while leaving simulated
-# SNAP in place would just shift categorical eligibility onto the other phantom benefit,
-# and PE requests are a single shared payload — every program in a request sees these
-# inputs — so a partial adoption is a per-white-label inconsistency rather than a
+# The set moves as a unit across *calculators* on purpose. Suppressing simulated SSI while
+# leaving simulated SNAP in place would just shift categorical eligibility onto the other
+# phantom benefit, and PE requests are a single shared payload — every program in a request
+# sees these inputs — so a partial adoption is a per-white-label inconsistency rather than a
 # narrower change.
+#
+# The version gating within the bundle is deliberately NOT uniform: `ssi` and `tanf` predate
+# the contract by years and stay ungated, while the six receipt/take-up fields are floored at
+# 1.779.3. Flooring the amounts too would stop sending reported SSI/TANF to any older model —
+# a regression, since those amounts are load-bearing today (TX CEAP's income tier, SNAP
+# categorical from a reported amount). The asymmetry is safe because the *suppressing* half is
+# the gated half: below the floor we send amounts without take-up flags, which is exactly the
+# pre-contract behavior, and there is no version at which we suppress a benefit without also
+# sending the evidence for it. test_receipt_contract.py pins that direction.
 receipt_contract = [
     member.Ssi,
     member.ReceivesSsiDependency,

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -1,4 +1,5 @@
 from .base import Member
+from .receipt import SSI_INCOME_TYPE, member_reports_ssi, screen_reports_unattributed_ssi
 
 
 class AgeDependency(Member):
@@ -133,19 +134,37 @@ class Wic(Member):
     field = "wic"
 
 
+class WicIfTakesUp(Member):
+    """
+    PolicyEngine's would-be WIC entitlement — what the member is eligible for whether or
+    not they take it up. The WIC program reads this rather than ``wic``, which is
+    receipt-gated: ``takes_up_wic_if_eligible`` (or any downstream take-up suppression)
+    zeroes ``wic``, and every WIC calculator gates on that value being positive, so a
+    non-recipient would drop out of results entirely.
+    """
+
+    field = "wic_if_takes_up"
+    min_pe_version = (1, 779, 3)
+
+
 class Medicaid(Member):
     field = "medicaid"
 
 
 class Ssi(Member):
     """
-    SSI as both PE input and output.
+    The household's reported SSI amount, as PolicyEngine's person-level ``ssi`` input.
 
-    - If user reports SSI: use reported value
-    - If no reported SSI: return None so PE calculates eligibility
+    - If the member reports SSI: send the reported amount (annual; PE spreads it across
+      the months itself). PE uses it in place of its own computed SSI, so it counts as
+      income downstream and confers the categorical eligibility SSI receipt carries.
+    - Otherwise: None, so PE computes. Whether that computed amount is then *used*
+      depends on ``TakesUpSsiIfEligibleDependency`` — for a member who reports no SSI it
+      is suppressed, so PE's simulated SSI no longer counts as unearned income for
+      programs like IL AABD.
 
-    Warning: When PE calculates SSI, the value sometimes counts as unearned
-    income for downstream calculations (e.g., IL AABD).
+    An explicit amount wins over the take-up flag: PE's flag only suppresses its own
+    computed value.
     """
 
     field = "ssi"
@@ -156,8 +175,70 @@ class Ssi(Member):
     )
 
     def value(self):
-        ssi = self.member.calc_gross_income("yearly", ["sSI"])
+        ssi = self.member.calc_gross_income("yearly", [SSI_INCOME_TYPE])
         return None if ssi == 0 else ssi
+
+
+class SsiIfTakesUp(Member):
+    """
+    PolicyEngine's would-be SSI entitlement, independent of take-up. The SSI program
+    reads this rather than ``ssi``: with ``takes_up_ssi_if_eligible: False`` sent for
+    every non-recipient, ``ssi`` is 0 for exactly the people the program should be shown
+    to, and the frontend filters programs valued at $0 out of results.
+    """
+
+    field = "ssi_if_takes_up"
+    min_pe_version = (1, 779, 3)
+
+
+class ReceivesSsiDependency(Member):
+    """
+    Reported SSI receipt for this member.
+
+    Distinct from the ``ssi`` amount: a household can report receiving SSI while PE
+    computes their entitlement as $0 (high other income, say), and this is what keeps the
+    categorical eligibility that receipt confers — SNAP's SSI-recipient path, Medicaid's
+    SSI category — firing in that case.
+    """
+
+    field = "receives_ssi"
+    min_pe_version = (1, 779, 3)
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
+
+    def value(self):
+        return member_reports_ssi(self.member)
+
+
+class TakesUpSsiIfEligibleDependency(Member):
+    """
+    False for a member who reports no SSI, which stops PolicyEngine counting the SSI it
+    simulates for them as income they actually receive.
+
+    This is the lever behind the largest behavior change in the receipt contract: a
+    non-reporter whom PE models as SSI-eligible no longer carries phantom SSI income into
+    IL AABD, SNAP's income test, TX CEAP or the Medicaid/MSP SSI methodologies.
+
+    Left at PE's default (True) when the household reports SSI receipt that no member's
+    income stream accounts for — see ``screen_reports_unattributed_ssi``.
+    """
+
+    field = "takes_up_ssi_if_eligible"
+    min_pe_version = (1, 779, 3)
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
+
+    def value(self):
+        if member_reports_ssi(self.member):
+            return True
+
+        return screen_reports_unattributed_ssi(self.screen)
 
 
 class IsDisabledDependency(Member):

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -130,10 +130,6 @@ class MedicaidSeniorOrDisabled(Member):
     field = "is_optional_senior_or_disabled_for_medicaid"
 
 
-class Wic(Member):
-    field = "wic"
-
-
 class WicIfTakesUp(Member):
     """
     PolicyEngine's would-be WIC entitlement — what the member is eligible for whether or
@@ -387,40 +383,6 @@ class IsBlindDependency(Member):
         return self.member.visually_impaired or False
 
 
-class SsiReportedDependency(Member):
-    field = "ssi_reported"
-    dependencies = (
-        "income_type",
-        "income_amount",
-        "income_frequency",
-    )
-
-    def value(self):
-        return self.member.calc_gross_income("yearly", ["sSI"])
-
-
-class UseReportedSsiDependency(Member):
-    """
-    Tells PolicyEngine to count the household's *reported* SSI (ssi_reported)
-    instead of PE's *calculated* ssi wherever a program's countable income reads
-    applicable_ssi (the calculator opts in by including this in its pe_inputs).
-    We always send True so the screener's reported SSI drives the income test.
-
-    Person-level and global within a request: it flips applicable_ssi for every
-    program in that request, so only add it to calculators where reported SSI is
-    the correct measure.
-
-    min_pe_version gates this to the first model that defines use_reported_ssi;
-    sending it to an earlier model 400s the whole request.
-    """
-
-    field = "use_reported_ssi"
-    min_pe_version = (1, 742, 0)
-
-    def value(self):
-        return True
-
-
 class SsdiReportedDependency(Member):
     # Amount in "Social Security disability benefits (SSDI)"
     field = "social_security_disability"
@@ -447,10 +409,6 @@ class SsiCountableResourcesDependency(Member):
             ssi_assets = self.screen.household_assets / self.screen.num_adults()
 
         return int(ssi_assets)
-
-
-class SsiAmountIfEligible(Member):
-    field = "ssi_amount_if_eligible"
 
 
 class Andcs(Member):

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -1,5 +1,5 @@
 from .base import Member
-from .receipt import SSI_INCOME_TYPE, member_reports_ssi, screen_reports_unattributed_ssi
+from .receipt import SSI_INCOME_TYPE, member_receives_ssi, screen_reports_unidentifiable_ssi
 
 
 class AgeDependency(Member):
@@ -194,7 +194,10 @@ class ReceivesSsiDependency(Member):
     Distinct from the ``ssi`` amount: a household can report receiving SSI while PE
     computes their entitlement as $0 (high other income, say), and this is what keeps the
     categorical eligibility that receipt confers — SNAP's SSI-recipient path, Medicaid's
-    SSI category — firing in that case.
+    SSI category — firing in that case. It is also the only signal for a household that
+    ticks the Current Benefits tile without entering an amount.
+
+    See ``member_receives_ssi`` for how a household-level tile is attributed to a person.
     """
 
     field = "receives_ssi"
@@ -203,10 +206,11 @@ class ReceivesSsiDependency(Member):
         "income_type",
         "income_amount",
         "income_frequency",
+        "age",
     )
 
     def value(self):
-        return member_reports_ssi(self.member)
+        return member_receives_ssi(self.screen, self.member)
 
 
 class TakesUpSsiIfEligibleDependency(Member):
@@ -218,8 +222,8 @@ class TakesUpSsiIfEligibleDependency(Member):
     non-reporter whom PE models as SSI-eligible no longer carries phantom SSI income into
     IL AABD, SNAP's income test, TX CEAP or the Medicaid/MSP SSI methodologies.
 
-    Left at PE's default (True) when the household reports SSI receipt that no member's
-    income stream accounts for — see ``screen_reports_unattributed_ssi``.
+    Left at PE's default (True) when the household reports SSI receipt that we can't pin on
+    anyone — see ``screen_reports_unidentifiable_ssi``.
     """
 
     field = "takes_up_ssi_if_eligible"
@@ -228,13 +232,14 @@ class TakesUpSsiIfEligibleDependency(Member):
         "income_type",
         "income_amount",
         "income_frequency",
+        "age",
     )
 
     def value(self):
-        if member_reports_ssi(self.member):
+        if member_receives_ssi(self.screen, self.member):
             return True
 
-        return screen_reports_unattributed_ssi(self.screen)
+        return screen_reports_unidentifiable_ssi(self.screen)
 
 
 class IsDisabledDependency(Member):

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -131,13 +131,9 @@ class MedicaidSeniorOrDisabled(Member):
 
 
 class WicIfTakesUp(Member):
-    """
-    PolicyEngine's would-be WIC entitlement — what the member is eligible for whether or
-    not they take it up. The WIC program reads this rather than ``wic``, which is
-    receipt-gated: ``takes_up_wic_if_eligible`` (or any downstream take-up suppression)
-    zeroes ``wic``, and every WIC calculator gates on that value being positive, so a
-    non-recipient would drop out of results entirely.
-    """
+    """PolicyEngine's would-be WIC entitlement, independent of take-up. Every WIC calculator
+    gates on it being positive, and the receipt-gated ``wic`` is zeroed by any take-up
+    suppression."""
 
     field = "wic_if_takes_up"
     min_pe_version = (1, 779, 3)
@@ -149,18 +145,12 @@ class Medicaid(Member):
 
 class Ssi(Member):
     """
-    The household's reported SSI amount, as PolicyEngine's person-level ``ssi`` input.
+    The member's reported SSI amount, as PolicyEngine's person-level ``ssi`` input; None when
+    they report none, leaving PolicyEngine to compute it.
 
-    - If the member reports SSI: send the reported amount (annual; PE spreads it across
-      the months itself). PE uses it in place of its own computed SSI, so it counts as
-      income downstream and confers the categorical eligibility SSI receipt carries.
-    - Otherwise: None, so PE computes. Whether that computed amount is then *used*
-      depends on ``TakesUpSsiIfEligibleDependency`` — for a member who reports no SSI it
-      is suppressed, so PE's simulated SSI no longer counts as unearned income for
-      programs like IL AABD.
-
-    An explicit amount wins over the take-up flag: PE's flag only suppresses its own
-    computed value.
+    A reported amount replaces PolicyEngine's own figure, counting as income downstream and
+    conferring the categorical eligibility SSI receipt carries. It also wins over the take-up
+    flag, which only suppresses PolicyEngine's *computed* value.
     """
 
     field = "ssi"
@@ -176,12 +166,9 @@ class Ssi(Member):
 
 
 class SsiIfTakesUp(Member):
-    """
-    PolicyEngine's would-be SSI entitlement, independent of take-up. The SSI program
-    reads this rather than ``ssi``: with ``takes_up_ssi_if_eligible: False`` sent for
-    every non-recipient, ``ssi`` is 0 for exactly the people the program should be shown
-    to, and the frontend filters programs valued at $0 out of results.
-    """
+    """PolicyEngine's would-be SSI entitlement, independent of take-up. ``ssi`` is 0 for
+    exactly the people the SSI program should be shown to, and the frontend filters out
+    programs valued at $0."""
 
     field = "ssi_if_takes_up"
     min_pe_version = (1, 779, 3)
@@ -189,13 +176,9 @@ class SsiIfTakesUp(Member):
 
 class ReceivesSsiDependency(Member):
     """
-    Reported SSI receipt for this member.
-
-    Distinct from the ``ssi`` amount: a household can report receiving SSI while PE
-    computes their entitlement as $0 (high other income, say), and this is what keeps the
-    categorical eligibility that receipt confers — SNAP's SSI-recipient path, Medicaid's
-    SSI category — firing in that case. It is also the only signal for a household that
-    ticks the Current Benefits tile without entering an amount.
+    Reported SSI receipt for this member — the signal an amount can't express, since a
+    household can report receiving SSI where PolicyEngine computes their entitlement as $0,
+    or tick the Current Benefits tile without entering an amount at all.
 
     See ``member_receives_ssi`` for how a household-level tile is attributed to a person.
     """
@@ -215,15 +198,13 @@ class ReceivesSsiDependency(Member):
 
 class TakesUpSsiIfEligibleDependency(Member):
     """
-    False for a member who reports no SSI, which stops PolicyEngine counting the SSI it
-    simulates for them as income they actually receive.
+    False for a member who reports no SSI, so PolicyEngine stops counting the SSI it
+    simulates for them as income they receive — the lever behind this contract's largest
+    behavior change, across IL AABD, SNAP's income test, TX CEAP and the Medicaid/MSP SSI
+    methodologies.
 
-    This is the lever behind the largest behavior change in the receipt contract: a
-    non-reporter whom PE models as SSI-eligible no longer carries phantom SSI income into
-    IL AABD, SNAP's income test, TX CEAP or the Medicaid/MSP SSI methodologies.
-
-    Left at PE's default (True) when the household reports SSI receipt that we can't pin on
-    anyone — see ``screen_reports_unidentifiable_ssi``.
+    Left at PolicyEngine's default when the household's report can't be pinned on anyone —
+    see ``screen_reports_unidentifiable_ssi``.
     """
 
     field = "takes_up_ssi_if_eligible"

--- a/programs/programs/policyengine/calculators/dependencies/member.py
+++ b/programs/programs/policyengine/calculators/dependencies/member.py
@@ -1,5 +1,5 @@
 from .base import Member
-from .receipt import SSI_INCOME_TYPE, member_receives_ssi, screen_reports_unidentifiable_ssi
+from .receipt import SSI_INCOME_TYPE, member_reports_ssi_amount, screen_reports_ssi_without_amount
 
 
 class AgeDependency(Member):
@@ -130,13 +130,19 @@ class MedicaidSeniorOrDisabled(Member):
     field = "is_optional_senior_or_disabled_for_medicaid"
 
 
-class WicIfTakesUp(Member):
-    """PolicyEngine's would-be WIC entitlement, independent of take-up. Every WIC calculator
-    gates on it being positive, and the receipt-gated ``wic`` is zeroed by any take-up
-    suppression."""
+class Wic(Member):
+    """
+    PolicyEngine's ``wic`` person output — the member's WIC entitlement by food package.
 
-    field = "wic_if_takes_up"
-    min_pe_version = (1, 779, 3)
+    Already the would-be value for our payloads, unlike SSI/SNAP/TANF, whose programs need the
+    ``*_if_takes_up`` variants: ``wic`` is ``wic_if_takes_up`` gated on
+    ``takes_up_wic_if_eligible``, which defaults True and which we never send, so the two are
+    equal for every household we submit. (``receives_wic`` is measurably inert, so it is not
+    wired either.) Being ungated also keeps WIC clear of the ``min_pe_version`` floor, and so of
+    ``_drop_unreadable_programs``.
+    """
+
+    field = "wic"
 
 
 class Medicaid(Member):
@@ -166,9 +172,14 @@ class Ssi(Member):
 
 
 class SsiIfTakesUp(Member):
-    """PolicyEngine's would-be SSI entitlement, independent of take-up. ``ssi`` is 0 for
-    exactly the people the SSI program should be shown to, and the frontend filters out
-    programs valued at $0."""
+    """
+    PolicyEngine's ``ssi_if_takes_up`` person output: the SSI this member would get if they took
+    the program up, regardless of reported take-up.
+
+    What the SSI program reads, since the plain ``ssi`` output is gated on
+    ``takes_up_ssi_if_eligible`` and so reads 0 for exactly the non-recipients the program
+    should be recommended to — and the frontend filters out programs valued at $0.
+    """
 
     field = "ssi_if_takes_up"
     min_pe_version = (1, 779, 3)
@@ -176,11 +187,17 @@ class SsiIfTakesUp(Member):
 
 class ReceivesSsiDependency(Member):
     """
-    Reported SSI receipt for this member — the signal an amount can't express, since a
-    household can report receiving SSI where PolicyEngine computes their entitlement as $0,
-    or tick the Current Benefits tile without entering an amount at all.
+    PolicyEngine's ``receives_ssi`` person input: this member is a reported SSI recipient.
 
-    See ``member_receives_ssi`` for how a household-level tile is attributed to a person.
+    Read alongside the ``ssi`` amount rather than instead of it — every consumer tests
+    ``(ssi > 0) | receives_ssi`` (``meets_snap_categorical_eligibility``,
+    ``is_ssi_recipient_for_medicaid`` and its 209(b) variant). So the boolean is what carries
+    receipt when PolicyEngine computes the member's own entitlement as $0, the one case an
+    amount cannot express.
+
+    Set from a reported amount only, since that is the only per-member signal the screener
+    captures. PolicyEngine treats the flag as conclusive — it confers the SSI-recipient
+    Medicaid pathway with no demographic or income test — so it is never inferred.
     """
 
     field = "receives_ssi"
@@ -189,22 +206,25 @@ class ReceivesSsiDependency(Member):
         "income_type",
         "income_amount",
         "income_frequency",
-        "age",
     )
 
     def value(self):
-        return member_receives_ssi(self.screen, self.member)
+        return member_reports_ssi_amount(self.member)
 
 
 class TakesUpSsiIfEligibleDependency(Member):
     """
-    False for a member who reports no SSI, so PolicyEngine stops counting the SSI it
-    simulates for them as income they receive — the lever behind this contract's largest
-    behavior change, across IL AABD, SNAP's income test, TX CEAP and the Medicaid/MSP SSI
-    methodologies.
+    PolicyEngine's ``takes_up_ssi_if_eligible`` person input, default True. False stops
+    PolicyEngine from counting the SSI it simulates for this member as income they receive, and
+    withdraws the categorical eligibility that receipt confers — reaching IL AABD, SNAP's
+    income test, TX CEAP and the Medicaid/MSP SSI methodologies.
 
-    Left at PolicyEngine's default when the household's report can't be pinned on anyone —
-    see ``screen_reports_unidentifiable_ssi``.
+    Lowered for a member reporting no SSI amount, which is the point of the receipt contract:
+    a simulated entitlement is not income.
+
+    Held at the default for a household that ticked the SSI tile without an amount — somebody
+    receives SSI but nothing says who, and zeroing them all would suppress a real benefit. See
+    ``screen_reports_ssi_without_amount``.
     """
 
     field = "takes_up_ssi_if_eligible"
@@ -213,14 +233,13 @@ class TakesUpSsiIfEligibleDependency(Member):
         "income_type",
         "income_amount",
         "income_frequency",
-        "age",
     )
 
     def value(self):
-        if member_receives_ssi(self.screen, self.member):
+        if member_reports_ssi_amount(self.member):
             return True
 
-        return screen_reports_unidentifiable_ssi(self.screen)
+        return screen_reports_ssi_without_amount(self.screen)
 
 
 class IsDisabledDependency(Member):

--- a/programs/programs/policyengine/calculators/dependencies/receipt.py
+++ b/programs/programs/policyengine/calculators/dependencies/receipt.py
@@ -1,0 +1,83 @@
+"""
+Who actually receives SSI, TANF and SNAP — the input side of PolicyEngine's
+actual-receipt contract (policyengine-us 1.779.3).
+
+PolicyEngine used to feed *simulated* (would-be-eligible) SSI/TANF/SNAP into other
+programs' calculations, both as countable income and to confer categorical eligibility
+(SNAP categorical via SSI/TANF, WIC adjunctive, Head Start categorical, Medicaid's SSI
+category). Being eligible for a benefit is not the same as receiving it, so that
+over-stated downstream eligibility and income. Since 1.779.3 both key off receipt, which
+we drive with two inputs per program:
+
+  receives_X              the household reports receiving X. Confers categorical
+                          eligibility even where PE computes the amount as $0 — the case
+                          a reported amount alone cannot express.
+  takes_up_X_if_eligible  False for a household that reports *not* receiving X: zeroes
+                          PE's simulated X and switches off the categorical eligibility
+                          it would otherwise confer.
+
+Reported *amounts* are separate inputs (``member.Ssi``, ``spm.Tanf``) and win over the
+take-up flag — the flag only suppresses PE's own computed value. SNAP has no amount
+capture in the screener, so its receipt is a boolean only.
+
+"Not receiving" is not the same as "no signal". Every helper here reads receipt from both
+the Current Benefits tiles and the income streams, and the take-up flag is lowered only
+when neither says anything. Where a signal is real but unattributable — a household that
+ticks SSI without any member reporting an amount — we leave PE's default take-up alone
+rather than zero out a real recipient's benefit.
+"""
+
+from screener.models import HouseholdMember, Screen
+
+# The income options that carry these benefits' dollar amounts. Note the `sSI` casing,
+# and that TANF is captured as `cashAssistance` rather than a `tanf` income type.
+SSI_INCOME_TYPE = "sSI"
+TANF_INCOME_TYPE = "cashAssistance"
+
+
+def screen_reports_snap(screen: Screen) -> bool:
+    """
+    Whether the household reports receiving SNAP.
+
+    The Current Benefits tile is the only signal: the screener captures no SNAP dollar
+    amount. ``has_base_benefit`` covers every white-label variant (co_snap, ks_snap,
+    wa_snap, …); ``has_benefit`` is an exact match on the bare name, which no white label
+    ships.
+    """
+    return screen.has_base_benefit("snap")
+
+
+def screen_reports_tanf(screen: Screen) -> bool:
+    """
+    Whether the household reports receiving TANF.
+
+    Either the tile or a reported cash-assistance income stream — the same amount
+    ``spm.Tanf`` sends PolicyEngine as the ``tanf`` input. Reading the income stream here
+    (rather than deriving TANF receipt into the CurrentBenefit join table) keeps this out
+    of the results layer's ``already_has`` filter: "Cash Assistance Grant" is a broader
+    label than TANF, and mislabelling it would drop the state's TANF program from a
+    household's results.
+    """
+    return screen.has_base_benefit("tanf") or screen.calc_gross_income("yearly", [TANF_INCOME_TYPE]) > 0
+
+
+def member_reports_ssi(member: HouseholdMember) -> bool:
+    """
+    Whether this member reports an SSI amount. `ssi` and `receives_ssi` are person-level
+    in PolicyEngine, so receipt has to be attributed to the individual — crediting the
+    whole household would hand a non-disabled member the SSI-recipient Medicaid pathway.
+    """
+    return member.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0
+
+
+def screen_reports_unattributed_ssi(screen: Screen) -> bool:
+    """
+    Whether the household reports SSI receipt that we cannot attribute to any member —
+    the tile is ticked but no member reports an SSI amount.
+
+    The signal is real, so suppressing simulated SSI for everyone would zero out a
+    genuine recipient's benefit; but there is no basis for picking which member receives
+    it. Callers leave PE's default take-up in place for the whole household, which is the
+    pre-contract behavior rather than a silent zeroing.
+    """
+    return screen.has_base_benefit("ssi") and screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) == 0

--- a/programs/programs/policyengine/calculators/dependencies/receipt.py
+++ b/programs/programs/policyengine/calculators/dependencies/receipt.py
@@ -1,30 +1,23 @@
 """
-Who actually receives SSI, TANF and SNAP — the input side of PolicyEngine's
-actual-receipt contract (policyengine-us 1.779.3).
+Who actually receives SSI, TANF and SNAP — the input side of PolicyEngine's actual-receipt
+contract.
 
-PolicyEngine used to feed *simulated* (would-be-eligible) SSI/TANF/SNAP into other
-programs' calculations, both as countable income and to confer categorical eligibility
-(SNAP categorical via SSI/TANF, WIC adjunctive, Head Start categorical, Medicaid's SSI
-category). Being eligible for a benefit is not the same as receiving it, so that
-over-stated downstream eligibility and income. Since 1.779.3 both key off receipt, which
-we drive with two inputs per program:
+PolicyEngine used to feed *simulated* (would-be-eligible) SSI/TANF/SNAP into other programs'
+calculations, both as countable income and to confer categorical eligibility, over-stating
+both. It now keys off receipt, which we drive with two inputs per program:
 
-  receives_X              the household reports receiving X. Confers categorical
-                          eligibility even where PE computes the amount as $0 — the case
-                          a reported amount alone cannot express.
+  receives_X              the household reports receiving X. Confers categorical eligibility
+                          even where PolicyEngine computes the amount as $0 — the case a
+                          reported amount alone cannot express.
   takes_up_X_if_eligible  False for a household that reports *not* receiving X: zeroes
-                          PE's simulated X and switches off the categorical eligibility
-                          it would otherwise confer.
+                          PolicyEngine's simulated X and the eligibility it would confer.
 
-Reported *amounts* are separate inputs (``member.Ssi``, ``spm.Tanf``) and win over the
-take-up flag — the flag only suppresses PE's own computed value. SNAP has no amount
-capture in the screener, so its receipt is a boolean only.
+Reported amounts are separate inputs (``member.Ssi``, ``spm.Tanf``) and win over the take-up
+flag, which only suppresses PolicyEngine's own computed value. SNAP has no amount capture, so
+its receipt is a boolean only.
 
-"Not receiving" is not the same as "no signal". Every helper here reads receipt from both
-the Current Benefits tiles and the income streams, and the take-up flag is lowered only
-when neither says anything. Where a signal is real but unattributable — a household that
-ticks SSI without any member reporting an amount — we leave PE's default take-up alone
-rather than zero out a real recipient's benefit.
+"Not receiving" is not the same as "no signal": these helpers read both the Current Benefits
+tiles and the income streams, and lower the take-up flag only when neither says anything.
 """
 
 from screener.models import HouseholdMember, Screen
@@ -39,27 +32,20 @@ SSI_AGED_MIN_AGE = 65
 
 
 def screen_reports_snap(screen: Screen) -> bool:
-    """
-    Whether the household reports receiving SNAP.
-
-    The Current Benefits tile is the only signal: the screener captures no SNAP dollar
-    amount. ``has_base_benefit`` covers every white-label variant (co_snap, ks_snap,
-    wa_snap, …); ``has_benefit`` is an exact match on the bare name, which no white label
-    ships.
-    """
+    """Whether the household reports receiving SNAP. The Current Benefits tile is the only
+    signal, since the screener captures no SNAP amount. ``has_base_benefit`` covers every
+    white-label variant; ``has_benefit`` matches a bare name no white label ships."""
     return screen.has_base_benefit("snap")
 
 
 def screen_reports_tanf(screen: Screen) -> bool:
     """
-    Whether the household reports receiving TANF.
+    Whether the household reports receiving TANF — the tile, or a reported cash-assistance
+    amount.
 
-    Either the tile or a reported cash-assistance income stream — the same amount
-    ``spm.Tanf`` sends PolicyEngine as the ``tanf`` input. Reading the income stream here
-    (rather than deriving TANF receipt into the CurrentBenefit join table) keeps this out
-    of the results layer's ``already_has`` filter: "Cash Assistance Grant" is a broader
-    label than TANF, and mislabelling it would drop the state's TANF program from a
-    household's results.
+    Read here rather than derived into the CurrentBenefit table on purpose: that would feed
+    the results layer's ``already_has`` filter, and "Cash Assistance Grant" is a broader label
+    than TANF, so mislabelling it would drop the state's TANF program from their results.
     """
     return screen.has_base_benefit("tanf") or screen.calc_gross_income("yearly", [TANF_INCOME_TYPE]) > 0
 
@@ -70,13 +56,9 @@ def member_reports_ssi_amount(member: HouseholdMember) -> bool:
 
 
 def _could_receive_ssi(member: HouseholdMember) -> bool:
-    """
-    Whether this member could be the SSI recipient in a household reporting SSI.
-
-    SSI is only payable to someone aged, blind or disabled (42 U.S.C. § 1382(a)), which is
-    also the screener data we have. Used only to decide *who* to attribute a household-level
-    report to — never to decide eligibility.
-    """
+    """Whether this member could be the SSI recipient in a household reporting SSI: SSI is
+    only payable to someone aged, blind or disabled (42 U.S.C. § 1382(a)). Used to attribute a
+    household-level report, never to decide eligibility."""
     age = member.calc_age()
     if age is not None and age >= SSI_AGED_MIN_AGE:
         return True
@@ -86,22 +68,15 @@ def _could_receive_ssi(member: HouseholdMember) -> bool:
 
 def member_receives_ssi(screen: Screen, member: HouseholdMember) -> bool:
     """
-    Whether this member reports receiving SSI, from either signal: their own reported
-    amount, or the household's Current Benefits tile.
+    Whether this member reports receiving SSI, from either signal: their own reported amount,
+    or the household's Current Benefits tile.
 
-    `ssi` and `receives_ssi` are person-level in PolicyEngine, so a household-level tile has
-    to be attributed to somebody — and PolicyEngine treats `receives_ssi` as conclusive.
-    Measured against the live API: the flag alone flips `medicaid_category` to
-    SSI_RECIPIENT with no demographic or income test, worth $15,167 to a non-disabled
-    30-year-old at $90k and $10,222 to a 3-year-old. So we attribute rather than broadcast:
-
-    - a member reporting their own amount receives SSI, full stop;
-    - otherwise, if the tile is ticked and *nobody* reports an amount, the members who could
-      plausibly be the recipient (aged/blind/disabled) are credited. One is enough for the
-      cross-program signal — SNAP's categorical eligibility fires off a single member.
-
-    A reported amount explains the tile, so when any member reports one the others are
-    non-recipients rather than additional recipients.
+    ``receives_ssi`` is person-level and PolicyEngine treats it as conclusive — measured, the
+    flag alone confers the SSI-recipient Medicaid pathway with no demographic or income test.
+    So a household-level tile is attributed, not broadcast: a member reporting their own amount
+    receives SSI, and otherwise a ticked tile with no amount anywhere credits only the members
+    who could plausibly be the recipient. A reported amount explains the tile, leaving the
+    others as non-recipients.
     """
     if member_reports_ssi_amount(member):
         return True
@@ -118,13 +93,12 @@ def member_receives_ssi(screen: Screen, member: HouseholdMember) -> bool:
 
 def screen_reports_unidentifiable_ssi(screen: Screen) -> bool:
     """
-    Whether the household reports SSI receipt we can't pin on anyone: the tile is ticked,
-    no member reports an amount, and no member is aged, blind or disabled.
+    Whether the household reports SSI receipt we can't pin on anyone: tile ticked, no amount
+    reported, and nobody aged, blind or disabled.
 
-    The signal is real — so suppressing simulated SSI across the household would zero out a
+    The signal is real, so suppressing simulated SSI across the household would zero out a
     genuine recipient's benefit — but there is no defensible member to credit. Callers leave
-    PolicyEngine's default take-up in place for everyone, which is the pre-contract
-    behavior rather than a silent zeroing.
+    PolicyEngine's default take-up alone, which is the pre-contract behavior.
     """
     if not screen.has_base_benefit("ssi"):
         return False

--- a/programs/programs/policyengine/calculators/dependencies/receipt.py
+++ b/programs/programs/policyengine/calculators/dependencies/receipt.py
@@ -34,6 +34,9 @@ from screener.models import HouseholdMember, Screen
 SSI_INCOME_TYPE = "sSI"
 TANF_INCOME_TYPE = "cashAssistance"
 
+# SSI's aged pathway (42 U.S.C. § 1382(a)); the blind/disabled pathways have no age floor.
+SSI_AGED_MIN_AGE = 65
+
 
 def screen_reports_snap(screen: Screen) -> bool:
     """
@@ -61,23 +64,72 @@ def screen_reports_tanf(screen: Screen) -> bool:
     return screen.has_base_benefit("tanf") or screen.calc_gross_income("yearly", [TANF_INCOME_TYPE]) > 0
 
 
-def member_reports_ssi(member: HouseholdMember) -> bool:
-    """
-    Whether this member reports an SSI amount. `ssi` and `receives_ssi` are person-level
-    in PolicyEngine, so receipt has to be attributed to the individual — crediting the
-    whole household would hand a non-disabled member the SSI-recipient Medicaid pathway.
-    """
+def member_reports_ssi_amount(member: HouseholdMember) -> bool:
+    """Whether this member reports an SSI dollar amount of their own."""
     return member.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0
 
 
-def screen_reports_unattributed_ssi(screen: Screen) -> bool:
+def _could_receive_ssi(member: HouseholdMember) -> bool:
     """
-    Whether the household reports SSI receipt that we cannot attribute to any member —
-    the tile is ticked but no member reports an SSI amount.
+    Whether this member could be the SSI recipient in a household reporting SSI.
 
-    The signal is real, so suppressing simulated SSI for everyone would zero out a
-    genuine recipient's benefit; but there is no basis for picking which member receives
-    it. Callers leave PE's default take-up in place for the whole household, which is the
-    pre-contract behavior rather than a silent zeroing.
+    SSI is only payable to someone aged, blind or disabled (42 U.S.C. § 1382(a)), which is
+    also the screener data we have. Used only to decide *who* to attribute a household-level
+    report to — never to decide eligibility.
     """
-    return screen.has_base_benefit("ssi") and screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) == 0
+    age = member.calc_age()
+    if age is not None and age >= SSI_AGED_MIN_AGE:
+        return True
+
+    return bool(member.disabled or member.long_term_disability or member.visually_impaired)
+
+
+def member_receives_ssi(screen: Screen, member: HouseholdMember) -> bool:
+    """
+    Whether this member reports receiving SSI, from either signal: their own reported
+    amount, or the household's Current Benefits tile.
+
+    `ssi` and `receives_ssi` are person-level in PolicyEngine, so a household-level tile has
+    to be attributed to somebody — and PolicyEngine treats `receives_ssi` as conclusive.
+    Measured against the live API: the flag alone flips `medicaid_category` to
+    SSI_RECIPIENT with no demographic or income test, worth $15,167 to a non-disabled
+    30-year-old at $90k and $10,222 to a 3-year-old. So we attribute rather than broadcast:
+
+    - a member reporting their own amount receives SSI, full stop;
+    - otherwise, if the tile is ticked and *nobody* reports an amount, the members who could
+      plausibly be the recipient (aged/blind/disabled) are credited. One is enough for the
+      cross-program signal — SNAP's categorical eligibility fires off a single member.
+
+    A reported amount explains the tile, so when any member reports one the others are
+    non-recipients rather than additional recipients.
+    """
+    if member_reports_ssi_amount(member):
+        return True
+
+    if not screen.has_base_benefit("ssi"):
+        return False
+
+    if screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0:
+        # Somebody's amount already accounts for the tile.
+        return False
+
+    return _could_receive_ssi(member)
+
+
+def screen_reports_unidentifiable_ssi(screen: Screen) -> bool:
+    """
+    Whether the household reports SSI receipt we can't pin on anyone: the tile is ticked,
+    no member reports an amount, and no member is aged, blind or disabled.
+
+    The signal is real — so suppressing simulated SSI across the household would zero out a
+    genuine recipient's benefit — but there is no defensible member to credit. Callers leave
+    PolicyEngine's default take-up in place for everyone, which is the pre-contract
+    behavior rather than a silent zeroing.
+    """
+    if not screen.has_base_benefit("ssi"):
+        return False
+
+    if screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0:
+        return False
+
+    return not any(_could_receive_ssi(member) for member in screen.household_members.all())

--- a/programs/programs/policyengine/calculators/dependencies/receipt.py
+++ b/programs/programs/policyengine/calculators/dependencies/receipt.py
@@ -1,10 +1,9 @@
 """
-Who actually receives SSI, TANF and SNAP — the input side of PolicyEngine's actual-receipt
-contract.
+Who receives SSI, TANF and SNAP — the input side of PolicyEngine's actual-receipt contract.
 
-PolicyEngine used to feed *simulated* (would-be-eligible) SSI/TANF/SNAP into other programs'
-calculations, both as countable income and to confer categorical eligibility, over-stating
-both. It now keys off receipt, which we drive with two inputs per program:
+PolicyEngine keys SSI/TANF/SNAP off actual receipt rather than simulated eligibility, both for
+countable income and for the categorical eligibility they confer. Two inputs per program drive
+it:
 
   receives_X              the household reports receiving X. Confers categorical eligibility
                           even where PolicyEngine computes the amount as $0 — the case a
@@ -16,8 +15,29 @@ Reported amounts are separate inputs (``member.Ssi``, ``spm.Tanf``) and win over
 flag, which only suppresses PolicyEngine's own computed value. SNAP has no amount capture, so
 its receipt is a boolean only.
 
-"Not receiving" is not the same as "no signal": these helpers read both the Current Benefits
-tiles and the income streams, and lower the take-up flag only when neither says anything.
+Entity scope is why the three are not read the same way
+-------------------------------------------------------
+``receives_snap`` and ``receives_tanf`` are **spm_unit**-level, matching the household scope of
+a Current Benefits tile, so the tile maps onto them directly.
+
+``receives_ssi`` is **person**-level. The screener captures the tile per household, so a ticked
+SSI tile with no dollar amount names no recipient — and with more than one plausible member,
+nothing in the data distinguishes which of them receives it. Guessing is not free:
+PolicyEngine treats ``receives_ssi`` as conclusive, so crediting the wrong member confers the
+SSI-recipient Medicaid pathway on them with no demographic or income test. So SSI receipt is
+read from a reported amount only, which is per-member and unambiguous.
+
+The tile still counts for take-up: ``screen_reports_ssi_without_amount`` holds it at
+PolicyEngine's default for such a household, so a real recipient's SSI is never zeroed. The
+tile just isn't asserted as any particular member's receipt.
+
+Little rides on that narrower read, because ``ssi`` and ``receives_ssi`` are consumed as a
+pair — every consumer tests ``(ssi > 0) | receives_ssi`` (SNAP's
+``meets_snap_categorical_eligibility``, Medicaid's ``is_ssi_recipient_for_medicaid`` and its
+209(b) variant). A tile-only household keeps ``takes_up_ssi_if_eligible`` True, so PolicyEngine
+models their SSI, ``ssi > 0``, and those tests fire anyway. The boolean decides only the case
+where PolicyEngine computes the amount as $0, which is the one receipt a tile-only household
+does not get credited for.
 """
 
 from screener.models import HouseholdMember, Screen
@@ -26,9 +46,6 @@ from screener.models import HouseholdMember, Screen
 # and that TANF is captured as `cashAssistance` rather than a `tanf` income type.
 SSI_INCOME_TYPE = "sSI"
 TANF_INCOME_TYPE = "cashAssistance"
-
-# SSI's aged pathway (42 U.S.C. § 1382(a)); the blind/disabled pathways have no age floor.
-SSI_AGED_MIN_AGE = 65
 
 
 def screen_reports_snap(screen: Screen) -> bool:
@@ -51,59 +68,30 @@ def screen_reports_tanf(screen: Screen) -> bool:
 
 
 def member_reports_ssi_amount(member: HouseholdMember) -> bool:
-    """Whether this member reports an SSI dollar amount of their own."""
+    """
+    Whether this member reports an SSI dollar amount of their own — the only per-member SSI
+    receipt signal the screener captures, and so the sole basis for ``receives_ssi``.
+
+    The Current Benefits tile is deliberately not read here: it is household-scoped, so it
+    names no recipient, and with more than one plausible member the screener holds nothing to
+    tell them apart. See ``screen_reports_ssi_without_amount`` for what the tile does drive.
+    """
     return member.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0
 
 
-def _could_receive_ssi(member: HouseholdMember) -> bool:
-    """Whether this member could be the SSI recipient in a household reporting SSI: SSI is
-    only payable to someone aged, blind or disabled (42 U.S.C. § 1382(a)). Used to attribute a
-    household-level report, never to decide eligibility."""
-    age = member.calc_age()
-    if age is not None and age >= SSI_AGED_MIN_AGE:
-        return True
-
-    return bool(member.disabled or member.long_term_disability or member.visually_impaired)
-
-
-def member_receives_ssi(screen: Screen, member: HouseholdMember) -> bool:
+def screen_reports_ssi_without_amount(screen: Screen) -> bool:
     """
-    Whether this member reports receiving SSI, from either signal: their own reported amount,
-    or the household's Current Benefits tile.
+    Whether the household ticked the SSI tile but reported no SSI amount for anyone.
 
-    ``receives_ssi`` is person-level and PolicyEngine treats it as conclusive — measured, the
-    flag alone confers the SSI-recipient Medicaid pathway with no demographic or income test.
-    So a household-level tile is attributed, not broadcast: a member reporting their own amount
-    receives SSI, and otherwise a ticked tile with no amount anywhere credits only the members
-    who could plausibly be the recipient. A reported amount explains the tile, leaving the
-    others as non-recipients.
-    """
-    if member_reports_ssi_amount(member):
-        return True
+    Somebody here receives SSI, but nothing identifies who, so no member is asserted as a
+    recipient. Lowering ``takes_up_ssi_if_eligible`` would zero the simulated SSI of whoever
+    that is, so callers leave take-up at PolicyEngine's default for the whole household —
+    unknown stays unknown rather than becoming a denial.
 
-    if not screen.has_base_benefit("ssi"):
-        return False
-
-    if screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0:
-        # Somebody's amount already accounts for the tile.
-        return False
-
-    return _could_receive_ssi(member)
-
-
-def screen_reports_unidentifiable_ssi(screen: Screen) -> bool:
-    """
-    Whether the household reports SSI receipt we can't pin on anyone: tile ticked, no amount
-    reported, and nobody aged, blind or disabled.
-
-    The signal is real, so suppressing simulated SSI across the household would zero out a
-    genuine recipient's benefit — but there is no defensible member to credit. Callers leave
-    PolicyEngine's default take-up alone, which is the pre-contract behavior.
+    Once any member reports an amount, that member accounts for the tile and the rest of the
+    household is suppressed normally.
     """
     if not screen.has_base_benefit("ssi"):
         return False
 
-    if screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) > 0:
-        return False
-
-    return not any(_could_receive_ssi(member) for member in screen.household_members.all())
+    return screen.calc_gross_income("yearly", [SSI_INCOME_TYPE]) == 0

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -63,15 +63,12 @@ class SnapGrossIncomeDependency(SpmUnit):
 class TakesUpSnapIfEligibleDependency(SpmUnit):
     """
     False for a household that does not report receiving SNAP, which zeroes PolicyEngine's
-    simulated SNAP and switches off the categorical eligibility SNAP receipt confers
-    (Head Start / Early Head Start, WIC's adjunct test).
+    simulated SNAP and the categorical eligibility SNAP receipt confers (Head Start / Early
+    Head Start, WIC's adjunct test).
 
-    The Current Benefits tile is the only signal — the screener captures no SNAP amount —
-    so an unticked tile is read as "not receiving" here, unlike SSI and TANF where a
-    reported dollar amount can also stand in for the tile.
-
-    ``takes_up_snap_if_eligible`` predates 1.779.3 but was ignored outside microsimulation
-    until then; the gate is set to the release where it started applying through the API.
+    The tile is the only signal, so an unticked one reads as "not receiving" — unlike SSI and
+    TANF, where a reported amount can stand in for it. The gate is set to the release where
+    this field started applying through the API, not the one that introduced it.
     """
 
     field = "takes_up_snap_if_eligible"
@@ -82,12 +79,9 @@ class TakesUpSnapIfEligibleDependency(SpmUnit):
 
 
 class ReceivesSnapDependency(SpmUnit):
-    """
-    Reported SNAP receipt, the signal that confers SNAP-based categorical eligibility on
-    other programs. Separate from the take-up flag: this stays True even where PE computes
-    the household's own SNAP entitlement as $0, which is the case a computed amount cannot
-    express.
-    """
+    """Reported SNAP receipt, which confers SNAP-based categorical eligibility on other
+    programs. Stays True even where PolicyEngine computes the household's own SNAP as $0 —
+    the case a computed amount cannot express."""
 
     field = "receives_snap"
     min_pe_version = (1, 779, 3)
@@ -180,14 +174,11 @@ class SnapEmergencyAllotmentDependency(SpmUnit):
 
 class SnapIfTakesUp(SpmUnit):
     """
-    PolicyEngine's would-be SNAP entitlement, independent of take-up. The SNAP program
-    reads this rather than ``snap``, which ``takes_up_snap_if_eligible: False`` zeroes for
-    every household that doesn't already receive it — precisely the households the
-    program should be shown to.
+    PolicyEngine's would-be SNAP entitlement, independent of take-up — what the SNAP program
+    reads, since ``snap`` is zeroed for every household not already receiving it.
 
-    This replaced a ``snap: 1`` receipt sentinel. The sentinel pinned PE's computed SNAP
-    to $1/mo for anyone who reported receiving it, polluting the income other programs
-    read; ``ReceivesSnapDependency`` carries the same signal without touching the amount.
+    Replaced a ``snap: 1`` receipt sentinel that pinned PolicyEngine's computed SNAP to $1/mo
+    for anyone reporting receipt, polluting the income other programs read.
     """
 
     field = "snap_if_takes_up"
@@ -220,16 +211,12 @@ class Lifeline(SpmUnit):
 
 class Tanf(SpmUnit):
     """
-    The household's reported TANF amount, as PolicyEngine's ``tanf`` input.
+    The household's reported TANF amount, as PolicyEngine's ``tanf`` input; None when none is
+    reported, leaving PolicyEngine to compute it.
 
-    A positive ``tanf`` drives SNAP / Head Start / WIC categorical eligibility, and
-    consumers that read the amount (spm_unit_benefits, tx_ceap_countable_income, HUD
-    income) get the real figure. Otherwise None, so PE computes the benefit — whether that
-    computed amount is then used depends on ``TakesUpTanfIfEligibleDependency``.
-
-    The reported cash-assistance amount is the receipt signal on its own; a household that
-    enters an amount without ticking the Current Benefits tile is still telling us they
-    receive TANF, so this no longer requires the tile.
+    A positive value drives SNAP / Head Start / WIC categorical eligibility and gives the
+    consumers that read the amount (spm_unit_benefits, tx_ceap_countable_income, HUD income)
+    the real figure. The amount is itself the receipt signal, so this does not require the tile.
     """
 
     field = "tanf"
@@ -246,12 +233,12 @@ class Tanf(SpmUnit):
 
 class TanfIfTakesUp(SpmUnit):
     """
-    PolicyEngine's would-be TANF entitlement, independent of take-up — what the TANF
-    program reads instead of the receipt-gated ``tanf``.
+    PolicyEngine's would-be TANF entitlement, independent of take-up — what the TANF program
+    reads instead of the receipt-gated ``tanf``.
 
-    Caveat: pinning a reported ``tanf`` amount drives this to 0, so it is a would-be read
-    for non-recipients only. That is who the program is shown to — recipients are filtered
-    out of results by ``already_has`` — but it means the two are not interchangeable.
+    Caveat: pinning a reported ``tanf`` amount drives this to 0, so it is a would-be read for
+    non-recipients only. That is who the program is shown to (``already_has`` filters
+    recipients out), but the two fields are not interchangeable.
     """
 
     field = "tanf_if_takes_up"
@@ -260,12 +247,10 @@ class TanfIfTakesUp(SpmUnit):
 
 class ReceivesTanfDependency(SpmUnit):
     """
-    Reported TANF receipt. Confers the categorical eligibility TANF carries (SNAP, Head
-    Start, WIC's adjunct test) even where PE computes the household's own TANF as $0.
+    Reported TANF receipt, conferring the categorical eligibility TANF carries (SNAP, Head
+    Start, WIC's adjunct test) even where PolicyEngine computes the household's own TANF as $0.
 
-    PolicyEngine's ``is_tanf_enrolled`` defaults to this, so one boolean drives both
-    cross-program categorical eligibility and TANF's own applicant-vs-recipient rules;
-    there is no need to send ``is_tanf_enrolled`` separately.
+    ``is_tanf_enrolled`` defaults to this, so it need not be sent separately.
     """
 
     field = "receives_tanf"
@@ -281,11 +266,8 @@ class ReceivesTanfDependency(SpmUnit):
 
 
 class TakesUpTanfIfEligibleDependency(SpmUnit):
-    """
-    False for a household that reports no TANF — neither the tile nor a cash-assistance
-    income stream — so PE's simulated TANF stops counting as income and stops conferring
-    categorical eligibility on other programs.
-    """
+    """False for a household reporting no TANF by either signal, so PolicyEngine's simulated
+    TANF stops counting as income and stops conferring categorical eligibility."""
 
     field = "takes_up_tanf_if_eligible"
     min_pe_version = (1, 779, 3)

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -62,13 +62,17 @@ class SnapGrossIncomeDependency(SpmUnit):
 
 class TakesUpSnapIfEligibleDependency(SpmUnit):
     """
-    False for a household that does not report receiving SNAP, which zeroes PolicyEngine's
-    simulated SNAP and the categorical eligibility SNAP receipt confers (Head Start / Early
-    Head Start, WIC's adjunct test).
+    PolicyEngine's ``takes_up_snap_if_eligible`` spm_unit input, default True. False stops
+    PolicyEngine counting the SNAP it simulates for the household as income they receive, and
+    withdraws the categorical eligibility SNAP receipt confers (Head Start / Early Head Start,
+    WIC's adjunct test).
 
-    The tile is the only signal, so an unticked one reads as "not receiving" — unlike SSI and
-    TANF, where a reported amount can stand in for it. The gate is set to the release where
-    this field started applying through the API, not the one that introduced it.
+    Lowered for a household that does not report receiving SNAP. The tile is the only signal,
+    so an unticked one reads as "not receiving" — unlike SSI and TANF, where a reported amount
+    can stand in for it.
+
+    The gate is the release where this field started applying through the API, not the one that
+    introduced it.
     """
 
     field = "takes_up_snap_if_eligible"
@@ -79,9 +83,14 @@ class TakesUpSnapIfEligibleDependency(SpmUnit):
 
 
 class ReceivesSnapDependency(SpmUnit):
-    """Reported SNAP receipt, which confers SNAP-based categorical eligibility on other
-    programs. Stays True even where PolicyEngine computes the household's own SNAP as $0 —
-    the case a computed amount cannot express."""
+    """
+    PolicyEngine's ``receives_snap`` spm_unit input: the household is a reported SNAP recipient.
+
+    Confers SNAP-based categorical eligibility on other programs even where PolicyEngine
+    computes the household's own SNAP as $0 — the case a computed amount cannot express.
+    spm_unit-scoped, matching the household scope of the tile it reads, so unlike SSI it needs
+    no attribution to a member.
+    """
 
     field = "receives_snap"
     min_pe_version = (1, 779, 3)
@@ -174,11 +183,12 @@ class SnapEmergencyAllotmentDependency(SpmUnit):
 
 class SnapIfTakesUp(SpmUnit):
     """
-    PolicyEngine's would-be SNAP entitlement, independent of take-up — what the SNAP program
-    reads, since ``snap`` is zeroed for every household not already receiving it.
+    PolicyEngine's ``snap_if_takes_up`` spm_unit output: the SNAP the household would get if it
+    took the program up, regardless of reported take-up.
 
-    Replaced a ``snap: 1`` receipt sentinel that pinned PolicyEngine's computed SNAP to $1/mo
-    for anyone reporting receipt, polluting the income other programs read.
+    What the SNAP program reads, since the plain ``snap`` output is gated on
+    ``takes_up_snap_if_eligible`` and so reads 0 for exactly the non-recipients the program
+    should be recommended to.
     """
 
     field = "snap_if_takes_up"
@@ -233,12 +243,12 @@ class Tanf(SpmUnit):
 
 class TanfIfTakesUp(SpmUnit):
     """
-    PolicyEngine's would-be TANF entitlement, independent of take-up — what the TANF program
-    reads instead of the receipt-gated ``tanf``.
+    PolicyEngine's ``tanf_if_takes_up`` spm_unit output: the TANF the household would get if it
+    took the program up, summed across the state programs, regardless of reported take-up.
 
-    Caveat: pinning a reported ``tanf`` amount drives this to 0, so it is a would-be read for
-    non-recipients only. That is who the program is shown to (``already_has`` filters
-    recipients out), but the two fields are not interchangeable.
+    What the TANF program reads, since the plain ``tanf`` output is gated on
+    ``takes_up_tanf_if_eligible`` and so reads 0 for exactly the non-recipients the program
+    should be recommended to.
     """
 
     field = "tanf_if_takes_up"
@@ -247,8 +257,12 @@ class TanfIfTakesUp(SpmUnit):
 
 class ReceivesTanfDependency(SpmUnit):
     """
-    Reported TANF receipt, conferring the categorical eligibility TANF carries (SNAP, Head
-    Start, WIC's adjunct test) even where PolicyEngine computes the household's own TANF as $0.
+    PolicyEngine's ``receives_tanf`` spm_unit input: the household is a reported TANF recipient.
+
+    Confers the categorical eligibility TANF carries (SNAP, Head Start, WIC's adjunct test) even
+    where PolicyEngine computes the household's own TANF as $0 — the case a reported amount
+    cannot express. spm_unit-scoped, matching the household scope of the signals it reads, so
+    unlike SSI it needs no attribution to a member.
 
     ``is_tanf_enrolled`` defaults to this, so it need not be sent separately.
     """
@@ -266,8 +280,14 @@ class ReceivesTanfDependency(SpmUnit):
 
 
 class TakesUpTanfIfEligibleDependency(SpmUnit):
-    """False for a household reporting no TANF by either signal, so PolicyEngine's simulated
-    TANF stops counting as income and stops conferring categorical eligibility."""
+    """
+    PolicyEngine's ``takes_up_tanf_if_eligible`` spm_unit input, default True. False stops
+    PolicyEngine counting the TANF it simulates for the household as income they receive, and
+    withdraws the categorical eligibility that receipt confers.
+
+    Lowered for a household reporting no TANF by either signal — the tile or a cash-assistance
+    amount.
+    """
 
     field = "takes_up_tanf_if_eligible"
     min_pe_version = (1, 779, 3)

--- a/programs/programs/policyengine/calculators/dependencies/spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/spm.py
@@ -1,5 +1,6 @@
 from screener.models import HouseholdMember
 from .base import SpmUnit
+from .receipt import TANF_INCOME_TYPE, screen_reports_snap, screen_reports_tanf
 
 
 class ChildCareDependency(SpmUnit):
@@ -60,10 +61,39 @@ class SnapGrossIncomeDependency(SpmUnit):
 
 
 class TakesUpSnapIfEligibleDependency(SpmUnit):
+    """
+    False for a household that does not report receiving SNAP, which zeroes PolicyEngine's
+    simulated SNAP and switches off the categorical eligibility SNAP receipt confers
+    (Head Start / Early Head Start, WIC's adjunct test).
+
+    The Current Benefits tile is the only signal — the screener captures no SNAP amount —
+    so an unticked tile is read as "not receiving" here, unlike SSI and TANF where a
+    reported dollar amount can also stand in for the tile.
+
+    ``takes_up_snap_if_eligible`` predates 1.779.3 but was ignored outside microsimulation
+    until then; the gate is set to the release where it started applying through the API.
+    """
+
     field = "takes_up_snap_if_eligible"
+    min_pe_version = (1, 779, 3)
 
     def value(self):
-        return True
+        return screen_reports_snap(self.screen)
+
+
+class ReceivesSnapDependency(SpmUnit):
+    """
+    Reported SNAP receipt, the signal that confers SNAP-based categorical eligibility on
+    other programs. Separate from the take-up flag: this stays True even where PE computes
+    the household's own SNAP entitlement as $0, which is the case a computed amount cannot
+    express.
+    """
+
+    field = "receives_snap"
+    min_pe_version = (1, 779, 3)
+
+    def value(self):
+        return screen_reports_snap(self.screen)
 
 
 class HasHeatingCoolingExpenseDependency(SpmUnit):
@@ -148,33 +178,20 @@ class SnapEmergencyAllotmentDependency(SpmUnit):
         return 0
 
 
-class Snap(SpmUnit):
+class SnapIfTakesUp(SpmUnit):
     """
-    snap as both PE input and output.
+    PolicyEngine's would-be SNAP entitlement, independent of take-up. The SNAP program
+    reads this rather than ``snap``, which ``takes_up_snap_if_eligible: False`` zeroes for
+    every household that doesn't already receive it — precisely the households the
+    program should be shown to.
 
-    - If user reports having snap: send 1 so PE treats the household as
-      receiving SNAP, enabling categorical eligibility for programs like
-      Head Start and Early Head Start.
-    - If no reported snap: return None so PE calculates the SNAP benefit
-      amount the household is eligible for.
-
-    ``has_base_benefit`` covers every white-label variant (il_snap, ks_snap, co_snap,
-    …); ``has_benefit`` is an exact match on the bare name, which no white label uses,
-    so reported SNAP never reached PE and the categorical branch could not fire.
-    ``Tanf`` below reads the same way for the same reason.
-
-    Sending 1 does overwrite PE's *calculated* snap for this household, so the SNAP
-    program's own value becomes $1/mo. That is only ever the households that reported
-    receiving SNAP, and the results layer flags those `already_has` and filters the
-    program out (see ``isProgramBasicallyVisible``), so the clamped value is never
-    surfaced. PE models no reported-vs-calculated split for snap the way it does for
-    ssi (``ssi_reported`` / ``use_reported_ssi``), so this is the available signal.
+    This replaced a ``snap: 1`` receipt sentinel. The sentinel pinned PE's computed SNAP
+    to $1/mo for anyone who reported receiving it, polluting the income other programs
+    read; ``ReceivesSnapDependency`` carries the same signal without touching the amount.
     """
 
-    field = "snap"
-
-    def value(self):
-        return 1 if self.screen.has_base_benefit("snap") else None
+    field = "snap_if_takes_up"
+    min_pe_version = (1, 779, 3)
 
 
 class Acp(SpmUnit):
@@ -203,25 +220,83 @@ class Lifeline(SpmUnit):
 
 class Tanf(SpmUnit):
     """
-    tanf as both PE input and output.
+    The household's reported TANF amount, as PolicyEngine's ``tanf`` input.
 
-    When the household reports a TANF cash amount, send it as the `tanf` value. A
-    positive `tanf` drives SNAP/Head Start/WIC categorical eligibility, and consumers
-    that read the amount (spm_unit_benefits, tx_ceap_countable_income, HUD income) get
-    the real figure. Otherwise send None so PE computes the benefit — we only override
-    when we have an actual reported amount.
+    A positive ``tanf`` drives SNAP / Head Start / WIC categorical eligibility, and
+    consumers that read the amount (spm_unit_benefits, tx_ceap_countable_income, HUD
+    income) get the real figure. Otherwise None, so PE computes the benefit — whether that
+    computed amount is then used depends on ``TakesUpTanfIfEligibleDependency``.
 
-    has_base_benefit covers every white-label variant (ks_tanf, co_tanf, ma_tafdc, …);
-    has_benefit is an exact match that would miss the prefixed names.
+    The reported cash-assistance amount is the receipt signal on its own; a household that
+    enters an amount without ticking the Current Benefits tile is still telling us they
+    receive TANF, so this no longer requires the tile.
     """
 
     field = "tanf"
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
 
     def value(self):
-        if not self.screen.has_base_benefit("tanf"):
-            return None
-        reported_amount = self.screen.calc_gross_income("yearly", ["cashAssistance"])
+        reported_amount = self.screen.calc_gross_income("yearly", [TANF_INCOME_TYPE])
         return reported_amount if reported_amount > 0 else None
+
+
+class TanfIfTakesUp(SpmUnit):
+    """
+    PolicyEngine's would-be TANF entitlement, independent of take-up — what the TANF
+    program reads instead of the receipt-gated ``tanf``.
+
+    Caveat: pinning a reported ``tanf`` amount drives this to 0, so it is a would-be read
+    for non-recipients only. That is who the program is shown to — recipients are filtered
+    out of results by ``already_has`` — but it means the two are not interchangeable.
+    """
+
+    field = "tanf_if_takes_up"
+    min_pe_version = (1, 779, 3)
+
+
+class ReceivesTanfDependency(SpmUnit):
+    """
+    Reported TANF receipt. Confers the categorical eligibility TANF carries (SNAP, Head
+    Start, WIC's adjunct test) even where PE computes the household's own TANF as $0.
+
+    PolicyEngine's ``is_tanf_enrolled`` defaults to this, so one boolean drives both
+    cross-program categorical eligibility and TANF's own applicant-vs-recipient rules;
+    there is no need to send ``is_tanf_enrolled`` separately.
+    """
+
+    field = "receives_tanf"
+    min_pe_version = (1, 779, 3)
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
+
+    def value(self):
+        return screen_reports_tanf(self.screen)
+
+
+class TakesUpTanfIfEligibleDependency(SpmUnit):
+    """
+    False for a household that reports no TANF — neither the tile nor a cash-assistance
+    income stream — so PE's simulated TANF stops counting as income and stops conferring
+    categorical eligibility on other programs.
+    """
+
+    field = "takes_up_tanf_if_eligible"
+    min_pe_version = (1, 779, 3)
+    dependencies = (
+        "income_type",
+        "income_amount",
+        "income_frequency",
+    )
+
+    def value(self):
+        return screen_reports_tanf(self.screen)
 
 
 class CoTanf(SpmUnit):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1571,11 +1571,15 @@ class TestCareExpensesDependency(TestCase):
 
 class TestSsiReceiptDependencies(TestCase):
     """
-    Tests for the SSI half of the actual-receipt contract. ``ssi`` and ``receives_ssi`` are
-    person-level, so receipt is attributed per member from that member's own ``sSI`` income
-    stream — crediting the whole household would hand a non-disabled member the
-    SSI-recipient Medicaid pathway. SSDI (``sSDisability``) is a different program and must
-    never be folded in.
+    Tests for the SSI half of the actual-receipt contract.
+
+    Receipt comes from either signal — the member's own ``sSI`` amount, or the household's
+    Current Benefits tile — but ``ssi`` and ``receives_ssi`` are person-level, so a
+    household-level tile has to be *attributed* rather than broadcast. PolicyEngine treats
+    ``receives_ssi`` as conclusive (measured: it alone flips ``medicaid_category`` to
+    SSI_RECIPIENT with no demographic or income test), so crediting everyone would hand
+    Medicaid to a toddler. SSDI (``sSDisability``) is a different program and must never be
+    folded in.
     """
 
     def setUp(self):
@@ -1587,8 +1591,11 @@ class TestSsiReceiptDependencies(TestCase):
             household_size=2,
             completed=False,
         )
+        # Aged head, working-age non-disabled spouse, young child: only the head could be
+        # an SSI recipient, so attribution is observable.
         self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
-        self.spouse = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=65)
+        self.spouse = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=40)
+        self.child = HouseholdMember.objects.create(screen=self.screen, relationship="child", age=3)
 
     def _report_ssi(self, household_member, monthly):
         IncomeStream.objects.create(
@@ -1642,13 +1649,50 @@ class TestSsiReceiptDependencies(TestCase):
         self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
         self.assertTrue(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
 
-    def test_unattributable_household_receipt_leaves_take_up_alone(self):
+    def test_tile_alone_confers_receipt_on_the_plausible_member(self):
         """
-        The household ticked SSI but no member reports an amount, so there is no basis for
-        picking a recipient. Lowering take-up for everyone would zero a real recipient's
-        SSI, so the whole household keeps PolicyEngine's default — the pre-contract
+        A household can tick the SSI tile without entering an amount — that is a report of
+        receipt and has to reach PolicyEngine, or their categorical eligibility silently
+        goes missing.
+
+        It lands on the aged head, not the whole household: SSI is only payable to someone
+        aged, blind or disabled, and one credited member is enough for the cross-program
+        signal (SNAP's categorical eligibility fires off a single member).
+        """
+        self._tick_ssi_tile()
+
+        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+
+    def test_tile_does_not_credit_members_who_could_not_receive_ssi(self):
+        """
+        The non-disabled 40-year-old and the 3-year-old are not SSI recipients. Crediting
+        them would hand each the SSI-recipient Medicaid pathway — measured at $15,167 and
+        $10,222 against the live API, with no demographic or income test applied.
+        """
+        self._tick_ssi_tile()
+
+        for non_recipient in (self.spouse, self.child):
+            self.assertFalse(member.ReceivesSsiDependency(self.screen, non_recipient, {}).value())
+            self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, non_recipient, {}).value())
+
+    def test_tile_credits_a_disabled_member_of_any_age(self):
+        """The blind/disabled pathways have no age floor, so plausibility isn't just age."""
+        self.spouse.disabled = True
+        self.spouse.save()
+        self._tick_ssi_tile()
+
+        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
+
+    def test_unidentifiable_household_receipt_leaves_take_up_alone(self):
+        """
+        Tile ticked, no amount, and nobody aged/blind/disabled — the report is real but there
+        is no defensible member to credit. Lowering take-up for everyone would zero a genuine
+        recipient's SSI, so the household keeps PolicyEngine's default: the pre-contract
         behavior rather than a silent zeroing.
         """
+        self.head.age = 40
+        self.head.save()
         self._tick_ssi_tile()
 
         self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
@@ -1665,12 +1709,14 @@ class TestSsiReceiptDependencies(TestCase):
 
         self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
         self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.spouse, {}).value())
+        self.assertFalse(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
 
     def test_receipt_resolves_a_white_label_prefixed_ssi_program(self):
         """White labels ship ks_ssi / mo_ssi / tx_ssi, so the tile has to resolve by
         base_program rather than the bare name."""
         self._tick_ssi_tile("ks_ssi")
 
+        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
         self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
 
     def test_ssdi_and_other_income_are_not_ssi(self):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -1573,13 +1573,13 @@ class TestSsiReceiptDependencies(TestCase):
     """
     Tests for the SSI half of the actual-receipt contract.
 
-    Receipt comes from either signal — the member's own ``sSI`` amount, or the household's
-    Current Benefits tile — but ``ssi`` and ``receives_ssi`` are person-level, so a
-    household-level tile has to be *attributed* rather than broadcast. PolicyEngine treats
+    ``ssi`` and ``receives_ssi`` are person-level, and a reported amount is the only per-member
+    SSI signal the screener captures, so receipt is read from the amount alone. The
+    household-scoped Current Benefits tile names no recipient, and PolicyEngine treats
     ``receives_ssi`` as conclusive (measured: it alone flips ``medicaid_category`` to
-    SSI_RECIPIENT with no demographic or income test), so crediting everyone would hand
-    Medicaid to a toddler. SSDI (``sSDisability``) is a different program and must never be
-    folded in.
+    SSI_RECIPIENT with no demographic or income test), so a tile is never attributed to a
+    guessed member. It still holds take-up at PolicyEngine's default so a real recipient is not
+    zeroed. SSDI (``sSDisability``) is a different program and must never be folded in.
     """
 
     def setUp(self):
@@ -1632,9 +1632,9 @@ class TestSsiReceiptDependencies(TestCase):
 
     def test_no_reported_ssi_lowers_take_up(self):
         """
-        The core behavior change: PolicyEngine stops counting the SSI it simulates for a
-        non-reporter as income they receive, which is what unblocks IL AABD and lifts the
-        phantom income out of SNAP's income test.
+        Lowering take-up is what keeps PolicyEngine from counting the SSI it simulates for a
+        non-reporter as income they receive — load-bearing for IL AABD, which that phantom
+        income blocks outright, and for SNAP's income test.
         """
         self.assertIsNone(member.Ssi(self.screen, self.head, {}).value())
         self.assertFalse(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
@@ -1649,74 +1649,47 @@ class TestSsiReceiptDependencies(TestCase):
         self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
         self.assertTrue(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
 
-    def test_tile_alone_confers_receipt_on_the_plausible_member(self):
+    def test_tile_without_an_amount_asserts_nobody_receives_ssi(self):
         """
-        A household can tick the SSI tile without entering an amount — that is a report of
-        receipt and has to reach PolicyEngine, or their categorical eligibility silently
-        goes missing.
-
-        It lands on the aged head, not the whole household: SSI is only payable to someone
-        aged, blind or disabled, and one credited member is enough for the cross-program
-        signal (SNAP's categorical eligibility fires off a single member).
+        A ticked tile is household-scoped, so it names no recipient. With an aged head, a
+        working-age spouse and a child all equally unexcluded by the data we hold, crediting any
+        of them is a guess — and PolicyEngine would treat it as conclusive, handing that member
+        the SSI-recipient Medicaid pathway with no demographic or income test (measured at
+        $15,167 for the spouse, $10,222 for the child).
         """
         self._tick_ssi_tile()
 
-        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
-        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+        for household_member in (self.head, self.spouse, self.child):
+            self.assertFalse(member.ReceivesSsiDependency(self.screen, household_member, {}).value())
 
-    def test_tile_does_not_credit_members_who_could_not_receive_ssi(self):
+    def test_tile_without_an_amount_leaves_take_up_alone(self):
         """
-        The non-disabled 40-year-old and the 3-year-old are not SSI recipients. Crediting
-        them would hand each the SSI-recipient Medicaid pathway — measured at $15,167 and
-        $10,222 against the live API, with no demographic or income test applied.
+        The tile is not discarded, though: somebody here receives SSI, so lowering take-up would
+        zero the simulated SSI of whoever that is. The whole household keeps PolicyEngine's
+        default instead — unknown stays unknown rather than becoming a denial.
         """
         self._tick_ssi_tile()
 
-        for non_recipient in (self.spouse, self.child):
-            self.assertFalse(member.ReceivesSsiDependency(self.screen, non_recipient, {}).value())
-            self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, non_recipient, {}).value())
-
-    def test_tile_credits_a_disabled_member_of_any_age(self):
-        """The blind/disabled pathways have no age floor, so plausibility isn't just age."""
-        self.spouse.disabled = True
-        self.spouse.save()
-        self._tick_ssi_tile()
-
-        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
-
-    def test_unidentifiable_household_receipt_leaves_take_up_alone(self):
-        """
-        Tile ticked, no amount, and nobody aged/blind/disabled — the report is real but there
-        is no defensible member to credit. Lowering take-up for everyone would zero a genuine
-        recipient's SSI, so the household keeps PolicyEngine's default: the pre-contract
-        behavior rather than a silent zeroing.
-        """
-        self.head.age = 40
-        self.head.save()
-        self._tick_ssi_tile()
-
-        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
-        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.spouse, {}).value())
-        # Still nobody to attribute receipt to.
-        self.assertFalse(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+        for household_member in (self.head, self.spouse, self.child):
+            self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, household_member, {}).value())
 
     def test_a_reported_amount_explains_the_tile_for_the_rest_of_the_household(self):
-        """Once one member accounts for the household's SSI, members reporting nothing are
-        non-recipients again — otherwise one SSI recipient would shield every relative's
+        """Once a member accounts for the household's SSI, members reporting nothing are
+        suppressed normally — otherwise one SSI recipient would shield every relative's
         simulated SSI from suppression."""
         self._tick_ssi_tile()
         self._report_ssi(self.head, 943)
 
         self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
         self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.spouse, {}).value())
         self.assertFalse(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
 
-    def test_receipt_resolves_a_white_label_prefixed_ssi_program(self):
+    def test_tile_resolves_a_white_label_prefixed_ssi_program(self):
         """White labels ship ks_ssi / mo_ssi / tx_ssi, so the tile has to resolve by
-        base_program rather than the bare name."""
+        base_program rather than the bare name for take-up to be held at the default."""
         self._tick_ssi_tile("ks_ssi")
 
-        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
         self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
 
     def test_ssdi_and_other_income_are_not_ssi(self):
@@ -1732,10 +1705,14 @@ class TestSsiReceiptDependencies(TestCase):
         self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
 
 
-class TestWicIfTakesUpDependency(TestCase):
-    """The WIC program's output. WIC has no take-up flag of its own, but every WIC
-    calculator gates on this value being positive, so it reads the would-be entitlement
-    rather than the receipt-gated ``wic``."""
+class TestWicDependency(TestCase):
+    """
+    The WIC program's output stays on the ungated ``wic``.
+
+    ``wic`` is ``wic_if_takes_up`` gated on ``takes_up_wic_if_eligible``, which defaults True and
+    which we never send, so the two are the same number for every payload we submit. Staying
+    ungated keeps WIC out of the version floor and so out of ``_drop_unreadable_programs``.
+    """
 
     def setUp(self):
         self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
@@ -1745,10 +1722,10 @@ class TestWicIfTakesUpDependency(TestCase):
         self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=29)
 
     def test_field_name(self):
-        self.assertEqual(member.WicIfTakesUp(self.screen, self.head, {}).field, "wic_if_takes_up")
+        self.assertEqual(member.Wic(self.screen, self.head, {}).field, "wic")
 
-    def test_version_gated(self):
-        self.assertEqual(member.WicIfTakesUp.min_pe_version, (1, 779, 3))
+    def test_not_version_gated(self):
+        self.assertEqual(member.Wic.min_pe_version, ())
 
 
 class TestSsiCountableResourcesDependency(TestCase):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_member.py
@@ -7,6 +7,9 @@ to determine TX SNAP and Lifeline eligibility and benefit amounts.
 
 from django.test import TestCase
 from screener.models import Screen, HouseholdMember, WhiteLabel, Expense, IncomeStream
+from programs.models import Program
+from screener.tests.helpers import seed_program
+from screener.serializers import _write_current_benefits
 from programs.programs.policyengine.calculators.dependencies import member
 
 
@@ -1566,11 +1569,13 @@ class TestCareExpensesDependency(TestCase):
         self.assertEqual(member.CareExpensesDependency(self.screen, d1, {}).value(), 3000)
 
 
-class TestSsiReportedDependency(TestCase):
+class TestSsiReceiptDependencies(TestCase):
     """
-    Tests for SsiReportedDependency, which tells PolicyEngine how much SSI the member
-    already reports receiving. Only the screener's ``sSI`` income type counts — SSDI
-    (``sSDisability``) is a different program and must not be folded in.
+    Tests for the SSI half of the actual-receipt contract. ``ssi`` and ``receives_ssi`` are
+    person-level, so receipt is attributed per member from that member's own ``sSI`` income
+    stream — crediting the whole household would hand a non-disabled member the
+    SSI-recipient Medicaid pathway. SSDI (``sSDisability``) is a different program and must
+    never be folded in.
     """
 
     def setUp(self):
@@ -1579,32 +1584,125 @@ class TestSsiReportedDependency(TestCase):
             white_label=self.white_label,
             zipcode="65101",
             county="Test County",
-            household_size=1,
+            household_size=2,
             completed=False,
         )
         self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=67)
+        self.spouse = HouseholdMember.objects.create(screen=self.screen, relationship="spouse", age=65)
 
-    def test_field_name(self):
-        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).field, "ssi_reported")
-
-    def test_value_annualizes_reported_ssi(self):
+    def _report_ssi(self, household_member, monthly):
         IncomeStream.objects.create(
-            screen=self.screen, household_member=self.head, type="sSI", amount=943, frequency="monthly"
+            screen=self.screen, household_member=household_member, type="sSI", amount=monthly, frequency="monthly"
         )
-        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).value(), 11316)
 
-    def test_value_returns_zero_when_no_ssi_reported(self):
-        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).value(), 0)
+    def _tick_ssi_tile(self, name_abbreviated="ssi"):
+        seed_program(self.white_label, name_abbreviated)
+        Program.objects.filter(white_label=self.white_label, name_abbreviated=name_abbreviated).update(
+            base_program="ssi"
+        )
+        _write_current_benefits(self.screen, [name_abbreviated])
 
-    def test_value_excludes_ssdi_and_other_income(self):
-        """SSDI is a separate program; counting it as reported SSI would suppress the benefit."""
+    def test_field_names(self):
+        self.assertEqual(member.Ssi(self.screen, self.head, {}).field, "ssi")
+        self.assertEqual(member.ReceivesSsiDependency(self.screen, self.head, {}).field, "receives_ssi")
+        self.assertEqual(
+            member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).field, "takes_up_ssi_if_eligible"
+        )
+        self.assertEqual(member.SsiIfTakesUp(self.screen, self.head, {}).field, "ssi_if_takes_up")
+
+    def test_new_fields_are_version_gated(self):
+        self.assertEqual(member.ReceivesSsiDependency.min_pe_version, (1, 779, 3))
+        self.assertEqual(member.TakesUpSsiIfEligibleDependency.min_pe_version, (1, 779, 3))
+        self.assertEqual(member.SsiIfTakesUp.min_pe_version, (1, 779, 3))
+        self.assertEqual(member.Ssi.min_pe_version, ())
+
+    def test_sends_the_reported_amount_annualized(self):
+        self._report_ssi(self.head, 943)
+
+        self.assertEqual(member.Ssi(self.screen, self.head, {}).value(), 11316)
+        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+
+    def test_no_reported_ssi_lowers_take_up(self):
+        """
+        The core behavior change: PolicyEngine stops counting the SSI it simulates for a
+        non-reporter as income they receive, which is what unblocks IL AABD and lifts the
+        phantom income out of SNAP's income test.
+        """
+        self.assertIsNone(member.Ssi(self.screen, self.head, {}).value())
+        self.assertFalse(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+        self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+
+    def test_receipt_is_scoped_to_the_reporting_member(self):
+        """A spouse's SSI is not this member's — ``ssi`` is person-level."""
+        self._report_ssi(self.spouse, 943)
+
+        self.assertIsNone(member.Ssi(self.screen, self.head, {}).value())
+        self.assertFalse(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+        self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+        self.assertTrue(member.ReceivesSsiDependency(self.screen, self.spouse, {}).value())
+
+    def test_unattributable_household_receipt_leaves_take_up_alone(self):
+        """
+        The household ticked SSI but no member reports an amount, so there is no basis for
+        picking a recipient. Lowering take-up for everyone would zero a real recipient's
+        SSI, so the whole household keeps PolicyEngine's default — the pre-contract
+        behavior rather than a silent zeroing.
+        """
+        self._tick_ssi_tile()
+
+        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.spouse, {}).value())
+        # Still nobody to attribute receipt to.
+        self.assertFalse(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+
+    def test_a_reported_amount_explains_the_tile_for_the_rest_of_the_household(self):
+        """Once one member accounts for the household's SSI, members reporting nothing are
+        non-recipients again — otherwise one SSI recipient would shield every relative's
+        simulated SSI from suppression."""
+        self._tick_ssi_tile()
+        self._report_ssi(self.head, 943)
+
+        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+        self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.spouse, {}).value())
+
+    def test_receipt_resolves_a_white_label_prefixed_ssi_program(self):
+        """White labels ship ks_ssi / mo_ssi / tx_ssi, so the tile has to resolve by
+        base_program rather than the bare name."""
+        self._tick_ssi_tile("ks_ssi")
+
+        self.assertTrue(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+
+    def test_ssdi_and_other_income_are_not_ssi(self):
         IncomeStream.objects.create(
             screen=self.screen, household_member=self.head, type="sSDisability", amount=1000, frequency="monthly"
         )
         IncomeStream.objects.create(
             screen=self.screen, household_member=self.head, type="wages", amount=500, frequency="monthly"
         )
-        self.assertEqual(member.SsiReportedDependency(self.screen, self.head, {}).value(), 0)
+
+        self.assertIsNone(member.Ssi(self.screen, self.head, {}).value())
+        self.assertFalse(member.ReceivesSsiDependency(self.screen, self.head, {}).value())
+        self.assertFalse(member.TakesUpSsiIfEligibleDependency(self.screen, self.head, {}).value())
+
+
+class TestWicIfTakesUpDependency(TestCase):
+    """The WIC program's output. WIC has no take-up flag of its own, but every WIC
+    calculator gates on this value being positive, so it reads the would-be entitlement
+    rather than the receipt-gated ``wic``."""
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label, zipcode="65101", county="Test County", household_size=1, completed=False
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=29)
+
+    def test_field_name(self):
+        self.assertEqual(member.WicIfTakesUp(self.screen, self.head, {}).field, "wic_if_takes_up")
+
+    def test_version_gated(self):
+        self.assertEqual(member.WicIfTakesUp.min_pe_version, (1, 779, 3))
 
 
 class TestSsiCountableResourcesDependency(TestCase):

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -571,8 +571,8 @@ class TestSnapReceiptDependencies(TestCase):
         self.assertEqual(spm.TakesUpSnapIfEligibleDependency(self.screen, None, {}).field, "takes_up_snap_if_eligible")
 
     def test_version_gated_to_the_release_that_honors_them(self):
-        """Both are policyengine-us 1.779.3 fields (takes_up_snap_if_eligible predates it but
-        was ignored outside microsimulation). Sending either to an older model 400s the whole
+        """Both arrived with the contract (takes_up_snap_if_eligible predates it but was
+        ignored outside microsimulation). Sending either to an older model 400s the whole
         request, taking every PE program in it down."""
         self.assertEqual(spm.ReceivesSnapDependency.min_pe_version, (1, 779, 3))
         self.assertEqual(spm.TakesUpSnapIfEligibleDependency.min_pe_version, (1, 779, 3))

--- a/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
+++ b/programs/programs/policyengine/calculators/dependencies/tests/test_spm.py
@@ -535,8 +535,16 @@ class TestSchoolMealCountableIncomeDependency(TestCase):
         self.assertEqual(dep.value(), 31200)  # ($2000 + $600) * 12
 
 
-class TestSnapDependency(TestCase):
-    """Tests for Snap dependency — dual-role as PE input (categorical eligibility) and output (benefit amount)."""
+class TestSnapReceiptDependencies(TestCase):
+    """
+    Tests for the SNAP half of the actual-receipt contract: receives_snap confers the
+    categorical eligibility SNAP receipt carries on other programs, and
+    takes_up_snap_if_eligible suppresses the SNAP PolicyEngine would otherwise simulate
+    for a household that reports not receiving it.
+
+    The Current Benefits tile is the only signal — the screener captures no SNAP amount —
+    so both read the same way and an unticked tile means "not receiving".
+    """
 
     def setUp(self):
         self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
@@ -547,10 +555,6 @@ class TestSnapDependency(TestCase):
             household_size=2,
             completed=False,
         )
-
-    def test_field_name(self):
-        dep = spm.Snap(self.screen, None, {})
-        self.assertEqual(dep.field, "snap")
 
     def _report_snap(self, name_abbreviated: str):
         """Seed a SNAP program under `name_abbreviated` with base_program set
@@ -562,41 +566,46 @@ class TestSnapDependency(TestCase):
         )
         _write_current_benefits(self.screen, [name_abbreviated])
 
-    def test_value_returns_1_when_screen_has_snap(self):
-        """When user reports having SNAP, send 1 to PE to enable categorical eligibility."""
+    def test_field_names(self):
+        self.assertEqual(spm.ReceivesSnapDependency(self.screen, None, {}).field, "receives_snap")
+        self.assertEqual(spm.TakesUpSnapIfEligibleDependency(self.screen, None, {}).field, "takes_up_snap_if_eligible")
+
+    def test_version_gated_to_the_release_that_honors_them(self):
+        """Both are policyengine-us 1.779.3 fields (takes_up_snap_if_eligible predates it but
+        was ignored outside microsimulation). Sending either to an older model 400s the whole
+        request, taking every PE program in it down."""
+        self.assertEqual(spm.ReceivesSnapDependency.min_pe_version, (1, 779, 3))
+        self.assertEqual(spm.TakesUpSnapIfEligibleDependency.min_pe_version, (1, 779, 3))
+
+    def test_reported_snap_receipt(self):
         self._report_snap("snap")
 
-        dep = spm.Snap(self.screen, None, {})
-        self.assertEqual(dep.value(), 1)
+        self.assertTrue(spm.ReceivesSnapDependency(self.screen, None, {}).value())
+        self.assertTrue(spm.TakesUpSnapIfEligibleDependency(self.screen, None, {}).value())
 
-    def test_value_returns_1_for_a_white_label_prefixed_snap(self):
-        """Every white label names its SNAP program with a prefix (il_snap, ks_snap, …).
-        Resolving by base_program rather than exact name is what lets reported SNAP reach
-        PE at all — an exact bare-name match found nothing, so no household ever hit the
-        Head Start / Early Head Start categorical branch."""
+    def test_reported_snap_receipt_under_a_white_label_prefixed_name(self):
+        """Every white label names its SNAP program with a prefix (il_snap, ks_snap, …), so
+        receipt has to resolve by base_program — an exact bare-name match finds nothing."""
         self._report_snap("il_snap")
 
-        dep = spm.Snap(self.screen, None, {})
-        self.assertEqual(dep.value(), 1)
+        self.assertTrue(spm.ReceivesSnapDependency(self.screen, None, {}).value())
+        self.assertTrue(spm.TakesUpSnapIfEligibleDependency(self.screen, None, {}).value())
 
-    def test_value_returns_none_when_screen_does_not_have_snap(self):
-        """When user does not report SNAP, return None so PE calculates the benefit amount."""
-        dep = spm.Snap(self.screen, None, {})
-        self.assertIsNone(dep.value())
+    def test_no_reported_snap_lowers_take_up(self):
+        self.assertFalse(spm.ReceivesSnapDependency(self.screen, None, {}).value())
+        self.assertFalse(spm.TakesUpSnapIfEligibleDependency(self.screen, None, {}).value())
 
-    def test_value_returns_none_for_an_unrelated_reported_benefit(self):
-        """base_program is what matches — an unrelated current benefit must not be read as
-        reported SNAP."""
+    def test_an_unrelated_reported_benefit_is_not_snap(self):
         seed_program(self.white_label, "il_tanf")
         Program.objects.filter(white_label=self.white_label, name_abbreviated="il_tanf").update(base_program="tanf")
         _write_current_benefits(self.screen, ["il_tanf"])
 
-        dep = spm.Snap(self.screen, None, {})
-        self.assertIsNone(dep.value())
+        self.assertFalse(spm.ReceivesSnapDependency(self.screen, None, {}).value())
+        self.assertFalse(spm.TakesUpSnapIfEligibleDependency(self.screen, None, {}).value())
 
 
-class TestTanfDependency(TestCase):
-    """Tests for Tanf dependency — dual-role as PE input (categorical eligibility) and output (benefit amount)."""
+class TestSnapIfTakesUpDependency(TestCase):
+    """The SNAP program's output — the would-be entitlement, which survives the take-up flag."""
 
     def setUp(self):
         self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
@@ -609,39 +618,96 @@ class TestTanfDependency(TestCase):
         )
 
     def test_field_name(self):
-        dep = spm.Tanf(self.screen, None, {})
-        self.assertEqual(dep.field, "tanf")
+        self.assertEqual(spm.SnapIfTakesUp(self.screen, None, {}).field, "snap_if_takes_up")
 
-    def _report_tanf(self):
+    def test_version_gated(self):
+        self.assertEqual(spm.SnapIfTakesUp.min_pe_version, (1, 779, 3))
+
+
+class TestTanfDependencies(TestCase):
+    """
+    Tests for the TANF half of the actual-receipt contract. Unlike SNAP, TANF has an
+    amount: the reported cash-assistance income stream is both the value sent to
+    PolicyEngine and, on its own, proof of receipt.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(name="Test State", code="test", state_code="TS")
+        self.screen = Screen.objects.create(
+            white_label=self.white_label,
+            zipcode="78701",
+            county="Test County",
+            household_size=2,
+            completed=False,
+        )
+        self.head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=35)
+
+    def _report_cash_assistance(self, monthly: int):
+        IncomeStream.objects.create(
+            screen=self.screen, household_member=self.head, type="cashAssistance", amount=monthly, frequency="monthly"
+        )
+
+    def _tick_tanf_tile(self):
         """Seed a TANF program with base_program set (seed_program leaves it None) and
         record receipt on the screen, mirroring how has_base_benefit resolves variants."""
         seed_program(self.white_label, "tanf")
         Program.objects.filter(white_label=self.white_label, name_abbreviated="tanf").update(base_program="tanf")
         _write_current_benefits(self.screen, ["tanf"])
 
-    def test_value_returns_reported_amount_when_screen_has_tanf(self):
-        """When the household reports TANF with a cash amount, send that amount to PE."""
-        head = HouseholdMember.objects.create(screen=self.screen, relationship="headOfHousehold", age=35)
+    def test_field_names(self):
+        self.assertEqual(spm.Tanf(self.screen, None, {}).field, "tanf")
+        self.assertEqual(spm.ReceivesTanfDependency(self.screen, None, {}).field, "receives_tanf")
+        self.assertEqual(spm.TakesUpTanfIfEligibleDependency(self.screen, None, {}).field, "takes_up_tanf_if_eligible")
+        self.assertEqual(spm.TanfIfTakesUp(self.screen, None, {}).field, "tanf_if_takes_up")
+
+    def test_new_fields_are_version_gated(self):
+        self.assertEqual(spm.ReceivesTanfDependency.min_pe_version, (1, 779, 3))
+        self.assertEqual(spm.TakesUpTanfIfEligibleDependency.min_pe_version, (1, 779, 3))
+        self.assertEqual(spm.TanfIfTakesUp.min_pe_version, (1, 779, 3))
+        self.assertEqual(spm.Tanf.min_pe_version, ())
+
+    def test_sends_the_reported_amount_annualized(self):
+        self._report_cash_assistance(400)
+        self._tick_tanf_tile()
+
+        self.assertEqual(spm.Tanf(self.screen, None, {}).value(), 4800)  # $400/month * 12
+
+    def test_reported_amount_alone_is_receipt(self):
+        """
+        A household can enter a cash-assistance amount without ticking the tile. Reading
+        that as "not receiving" would send takes_up_tanf_if_eligible: false alongside their
+        own reported TANF amount.
+        """
+        self._report_cash_assistance(400)
+
+        self.assertEqual(spm.Tanf(self.screen, None, {}).value(), 4800)
+        self.assertTrue(spm.ReceivesTanfDependency(self.screen, None, {}).value())
+        self.assertTrue(spm.TakesUpTanfIfEligibleDependency(self.screen, None, {}).value())
+
+    def test_tile_without_an_amount_is_receipt_without_a_value(self):
+        """
+        receives_tanf is exactly the case an amount can't express: PolicyEngine may compute
+        the household's TANF as $0, and the boolean is what keeps the categorical
+        eligibility their receipt confers firing anyway.
+        """
+        self._tick_tanf_tile()
+
+        self.assertIsNone(spm.Tanf(self.screen, None, {}).value())
+        self.assertTrue(spm.ReceivesTanfDependency(self.screen, None, {}).value())
+        self.assertTrue(spm.TakesUpTanfIfEligibleDependency(self.screen, None, {}).value())
+
+    def test_no_reported_tanf_lowers_take_up(self):
+        self.assertIsNone(spm.Tanf(self.screen, None, {}).value())
+        self.assertFalse(spm.ReceivesTanfDependency(self.screen, None, {}).value())
+        self.assertFalse(spm.TakesUpTanfIfEligibleDependency(self.screen, None, {}).value())
+
+    def test_other_income_is_not_cash_assistance(self):
         IncomeStream.objects.create(
-            screen=self.screen, household_member=head, type="cashAssistance", amount=400, frequency="monthly"
+            screen=self.screen, household_member=self.head, type="wages", amount=2000, frequency="monthly"
         )
-        self._report_tanf()
 
-        dep = spm.Tanf(self.screen, None, {})
-        self.assertEqual(dep.value(), 4800)  # $400/month * 12
-
-    def test_value_returns_none_when_tanf_reported_without_amount(self):
-        """Reported receipt but no cash amount collected: return None (don't override with a
-        placeholder), so PE computes the benefit rather than seeing a bogus value."""
-        self._report_tanf()
-
-        dep = spm.Tanf(self.screen, None, {})
-        self.assertIsNone(dep.value())
-
-    def test_value_returns_none_when_screen_does_not_have_tanf(self):
-        """When user does not report TANF, return None so PE calculates the benefit amount."""
-        dep = spm.Tanf(self.screen, None, {})
-        self.assertIsNone(dep.value())
+        self.assertIsNone(spm.Tanf(self.screen, None, {}).value())
+        self.assertFalse(spm.ReceivesTanfDependency(self.screen, None, {}).value())
 
 
 class TestWaTanfDependency(TestCase):

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -129,13 +129,11 @@ def all_eligibility(method: Sim, valid_programs: dict[str, PolicyEngineCalulator
 def _resolve_comparable_version(programs: List[PolicyEngineCalulator], version: str) -> Optional[tuple]:
     """Tuple form of `version`, for gating which inputs and outputs may be sent.
 
-    We send the "current" alias unpinned (its comparable form is None), but for gating we
-    still need to know what current concretely is — otherwise a min_pe_version floor can
-    never be met and gated fields are withheld forever. Resolve it from PE's published
-    /versions/us. If PE is unreachable this stays None, keeping the conservative
-    withhold-gated behavior. Only bother resolving when the request actually carries a
-    gated field — the vast majority don't, and resolving would be a needless (cached)
-    lookup."""
+    The "current" alias has no comparable form of its own, so resolve what it points at from
+    PolicyEngine's /versions/us — otherwise a min_pe_version floor could never be met and
+    gated fields would be withheld forever. Stays None if PolicyEngine is unreachable, keeping
+    the conservative withhold-gated behavior. Only resolves when the request carries a gated
+    field, since most don't."""
     comparable_version = pe_versions.to_comparable_pe_version(version)
     if comparable_version is None and _has_gated_input(programs):
         comparable_version = pe_versions.resolve_unpinned_comparable_version()
@@ -148,21 +146,17 @@ def _drop_unreadable_programs(
 ) -> dict[str, PolicyEngineCalulator]:
     """Drop programs whose own output variable the resolved model doesn't define.
 
-    Version gating withholds such a field from the request, so PolicyEngine never returns
-    it and `Sim.value` raises KeyError on the missing key. `all_eligibility` doesn't
-    contain per-program failures, so a single unreadable program would empty the PE result
-    for the whole screen — every PolicyEngine program, not just that one.
+    Version gating withholds such a field, so PolicyEngine never returns it and `Sim.value`
+    raises KeyError on the missing key. `all_eligibility` has no per-program error handling, so
+    one unreadable program would empty the PE result for the whole screen.
 
-    Gated *inputs* need no equivalent: withholding one just leaves PolicyEngine to model
-    the value itself, which is the pre-contract behavior. Only outputs are load-bearing
-    this way, and the receipt-contract outputs (`*_if_takes_up`, floor 1.779.3) are the
-    first gated ones in the codebase.
+    Gated *inputs* need no equivalent — withholding one just leaves PolicyEngine to model the
+    value itself. Only outputs are load-bearing this way, and the receipt-contract outputs are
+    the first gated ones in the codebase.
 
-    This is reachable two ways: an exact `PolicyEngineConfig` pin below a floor, or PE's
-    /versions/us being unreachable while /calculate is healthy (they are separate
-    endpoints, and an unresolvable version withholds every gated field). `comparable_version`
-    is the request's single resolved version — None means unresolvable, which conservatively
-    drops every program carrying a gated output.
+    Reachable via an exact `PolicyEngineConfig` pin below a floor, or via /versions/us being
+    unreachable while /calculate is healthy. `comparable_version` is the request's single
+    resolved version; None conservatively drops every program carrying a gated output.
     """
     if not valid_programs:
         return valid_programs
@@ -185,9 +179,7 @@ def _drop_unreadable_programs(
         readable[name_abbr] = calculator
 
     if dropped:
-        # Silently serving a screen without these is the failure this guard exists to
-        # avoid compounding — make the reason visible rather than inferring it from a
-        # program's absence.
+        # Make the reason visible rather than leaving it inferred from a program's absence.
         capture_message(
             f"PolicyEngine: dropped {len(dropped)} program(s) whose output variable the resolved "
             f"model version does not define: {sorted(dropped)}",
@@ -218,10 +210,8 @@ def pe_input(
     Generate Policy Engine API request from the list of programs.
 
     `resolved_version` is the caller's already-resolved (version string, comparable version)
-    pair. `calc_pe_eligibility` passes it so the version that decides which programs are
-    readable is the same one that decides which fields are sent — resolving twice risks the
-    two disagreeing across a PolicyEngine release promotion or a cache expiry. Direct
-    callers may omit it and this resolves for itself.
+    pair, passed by `calc_pe_eligibility` so the version deciding which programs are readable
+    is the one deciding which fields are sent. Direct callers may omit it.
     """
     raw_input = {
         "household": {

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -33,6 +33,8 @@ def calc_pe_eligibility(
             continue
         valid_programs[name_abbr] = calculator
 
+    valid_programs = _drop_unreadable_programs(valid_programs, pe_version)
+
     empty_result: EligibilityPEResult = {
         "eligibility": {},
         "_pe_data": {"request": None, "response": None},
@@ -111,6 +113,78 @@ def all_eligibility(method: Sim, valid_programs: dict[str, PolicyEngineCalulator
     return all_eligibility
 
 
+def _resolve_comparable_version(programs: List[PolicyEngineCalulator], version: str) -> Optional[tuple]:
+    """Tuple form of `version`, for gating which inputs and outputs may be sent.
+
+    We send the "current" alias unpinned (its comparable form is None), but for gating we
+    still need to know what current concretely is — otherwise a min_pe_version floor can
+    never be met and gated fields are withheld forever. Resolve it from PE's published
+    /versions/us. If PE is unreachable this stays None, keeping the conservative
+    withhold-gated behavior. Only bother resolving when the request actually carries a
+    gated field — the vast majority don't, and resolving would be a needless (cached)
+    lookup."""
+    comparable_version = pe_versions.to_comparable_pe_version(version)
+    if comparable_version is None and _has_gated_input(programs):
+        comparable_version = pe_versions.resolve_unpinned_comparable_version()
+    return comparable_version
+
+
+def _drop_unreadable_programs(
+    valid_programs: dict[str, PolicyEngineCalulator],
+    pe_version: Optional[str],
+) -> dict[str, PolicyEngineCalulator]:
+    """Drop programs whose own output variable the resolved model doesn't define.
+
+    Version gating withholds such a field from the request, so PolicyEngine never returns
+    it and `Sim.value` raises KeyError on the missing key. `all_eligibility` doesn't
+    contain per-program failures, so a single unreadable program would empty the PE result
+    for the whole screen — every PolicyEngine program, not just that one.
+
+    Gated *inputs* need no equivalent: withholding one just leaves PolicyEngine to model
+    the value itself, which is the pre-contract behavior. Only outputs are load-bearing
+    this way, and the receipt-contract outputs (`*_if_takes_up`, floor 1.779.3) are the
+    first gated ones in the codebase.
+
+    This is reachable two ways: an exact `PolicyEngineConfig` pin below a floor, or PE's
+    /versions/us being unreachable while /calculate is healthy (they are separate
+    endpoints, and an unresolvable version withholds every gated field).
+    """
+    if not valid_programs:
+        return valid_programs
+
+    programs = list(valid_programs.values())
+    comparable_version = _resolve_comparable_version(programs, pe_versions.determine_pe_version(pe_version))
+
+    readable: dict[str, PolicyEngineCalulator] = {}
+    dropped: list[str] = []
+    for name_abbr, calculator in valid_programs.items():
+        unsupported = [
+            Data.field
+            for Data in calculator.pe_outputs
+            if not pe_versions.version_supports(
+                comparable_version,
+                getattr(Data, "min_pe_version", ()),
+                getattr(Data, "max_pe_version", ()),
+            )
+        ]
+        if unsupported:
+            dropped.append(f"{name_abbr} ({', '.join(unsupported)})")
+            continue
+        readable[name_abbr] = calculator
+
+    if dropped:
+        # Silently serving a screen without these is the failure this guard exists to
+        # avoid compounding — make the reason visible rather than inferring it from a
+        # program's absence.
+        capture_message(
+            f"PolicyEngine: dropped {len(dropped)} program(s) whose output variable the resolved "
+            f"model version does not define: {sorted(dropped)}",
+            level="warning",
+        )
+
+    return readable
+
+
 def _has_gated_input(programs: List[PolicyEngineCalulator]) -> bool:
     """True if any input/output in these programs is version-gated (has a
     min_pe_version or max_pe_version). Lets us skip resolving the PE version when
@@ -153,17 +227,7 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
     #                                   "current" alias (household.api resolves it server-side).
     #   comparable_version (tuple)  -> tuple representation to gate which inputs are sent
     version = pe_versions.determine_pe_version(pe_version)
-    comparable_version = pe_versions.to_comparable_pe_version(version)
-
-    # We send the "current" alias unpinned (comparable_version is None), but for input
-    # gating we still need to know what current concretely is — otherwise a min_pe_version
-    # floor can never be met and gated inputs (e.g. use_reported_ssi) are withheld forever.
-    # Resolve current from PE's published /versions/us. If PE is unreachable this stays
-    # None, keeping the conservative withhold-gated behavior (safe: PE just uses modeled
-    # values). Only bother resolving when this request actually carries a version-gated
-    # input — the vast majority don't, and resolving would be a needless (cached) lookup.
-    if comparable_version is None and _has_gated_input(programs):
-        comparable_version = pe_versions.resolve_unpinned_comparable_version()
+    comparable_version = _resolve_comparable_version(programs, version)
 
     members: list[HouseholdMember] = screen.household_members.all()
     relationship_map = screen.relationship_map()

--- a/programs/programs/policyengine/policy_engine.py
+++ b/programs/programs/policyengine/policy_engine.py
@@ -33,7 +33,15 @@ def calc_pe_eligibility(
             continue
         valid_programs[name_abbr] = calculator
 
-    valid_programs = _drop_unreadable_programs(valid_programs, pe_version)
+    # Resolve the model version ONCE and thread it through both consumers: independent
+    # resolutions can disagree (PolicyEngine promotes a new `current`, or our cached lookup
+    # expires or fails between calls), and a disagreement is exactly the failure
+    # _drop_unreadable_programs exists to prevent — a program kept because the first
+    # resolution supported its output, then its field withheld because the second didn't.
+    version = pe_versions.determine_pe_version(pe_version)
+    comparable_version = _resolve_comparable_version(list(valid_programs.values()), version)
+
+    valid_programs = _drop_unreadable_programs(valid_programs, comparable_version)
 
     empty_result: EligibilityPEResult = {
         "eligibility": {},
@@ -43,7 +51,12 @@ def calc_pe_eligibility(
     if not valid_programs or not screen.household_members.all():
         return empty_result
 
-    input_data = pe_input(screen, valid_programs.values(), pe_version=pe_version)
+    input_data = pe_input(
+        screen,
+        valid_programs.values(),
+        pe_version=pe_version,
+        resolved_version=(version, comparable_version),
+    )
 
     # A single engine: the authenticated private household.api. There is deliberately no
     # fallback to the public api.policyengine.org — it ignores the request `version` field
@@ -131,7 +144,7 @@ def _resolve_comparable_version(programs: List[PolicyEngineCalulator], version: 
 
 def _drop_unreadable_programs(
     valid_programs: dict[str, PolicyEngineCalulator],
-    pe_version: Optional[str],
+    comparable_version: Optional[tuple],
 ) -> dict[str, PolicyEngineCalulator]:
     """Drop programs whose own output variable the resolved model doesn't define.
 
@@ -147,13 +160,12 @@ def _drop_unreadable_programs(
 
     This is reachable two ways: an exact `PolicyEngineConfig` pin below a floor, or PE's
     /versions/us being unreachable while /calculate is healthy (they are separate
-    endpoints, and an unresolvable version withholds every gated field).
+    endpoints, and an unresolvable version withholds every gated field). `comparable_version`
+    is the request's single resolved version — None means unresolvable, which conservatively
+    drops every program carrying a gated output.
     """
     if not valid_programs:
         return valid_programs
-
-    programs = list(valid_programs.values())
-    comparable_version = _resolve_comparable_version(programs, pe_versions.determine_pe_version(pe_version))
 
     readable: dict[str, PolicyEngineCalulator] = {}
     dropped: list[str] = []
@@ -196,9 +208,20 @@ def _has_gated_input(programs: List[PolicyEngineCalulator]) -> bool:
     return False
 
 
-def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: Optional[str] = None):
+def pe_input(
+    screen: Screen,
+    programs: List[PolicyEngineCalulator],
+    pe_version: Optional[str] = None,
+    resolved_version: Optional[tuple[str, Optional[tuple]]] = None,
+):
     """
     Generate Policy Engine API request from the list of programs.
+
+    `resolved_version` is the caller's already-resolved (version string, comparable version)
+    pair. `calc_pe_eligibility` passes it so the version that decides which programs are
+    readable is the same one that decides which fields are sent — resolving twice risks the
+    two disagreeing across a PolicyEngine release promotion or a cache expiry. Direct
+    callers may omit it and this resolves for itself.
     """
     raw_input = {
         "household": {
@@ -226,8 +249,15 @@ def pe_input(screen: Screen, programs: List[PolicyEngineCalulator], pe_version: 
     #                                   set: the DB pin, the test override, or the literal
     #                                   "current" alias (household.api resolves it server-side).
     #   comparable_version (tuple)  -> tuple representation to gate which inputs are sent
-    version = pe_versions.determine_pe_version(pe_version)
-    comparable_version = _resolve_comparable_version(programs, version)
+    #
+    # Send the alias, never the concrete resolution: household.api serves only what its
+    # aliases currently point at and 422s any other exact version, so a resolved-then-stale
+    # string would hard-fail every request once PolicyEngine promotes a release.
+    if resolved_version is not None:
+        version, comparable_version = resolved_version
+    else:
+        version = pe_versions.determine_pe_version(pe_version)
+        comparable_version = _resolve_comparable_version(programs, version)
 
     members: list[HouseholdMember] = screen.household_members.all()
     relationship_map = screen.relationship_map()

--- a/programs/programs/policyengine/tests/cassettes/TestPeIntegrationHarness.test_replays_a_member_level_program_from_a_cassette.yaml
+++ b/programs/programs/policyengine/tests/cassettes/TestPeIntegrationHarness.test_replays_a_member_level_program_from_a_cassette.yaml
@@ -5,16 +5,20 @@ interactions:
       {"2025": 0}, "rental_income": {"2025": 0}, "taxable_pension_income": {"2025":
       0}, "social_security": {"2025": 0}, "unemployment_compensation": {"2025": 0},
       "long_term_capital_gains": {"2025": 0}, "taxable_ira_distributions": {"2025":
-      0}, "ssi": {"2025": null}, "head_start": {"2025": null}}, "2": {"age": {"2025":
-      3}, "was_in_foster_care": {"2025": null}, "employment_income": {"2025": 0},
-      "self_employment_income": {"2025": 0}, "rental_income": {"2025": 0}, "taxable_pension_income":
-      {"2025": 0}, "social_security": {"2025": 0}, "unemployment_compensation": {"2025":
-      0}, "long_term_capital_gains": {"2025": 0}, "taxable_ira_distributions": {"2025":
-      0}, "ssi": {"2025": null}, "head_start": {"2025": null}}}, "tax_units": {"main_tax_unit":
+      0}, "ssi": {"2025": null}, "receives_ssi": {"2025": false}, "takes_up_ssi_if_eligible":
+      {"2025": false}, "head_start": {"2025": null}}, "2": {"age": {"2025": 3}, "was_in_foster_care":
+      {"2025": null}, "employment_income": {"2025": 0}, "self_employment_income":
+      {"2025": 0}, "rental_income": {"2025": 0}, "taxable_pension_income": {"2025":
+      0}, "social_security": {"2025": 0}, "unemployment_compensation": {"2025": 0},
+      "long_term_capital_gains": {"2025": 0}, "taxable_ira_distributions": {"2025":
+      0}, "ssi": {"2025": null}, "receives_ssi": {"2025": false}, "takes_up_ssi_if_eligible":
+      {"2025": false}, "head_start": {"2025": null}}}, "tax_units": {"main_tax_unit":
       {"members": ["1", "2"]}}, "families": {"family": {"members": ["1", "2"]}}, "households":
       {"household": {"members": ["1", "2"], "state_code": {"2025": "TX"}}}, "spm_units":
-      {"spm_unit": {"members": ["1", "2"], "snap": {"2025": null}, "tanf": {"2025":
-      null}}}, "marital_units": {}}, "version": "1.784.3"}'
+      {"spm_unit": {"members": ["1", "2"], "tanf": {"2025": null}, "receives_tanf":
+      {"2025": false}, "takes_up_tanf_if_eligible": {"2025": false}, "receives_snap":
+      {"2025": false}, "takes_up_snap_if_eligible": {"2025": false}}}, "marital_units":
+      {}}, "version": "1.786.5"}'
     headers:
       Accept:
       - '*/*'
@@ -23,7 +27,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1197'
+      - '1489'
       Content-Type:
       - application/json
       User-Agent:
@@ -37,37 +41,40 @@ interactions:
         {"2025": 17952}, "self_employment_income": {"2025": 0}, "rental_income": {"2025":
         0}, "taxable_pension_income": {"2025": 0}, "social_security": {"2025": 0},
         "unemployment_compensation": {"2025": 0}, "long_term_capital_gains": {"2025":
-        0}, "taxable_ira_distributions": {"2025": 0}, "ssi": {"2025": 0.0}, "head_start":
+        0}, "taxable_ira_distributions": {"2025": 0}, "ssi": {"2025": 0.0}, "receives_ssi":
+        {"2025": false}, "takes_up_ssi_if_eligible": {"2025": false}, "head_start":
         {"2025": 0.0}}, "2": {"age": {"2025": 3}, "was_in_foster_care": {"2025": false},
         "employment_income": {"2025": 0}, "self_employment_income": {"2025": 0}, "rental_income":
         {"2025": 0}, "taxable_pension_income": {"2025": 0}, "social_security": {"2025":
         0}, "unemployment_compensation": {"2025": 0}, "long_term_capital_gains": {"2025":
-        0}, "taxable_ira_distributions": {"2025": 0}, "ssi": {"2025": 0.0}, "head_start":
+        0}, "taxable_ira_distributions": {"2025": 0}, "ssi": {"2025": 0.0}, "receives_ssi":
+        {"2025": false}, "takes_up_ssi_if_eligible": {"2025": false}, "head_start":
         {"2025": 12076.413}}}, "tax_units": {"main_tax_unit": {"members": ["1", "2"]}},
         "families": {"family": {"members": ["1", "2"]}}, "households": {"household":
         {"members": ["1", "2"], "state_code": {"2025": "TX"}}}, "spm_units": {"spm_unit":
-        {"members": ["1", "2"], "snap": {"2025": 2895.2998}, "tanf": {"2025": 0.0}}},
-        "marital_units": {}}, "policyengine_bundle": {"model_version": "1.784.3",
-        "data_version": null, "dataset": null}}'
+        {"members": ["1", "2"], "tanf": {"2025": 0.0}, "receives_tanf": {"2025": false},
+        "takes_up_tanf_if_eligible": {"2025": false}, "receives_snap": {"2025": false},
+        "takes_up_snap_if_eligible": {"2025": false}}}, "marital_units": {}}, "policyengine_bundle":
+        {"model_version": "1.786.5", "data_version": null, "dataset": null}}'
     headers:
       Alt-Svc:
-      - h3=":443"; ma=2592000
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Length:
-      - '1305'
+      - '1592'
       access-control-allow-origin:
       - '*'
       content-type:
       - application/json
       date:
-      - Thu, 06 Aug 2026 14:49:57 GMT
+      - Mon, 17 Aug 2026 22:44:39 GMT
       server:
       - Google Frontend
       traceparent:
-      - 00-f0fc5fd969910cf4a87bae015cc0fa63-3e35f9b43ec4737c-01
+      - 00-d1e999408e28594483be0e596440a669-2cb0a08213d8b32e-01
       via:
       - 1.1 google
       x-cloud-trace-context:
-      - f0fc5fd969910cf4a87bae015cc0fa63;o=1
+      - d1e999408e28594483be0e596440a669;o=1
       x-policyengine-backend:
       - modal
       x-policyengine-primary-backend:
@@ -75,7 +82,7 @@ interactions:
       x-policyengine-primary-state:
       - healthy
       x-policyengine-request-id:
-      - 3d80f994-ab7b-4c47-a74d-da6069207798
+      - 1b9d18ce-596d-4254-8d3b-1081cc39d91e
       x-policyengine-route-channel:
       - current
     status:

--- a/programs/programs/policyengine/tests/test_integration_helpers.py
+++ b/programs/programs/policyengine/tests/test_integration_helpers.py
@@ -29,9 +29,10 @@ from .integration_test_helpers import (
 
 @pytest.mark.integration
 class TestPeIntegrationHarness(PeIntegrationTestCase):
-    # A version PolicyEngine currently serves, so this cassette can actually be re-recorded.
-    # PE no longer serves 1.779.3; the value is unchanged at 1.784.3.
-    pe_version = "1.784.3"
+    # Must be a version PolicyEngine still serves, or re-recording 422s with
+    # `unsupported_version`. Retirement happens within days of a promotion, so expect to bump
+    # this; the asserted value has held across 1.779.3 → 1.784.3 → 1.786.5.
+    pe_version = "1.786.5"
 
     def test_replays_a_member_level_program_from_a_cassette(self):
         """One household, one POST, one cassette: a 3-year-old under the income limit.

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -291,8 +291,8 @@ class TestPeInputMultipleCalculators(PeInputTestBase):
         spm_unit = result["household"]["spm_units"]["spm_unit"]
         people = result["household"]["people"]
 
-        # SNAP adds snap output
-        self.assertIn("snap", spm_unit)
+        # SNAP adds its would-be-benefit output
+        self.assertIn("snap_if_takes_up", spm_unit)
 
         # WIC adds pregnancy/breastfeeding fields to people
         head_id = str(self.head.id)

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -316,10 +316,11 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
 
     def setUp(self):
         super().setUp()
-        from programs.programs.federal.pe.member import Ssi, Wic
+        from programs.programs.federal.pe.member import Ssi
         from programs.programs.federal.pe.spm import Snap, Tanf
 
-        self.gated_output_programs = {"snap": Snap, "ssi": Ssi, "tanf": Tanf, "wic": Wic}
+        # WIC is deliberately absent: it reads the ungated `wic`, so no floor applies to it.
+        self.gated_output_programs = {"snap": Snap, "ssi": Ssi, "tanf": Tanf}
 
     def _drop(self, programs, comparable_version):
         return _drop_unreadable_programs(programs, comparable_version)
@@ -330,7 +331,7 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
         self.assertEqual(set(kept), set(self.gated_output_programs))
 
     def test_dropped_when_the_model_predates_their_output(self):
-        """Below the floor these four are unreadable — but the request still goes out for
+        """Below the floor these three are unreadable — but the request still goes out for
         everything else, rather than one KeyError taking the whole screen down."""
         with patch("programs.programs.policyengine.policy_engine.capture_message"):
             kept = self._drop(dict(self.gated_output_programs), (1, 750, 0))
@@ -347,6 +348,16 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
 
         self.assertEqual(set(kept), {"acp", "nslp"})
 
+    def test_wic_survives_an_old_model(self):
+        """WIC reads the ungated `wic`, which every supported model defines, so it is not
+        exposed to the floor. Switching it to `wic_if_takes_up` would put it here for no
+        behavioral gain — the two are equal for every payload we send."""
+        from programs.programs.federal.pe.member import Wic
+
+        kept = self._drop({"wic": Wic}, (1, 750, 0))
+
+        self.assertEqual(set(kept), {"wic"})
+
     def test_reports_the_drop(self):
         """Serving a screen quietly missing SNAP is the failure this guard exists to avoid
         compounding, so the reason has to be visible."""
@@ -361,7 +372,7 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
     def test_unresolvable_version_drops_them_too(self):
         """PE's /versions/us is a different endpoint from /calculate: it can be down while
         calculation is healthy. An unresolvable version withholds every gated field, so the
-        four programs are unreadable and must drop rather than KeyError."""
+        three programs are unreadable and must drop rather than KeyError."""
         with patch("programs.programs.policyengine.policy_engine.capture_message"):
             kept = self._drop(dict(self.gated_output_programs), None)
 

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -8,7 +8,7 @@ independent of any specific calculator's dependencies.
 Calculator-specific dependency tests belong in the state's pe/tests/ directory.
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import TestCase, override_settings
 from benefits.tests.cache_override import LOCAL_CACHE
@@ -321,11 +321,11 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
 
         self.gated_output_programs = {"snap": Snap, "ssi": Ssi, "tanf": Tanf, "wic": Wic}
 
-    def _drop(self, programs, version):
-        return _drop_unreadable_programs(programs, version)
+    def _drop(self, programs, comparable_version):
+        return _drop_unreadable_programs(programs, comparable_version)
 
     def test_kept_when_the_model_defines_their_output(self):
-        kept = self._drop(dict(self.gated_output_programs), "1.784.3")
+        kept = self._drop(dict(self.gated_output_programs), (1, 784, 3))
 
         self.assertEqual(set(kept), set(self.gated_output_programs))
 
@@ -333,7 +333,7 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
         """Below the floor these four are unreadable — but the request still goes out for
         everything else, rather than one KeyError taking the whole screen down."""
         with patch("programs.programs.policyengine.policy_engine.capture_message"):
-            kept = self._drop(dict(self.gated_output_programs), "1.750.0")
+            kept = self._drop(dict(self.gated_output_programs), (1, 750, 0))
 
         self.assertEqual(kept, {})
 
@@ -343,7 +343,7 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
         the value itself."""
         from programs.programs.federal.pe.spm import Acp, SchoolLunch
 
-        kept = self._drop({"acp": Acp, "nslp": SchoolLunch}, "1.750.0")
+        kept = self._drop({"acp": Acp, "nslp": SchoolLunch}, (1, 750, 0))
 
         self.assertEqual(set(kept), {"acp", "nslp"})
 
@@ -351,7 +351,7 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
         """Serving a screen quietly missing SNAP is the failure this guard exists to avoid
         compounding, so the reason has to be visible."""
         with patch("programs.programs.policyengine.policy_engine.capture_message") as capture:
-            self._drop(dict(self.gated_output_programs), "1.750.0")
+            self._drop(dict(self.gated_output_programs), (1, 750, 0))
 
         capture.assert_called_once()
         message = capture.call_args[0][0]
@@ -362,13 +362,50 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
         """PE's /versions/us is a different endpoint from /calculate: it can be down while
         calculation is healthy. An unresolvable version withholds every gated field, so the
         four programs are unreadable and must drop rather than KeyError."""
-        with patch(
-            "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version",
-            return_value=None,
-        ), patch("programs.programs.policyengine.policy_engine.capture_message"):
+        with patch("programs.programs.policyengine.policy_engine.capture_message"):
             kept = self._drop(dict(self.gated_output_programs), None)
 
         self.assertEqual(kept, {})
+
+    def test_pe_input_trusts_a_caller_resolved_version(self):
+        """When the caller has already resolved, pe_input must not resolve again — that second
+        lookup is where the two can disagree."""
+        with patch(
+            "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version"
+        ) as resolve:
+            result = pe_input(
+                self.screen,
+                [self.gated_output_programs["snap"]],
+                resolved_version=("current", (1, 779, 3)),
+            )
+
+        resolve.assert_not_called()
+        # The floor is satisfied, so the gated fields ride along.
+        self.assertIn("receives_snap", result["household"]["spm_units"]["spm_unit"])
+        self.assertEqual(result["version"], "current")
+
+    def test_calc_pe_eligibility_resolves_once_and_threads_it(self):
+        """One resolution per request, handed to both the drop pass and the payload build."""
+        from programs.programs.policyengine.calculators.dependencies import member as member_deps
+        from programs.programs.policyengine.policy_engine import calc_pe_eligibility
+
+        calculator = Mock()
+        calculator.can_calc.return_value = True
+        calculator.pe_inputs = [member_deps.ReceivesSsiDependency]  # gated, so resolution is needed
+        calculator.pe_outputs = []  # ungated, so the drop pass keeps it
+
+        with patch(
+            "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version",
+            return_value=(1, 779, 3),
+        ) as resolve, patch(
+            "programs.programs.policyengine.policy_engine.pe_input", return_value={}
+        ) as build_payload, patch(
+            "programs.programs.policyengine.policy_engine.pe_engines", []
+        ):
+            calc_pe_eligibility(self.screen, {"fake_program": calculator})
+
+        self.assertEqual(resolve.call_count, 1)
+        self.assertEqual(build_payload.call_args.kwargs["resolved_version"], ("current", (1, 779, 3)))
 
 
 class TestPeInputVersionGating(PeInputTestBase):

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 from benefits.tests.cache_override import LOCAL_CACHE
 from screener.models import Screen, HouseholdMember, WhiteLabel, Expense, IncomeStream
-from programs.programs.policyengine.policy_engine import pe_input
+from programs.programs.policyengine.policy_engine import _drop_unreadable_programs, pe_input
 from programs.programs.policyengine.calculators.constants import (
     MAIN_TAX_UNIT,
     SECONDARY_TAX_UNIT,
@@ -297,6 +297,78 @@ class TestPeInputMultipleCalculators(PeInputTestBase):
         # WIC adds pregnancy/breastfeeding fields to people
         head_id = str(self.head.id)
         self.assertIn("age", people[head_id])
+
+
+class TestUnreadableProgramsAreDropped(PeInputTestBase):
+    """
+    A program whose own output variable the resolved model doesn't define must drop out of
+    the request cleanly.
+
+    Version gating withholds such a field, so PolicyEngine never returns it and
+    `Sim.value` raises KeyError on the missing key. `all_eligibility` has no per-program
+    error handling, so that KeyError propagates to `calc_pe_eligibility`'s catch-all and
+    empties the PE result for the *entire* screen — every PolicyEngine program, not just
+    the unreadable one.
+
+    The receipt-contract outputs (`*_if_takes_up`, floor 1.779.3) are the first gated
+    outputs in the codebase, so this path had no coverage before.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from programs.programs.federal.pe.member import Ssi, Wic
+        from programs.programs.federal.pe.spm import Snap, Tanf
+
+        self.gated_output_programs = {"snap": Snap, "ssi": Ssi, "tanf": Tanf, "wic": Wic}
+
+    def _drop(self, programs, version):
+        return _drop_unreadable_programs(programs, version)
+
+    def test_kept_when_the_model_defines_their_output(self):
+        kept = self._drop(dict(self.gated_output_programs), "1.784.3")
+
+        self.assertEqual(set(kept), set(self.gated_output_programs))
+
+    def test_dropped_when_the_model_predates_their_output(self):
+        """Below the floor these four are unreadable — but the request still goes out for
+        everything else, rather than one KeyError taking the whole screen down."""
+        with patch("programs.programs.policyengine.policy_engine.capture_message"):
+            kept = self._drop(dict(self.gated_output_programs), "1.750.0")
+
+        self.assertEqual(kept, {})
+
+    def test_programs_with_ungated_outputs_survive_an_old_model(self):
+        """The guard is scoped to unreadable outputs — it must not thin out the rest of
+        the request, whose gated *inputs* degrade harmlessly to PolicyEngine modelling
+        the value itself."""
+        from programs.programs.federal.pe.spm import Acp, SchoolLunch
+
+        kept = self._drop({"acp": Acp, "nslp": SchoolLunch}, "1.750.0")
+
+        self.assertEqual(set(kept), {"acp", "nslp"})
+
+    def test_reports_the_drop(self):
+        """Serving a screen quietly missing SNAP is the failure this guard exists to avoid
+        compounding, so the reason has to be visible."""
+        with patch("programs.programs.policyengine.policy_engine.capture_message") as capture:
+            self._drop(dict(self.gated_output_programs), "1.750.0")
+
+        capture.assert_called_once()
+        message = capture.call_args[0][0]
+        self.assertIn("snap_if_takes_up", message)
+        self.assertEqual(capture.call_args[1]["level"], "warning")
+
+    def test_unresolvable_version_drops_them_too(self):
+        """PE's /versions/us is a different endpoint from /calculate: it can be down while
+        calculation is healthy. An unresolvable version withholds every gated field, so the
+        four programs are unreadable and must drop rather than KeyError."""
+        with patch(
+            "programs.programs.policyengine.policy_engine.pe_versions.resolve_unpinned_comparable_version",
+            return_value=None,
+        ), patch("programs.programs.policyengine.policy_engine.capture_message"):
+            kept = self._drop(dict(self.gated_output_programs), None)
+
+        self.assertEqual(kept, {})
 
 
 class TestPeInputVersionGating(PeInputTestBase):

--- a/programs/programs/policyengine/tests/test_pe_input.py
+++ b/programs/programs/policyengine/tests/test_pe_input.py
@@ -310,8 +310,8 @@ class TestUnreadableProgramsAreDropped(PeInputTestBase):
     empties the PE result for the *entire* screen — every PolicyEngine program, not just
     the unreadable one.
 
-    The receipt-contract outputs (`*_if_takes_up`, floor 1.779.3) are the first gated
-    outputs in the codebase, so this path had no coverage before.
+    The receipt-contract outputs are the first gated outputs in the codebase, so this path
+    had no coverage before.
     """
 
     def setUp(self):

--- a/programs/programs/policyengine/tests/test_receipt_contract.py
+++ b/programs/programs/policyengine/tests/test_receipt_contract.py
@@ -59,6 +59,26 @@ class TestReceiptContractBundle(TestCase):
             expected = () if dep.field in UNGATED_FIELDS else (1, 779, 3)
             self.assertEqual(dep.min_pe_version, expected, f"{dep.field} carries the wrong version gate")
 
+    def test_the_suppressing_half_is_the_gated_half(self):
+        """
+        The bundle's gating is deliberately mixed, and this is what makes that safe.
+
+        Only `ssi` and `tanf` are ungated, and both are *amount* inputs that predate the
+        contract. Every field that can suppress a benefit or assert receipt is floored at
+        1.779.3. So below the floor we send amounts with no take-up flags — the
+        pre-contract behavior — and there is no resolvable version at which we tell
+        PolicyEngine to zero a benefit without also sending the evidence for it.
+
+        Flooring the amounts too (the symmetric-looking fix) would stop sending reported
+        SSI/TANF to older models, which is a regression, not a tightening.
+        """
+        for dep in receipt_contract:
+            suppresses_or_asserts_receipt = dep.field.startswith(("takes_up_", "receives_"))
+            if suppresses_or_asserts_receipt:
+                self.assertEqual(dep.min_pe_version, (1, 779, 3), f"{dep.field} must never outrun its floor")
+            else:
+                self.assertEqual(dep.field in UNGATED_FIELDS, True, f"{dep.field} is an unexpected ungated field")
+
     def test_would_be_outputs_are_version_gated(self):
         for dep in (member.SsiIfTakesUp, member.WicIfTakesUp, spm.SnapIfTakesUp, spm.TanfIfTakesUp):
             self.assertEqual(dep.min_pe_version, (1, 779, 3), dep.field)

--- a/programs/programs/policyengine/tests/test_receipt_contract.py
+++ b/programs/programs/policyengine/tests/test_receipt_contract.py
@@ -10,9 +10,8 @@ Three things can silently break it:
 * One of the four programs left reading its receipt-gated field. Those read 0 for every
   non-recipient once the take-up flags go out, and the frontend drops programs valued at
   $0 — so the program would vanish from results for everyone not already on it.
-* A contract input losing its min_pe_version. Every field here landed in policyengine-us
-  1.779.3, and an unknown variable 400s the whole request, taking down every PolicyEngine
-  program in it, not just the one that sent it.
+* A contract input losing its min_pe_version. An unknown variable 400s the whole request,
+  taking down every PolicyEngine program in it, not just the one that sent it.
 """
 
 from django.test import TestCase
@@ -25,7 +24,7 @@ from programs.programs.ks.pe.spm import KsTanf
 from programs.programs.policyengine.calculators.dependencies import member, receipt_contract, spm
 from programs.programs.tx.pe.spm import TxCeap
 
-# The amount inputs predate the contract by years; everything else is a 1.779.3 field.
+# The amount inputs predate the contract; everything else arrived with it.
 UNGATED_FIELDS = {"ssi", "tanf"}
 
 
@@ -64,10 +63,10 @@ class TestReceiptContractBundle(TestCase):
         The bundle's gating is deliberately mixed, and this is what makes that safe.
 
         Only `ssi` and `tanf` are ungated, and both are *amount* inputs that predate the
-        contract. Every field that can suppress a benefit or assert receipt is floored at
-        1.779.3. So below the floor we send amounts with no take-up flags — the
-        pre-contract behavior — and there is no resolvable version at which we tell
-        PolicyEngine to zero a benefit without also sending the evidence for it.
+        contract. Every field that can suppress a benefit or assert receipt carries the floor.
+        So below it we send amounts with no take-up flags — the pre-contract behavior — and
+        there is no resolvable version at which we tell PolicyEngine to zero a benefit without
+        also sending the evidence for it.
 
         Flooring the amounts too (the symmetric-looking fix) would stop sending reported
         SSI/TANF to older models, which is a regression, not a tightening.

--- a/programs/programs/policyengine/tests/test_receipt_contract.py
+++ b/programs/programs/policyengine/tests/test_receipt_contract.py
@@ -1,0 +1,151 @@
+"""
+Tests for PolicyEngine's actual-receipt contract as a whole — the wiring that has to hold
+across calculators rather than inside any one of them.
+
+Three things can silently break it:
+
+* A calculator that reads simulated SSI/TANF/SNAP without adopting the contract. It would
+  keep conferring categorical eligibility, or counting income, off a benefit the household
+  doesn't receive.
+* One of the four programs left reading its receipt-gated field. Those read 0 for every
+  non-recipient once the take-up flags go out, and the frontend drops programs valued at
+  $0 — so the program would vanish from results for everyone not already on it.
+* A contract input losing its min_pe_version. Every field here landed in policyengine-us
+  1.779.3, and an unknown variable 400s the whole request, taking down every PolicyEngine
+  program in it, not just the one that sent it.
+"""
+
+from django.test import TestCase
+
+from programs.programs.co.pe.member import AidToTheNeedyAndDisabled
+from programs.programs.federal.pe.member import EarlyHeadStart, HeadStart, Medicaid, Msp, Ssi, Wic
+from programs.programs.federal.pe.spm import SNAP_BASE_INPUTS, Lifeline, Snap, Tanf
+from programs.programs.il.pe.member import IlAabd
+from programs.programs.ks.pe.spm import KsTanf
+from programs.programs.policyengine.calculators.dependencies import member, receipt_contract, spm
+from programs.programs.tx.pe.spm import TxCeap
+
+# The amount inputs predate the contract by years; everything else is a 1.779.3 field.
+UNGATED_FIELDS = {"ssi", "tanf"}
+
+
+class TestReceiptContractBundle(TestCase):
+    def test_carries_receipt_and_take_up_for_all_three_benefits(self):
+        self.assertEqual(
+            {dep.field for dep in receipt_contract},
+            {
+                "ssi",
+                "receives_ssi",
+                "takes_up_ssi_if_eligible",
+                "tanf",
+                "receives_tanf",
+                "takes_up_tanf_if_eligible",
+                "receives_snap",
+                "takes_up_snap_if_eligible",
+            },
+        )
+
+    def test_snap_has_no_amount_input(self):
+        """
+        SNAP is receipt-only: the screener captures no SNAP dollar amount, so there is no
+        `snap` input to send. PolicyEngine computes the amount and `receives_snap` carries
+        the categorical signal. Should SNAP amount capture ever land, the amount input
+        belongs in this bundle alongside ssi and tanf.
+        """
+        self.assertNotIn("snap", {dep.field for dep in receipt_contract})
+
+    def test_every_new_field_is_version_gated(self):
+        for dep in receipt_contract:
+            expected = () if dep.field in UNGATED_FIELDS else (1, 779, 3)
+            self.assertEqual(dep.min_pe_version, expected, f"{dep.field} carries the wrong version gate")
+
+    def test_would_be_outputs_are_version_gated(self):
+        for dep in (member.SsiIfTakesUp, member.WicIfTakesUp, spm.SnapIfTakesUp, spm.TanfIfTakesUp):
+            self.assertEqual(dep.min_pe_version, (1, 779, 3), dep.field)
+
+
+class TestProgramsReadWouldBeOutputs(TestCase):
+    """
+    The four programs the contract gates must report what the household *would* get, not
+    the receipt-gated field the take-up flags zero out.
+    """
+
+    def test_snap(self):
+        self.assertEqual(Snap.pe_name, "snap_if_takes_up")
+        self.assertEqual(Snap.pe_outputs, [spm.SnapIfTakesUp])
+
+    def test_tanf(self):
+        self.assertEqual(Tanf.pe_name, "tanf_if_takes_up")
+        self.assertEqual(Tanf.pe_outputs, [spm.TanfIfTakesUp])
+
+    def test_ssi(self):
+        self.assertEqual(Ssi.pe_name, "ssi_if_takes_up")
+        self.assertEqual(Ssi.pe_outputs, [member.SsiIfTakesUp])
+
+    def test_wic(self):
+        self.assertEqual(Wic.pe_name, "wic_if_takes_up")
+        self.assertIn(member.WicIfTakesUp, Wic.pe_outputs)
+
+
+class TestAdoptingCalculators(TestCase):
+    """
+    Every calculator whose eligibility or income reads SSI, TANF or SNAP sends the contract.
+
+    PE requests are a single shared payload, so in practice these inputs reach every program
+    in a request regardless of which one declared them. Declaring them on each consumer is
+    what keeps that from depending on which programs a white label happens to enable.
+    """
+
+    def _assert_adopts(self, calculator, inputs=None):
+        pe_inputs = inputs if inputs is not None else calculator.pe_inputs
+        for dep in receipt_contract:
+            self.assertIn(dep, pe_inputs, f"{getattr(calculator, '__name__', calculator)} is missing {dep.field}")
+
+    def test_snap_all_states(self):
+        """All 8 SNAP variants are XxSnap(Snap) sharing SNAP_BASE_INPUTS, so this covers
+        CO / IL / KS / MA / NC / TX / WA and the federal calculator at once."""
+        self._assert_adopts(Snap, SNAP_BASE_INPUTS)
+        self._assert_adopts(Snap)
+
+    def test_head_start_and_early_head_start(self):
+        self._assert_adopts(HeadStart)
+        self._assert_adopts(EarlyHeadStart)
+
+    def test_wic(self):
+        """WIC's adjunct test reads SNAP/TANF receipt."""
+        self._assert_adopts(Wic)
+
+    def test_medicaid_and_msp(self):
+        """medicaid_category and msp_category both have SSI-recipient pathways."""
+        self._assert_adopts(Medicaid)
+        self._assert_adopts(Msp)
+
+    def test_lifeline(self):
+        self._assert_adopts(Lifeline)
+
+    def test_ssi_and_tanf_themselves(self):
+        self._assert_adopts(Ssi)
+        self._assert_adopts(Tanf)
+
+    def test_state_programs_that_read_ssi_or_tanf(self):
+        self._assert_adopts(IlAabd)  # counts SSI as unearned income
+        self._assert_adopts(TxCeap)  # counts SSI via applicable_ssi
+        self._assert_adopts(AidToTheNeedyAndDisabled)  # tops up SSI
+        self._assert_adopts(KsTanf)  # excludes SSI recipients from the assistance unit
+
+
+class TestRetiredSsiBridge(TestCase):
+    """
+    The reported-SSI bridge is gone: reported SSI is the `ssi` input, and suppression is the
+    take-up flag. Verified against the live API that ssi_reported without use_reported_ssi
+    moves nothing — not ssi, applicable_ssi, co_state_supplement, il_aabd_person or tx_ceap.
+    """
+
+    def test_dependencies_are_removed(self):
+        for name in ("SsiReportedDependency", "UseReportedSsiDependency", "SsiAmountIfEligible"):
+            self.assertFalse(hasattr(member, name), f"{name} should have been removed with the reported-SSI bridge")
+
+    def test_snap_receipt_sentinel_is_removed(self):
+        """The `snap: 1` sentinel pinned PolicyEngine's computed SNAP to $1/mo for anyone
+        reporting receipt, polluting the income every other program in the request read."""
+        self.assertFalse(hasattr(spm, "Snap"))

--- a/programs/programs/policyengine/tests/test_receipt_contract.py
+++ b/programs/programs/policyengine/tests/test_receipt_contract.py
@@ -62,14 +62,13 @@ class TestReceiptContractBundle(TestCase):
         """
         The bundle's gating is deliberately mixed, and this is what makes that safe.
 
-        Only `ssi` and `tanf` are ungated, and both are *amount* inputs that predate the
-        contract. Every field that can suppress a benefit or assert receipt carries the floor.
-        So below it we send amounts with no take-up flags — the pre-contract behavior — and
-        there is no resolvable version at which we tell PolicyEngine to zero a benefit without
-        also sending the evidence for it.
+        Only the `ssi` and `tanf` *amount* inputs are ungated; every field that can suppress a
+        benefit or assert receipt carries the floor. So below the floor we send amounts with no
+        take-up flags, and there is no resolvable version at which we tell PolicyEngine to zero
+        a benefit without also sending the evidence for it.
 
-        Flooring the amounts too (the symmetric-looking fix) would stop sending reported
-        SSI/TANF to older models, which is a regression, not a tightening.
+        Flooring the amounts too — the symmetric-looking alternative — would withhold reported
+        SSI/TANF from older models, which loses information rather than tightening anything.
         """
         for dep in receipt_contract:
             suppresses_or_asserts_receipt = dep.field.startswith(("takes_up_", "receives_"))
@@ -79,14 +78,31 @@ class TestReceiptContractBundle(TestCase):
                 self.assertEqual(dep.field in UNGATED_FIELDS, True, f"{dep.field} is an unexpected ungated field")
 
     def test_would_be_outputs_are_version_gated(self):
-        for dep in (member.SsiIfTakesUp, member.WicIfTakesUp, spm.SnapIfTakesUp, spm.TanfIfTakesUp):
+        for dep in (member.SsiIfTakesUp, spm.SnapIfTakesUp, spm.TanfIfTakesUp):
             self.assertEqual(dep.min_pe_version, (1, 779, 3), dep.field)
+
+    def test_wic_stays_on_the_ungated_output(self):
+        """
+        WIC is not switched to `wic_if_takes_up`, because for our payloads the two are the same
+        number: `wic` is `wic_if_takes_up` gated on `takes_up_wic_if_eligible`, which defaults
+        True and which we never send. `receives_wic` is measurably inert, so it is not wired
+        either — there is no WIC suppression for a would-be output to route around.
+
+        Staying ungated keeps WIC out of `_drop_unreadable_programs` below the version floor.
+        """
+        self.assertEqual(member.Wic.min_pe_version, ())
+        sent_fields = {dep.field for dep in receipt_contract}
+        self.assertNotIn("takes_up_wic_if_eligible", sent_fields)
+        self.assertNotIn("receives_wic", sent_fields)
 
 
 class TestProgramsReadWouldBeOutputs(TestCase):
     """
-    The four programs the contract gates must report what the household *would* get, not
-    the receipt-gated field the take-up flags zero out.
+    A program the contract gates must report what the household *would* get, not the
+    receipt-gated field its take-up flag zeroes out.
+
+    That means `*_if_takes_up` for SNAP, TANF and SSI. WIC is the exception: we send no WIC
+    take-up flag, so its plain output is already the would-be value.
     """
 
     def test_snap(self):
@@ -101,9 +117,12 @@ class TestProgramsReadWouldBeOutputs(TestCase):
         self.assertEqual(Ssi.pe_name, "ssi_if_takes_up")
         self.assertEqual(Ssi.pe_outputs, [member.SsiIfTakesUp])
 
-    def test_wic(self):
-        self.assertEqual(Wic.pe_name, "wic_if_takes_up")
-        self.assertIn(member.WicIfTakesUp, Wic.pe_outputs)
+    def test_wic_reads_the_ungated_output(self):
+        """The exception: `wic` is already the would-be value, since `takes_up_wic_if_eligible`
+        is never sent and holds at its True default. See
+        `test_wic_stays_on_the_ungated_output`."""
+        self.assertEqual(Wic.pe_name, "wic")
+        self.assertIn(member.Wic, Wic.pe_outputs)
 
 
 class TestAdoptingCalculators(TestCase):
@@ -153,18 +172,21 @@ class TestAdoptingCalculators(TestCase):
         self._assert_adopts(KsTanf)  # excludes SSI recipients from the assistance unit
 
 
-class TestRetiredSsiBridge(TestCase):
+class TestSupersededSsiInputsStayAbsent(TestCase):
     """
-    The reported-SSI bridge is gone: reported SSI is the `ssi` input, and suppression is the
-    take-up flag. Verified against the live API that ssi_reported without use_reported_ssi
-    moves nothing — not ssi, applicable_ssi, co_state_supplement, il_aabd_person or tx_ceap.
+    Reported SSI travels as the `ssi` amount and suppression as the take-up flag, so the
+    separate `ssi_reported` / `use_reported_ssi` channel must not come back. Measured against
+    the live API, `ssi_reported` without `use_reported_ssi` moves nothing — not `ssi`,
+    `applicable_ssi`, `co_state_supplement`, `il_aabd_person` or `tx_ceap` — so re-adding it
+    would read as a working input while doing nothing.
     """
 
-    def test_dependencies_are_removed(self):
+    def test_reported_ssi_dependencies_are_absent(self):
         for name in ("SsiReportedDependency", "UseReportedSsiDependency", "SsiAmountIfEligible"):
-            self.assertFalse(hasattr(member, name), f"{name} should have been removed with the reported-SSI bridge")
+            self.assertFalse(hasattr(member, name), f"{name} duplicates the `ssi` input and must stay absent")
 
-    def test_snap_receipt_sentinel_is_removed(self):
-        """The `snap: 1` sentinel pinned PolicyEngine's computed SNAP to $1/mo for anyone
-        reporting receipt, polluting the income every other program in the request read."""
+    def test_snap_receipt_sentinel_is_absent(self):
+        """A `snap: 1` input pins PolicyEngine's computed SNAP to $1/mo for anyone reporting
+        receipt, polluting the income every other program in the request reads. `receives_snap`
+        carries that signal without a dollar value."""
         self.assertFalse(hasattr(spm, "Snap"))

--- a/programs/programs/tx/pe/spm.py
+++ b/programs/programs/tx/pe/spm.py
@@ -103,12 +103,13 @@ class TxCeap(PolicyEngineSpmCalulator):
     pe_inputs = [
         dependency.household.TxStateCodeDependency,
         *dependency.irs_gross_income,
-        # tx_ceap counts SSI via applicable_ssi, which uses the household's reported
-        # SSI only when use_reported_ssi is True; otherwise PE substitutes its own
-        # modeled SSI (~0 for screener inputs), undercounting income. Send both the
-        # reported amount and the toggle so the household's actual SSI drives the tier.
-        dependency.member.SsiReportedDependency,
-        dependency.member.UseReportedSsiDependency,
+        # tx_ceap counts SSI via applicable_ssi, which follows the `ssi` input: the
+        # household's reported amount where they report one, and PolicyEngine's own
+        # simulated SSI otherwise — suppressed by the take-up flag for anyone who reports
+        # no SSI, so a modelled benefit they don't receive no longer sets their FPG tier.
+        # This replaced the ssi_reported / use_reported_ssi bridge, which addressed the
+        # same problem through a separate reported-SSI channel.
+        *dependency.receipt_contract,
         # tx_ceap caps the payment at electricity_expense + gas_expense; route the
         # screener's energy expenses into electricity_expense so the cap is non-zero.
         dependency.spm.TxCeapEnergyExpenseDependency,

--- a/programs/programs/tx/pe/spm.py
+++ b/programs/programs/tx/pe/spm.py
@@ -105,10 +105,8 @@ class TxCeap(PolicyEngineSpmCalulator):
         *dependency.irs_gross_income,
         # tx_ceap counts SSI via applicable_ssi, which follows the `ssi` input: the
         # household's reported amount where they report one, and PolicyEngine's own
-        # simulated SSI otherwise — suppressed by the take-up flag for anyone who reports
-        # no SSI, so a modelled benefit they don't receive no longer sets their FPG tier.
-        # This replaced the ssi_reported / use_reported_ssi bridge, which addressed the
-        # same problem through a separate reported-SSI channel.
+        # simulated SSI otherwise. The take-up flag suppresses that simulated value for
+        # anyone reporting no SSI, keeping a modelled benefit out of their FPG tier.
         *dependency.receipt_contract,
         # tx_ceap caps the payment at electricity_expense + gas_expense; route the
         # screener's energy expenses into electricity_expense so the cap is non-zero.

--- a/programs/programs/tx/pe/tests/test_integration.py
+++ b/programs/programs/tx/pe/tests/test_integration.py
@@ -151,8 +151,8 @@ class TestTxSnapPeInput(TxPeInputTestBase):
         """Test that pe_input includes TxSnap pe_outputs."""
         result = pe_input(self.screen, [TxSnap])
         spm_unit = result["household"]["spm_units"]["spm_unit"]
-        self.assertIn("snap", spm_unit)
-        self.assertIsInstance(spm_unit["snap"], dict)
+        self.assertIn("snap_if_takes_up", spm_unit)
+        self.assertIsInstance(spm_unit["snap_if_takes_up"], dict)
 
     def test_state_code_is_tx(self):
         """Test that TxStateCodeDependency sets state_code to TX."""
@@ -299,7 +299,7 @@ class TestTxWicPeInput(TxPeInputTestBase):
         people = result["household"]["people"]
 
         for member_id in [str(self.head.id), str(self.spouse.id), str(self.child.id)]:
-            self.assertIn("wic", people[member_id])
+            self.assertIn("wic_if_takes_up", people[member_id])
             self.assertIn("wic_category", people[member_id])
 
     def test_pregnancy_fields_for_pregnant_member(self):
@@ -333,7 +333,7 @@ class TestTxWicPeInput(TxPeInputTestBase):
         infant_id = str(infant.id)
 
         self.assertIn("age", people[infant_id])
-        self.assertIn("wic", people[infant_id])
+        self.assertIn("wic_if_takes_up", people[infant_id])
 
 
 class TestTxSsiPeInput(TxPeInputTestBase):
@@ -348,7 +348,9 @@ class TestTxSsiPeInput(TxPeInputTestBase):
         # SSI-specific member dependencies
         ssi_fields = [
             "ssi_countable_resources",
-            "ssi_reported",
+            "ssi",
+            "receives_ssi",
+            "takes_up_ssi_if_eligible",
             "is_blind",
             "is_disabled",
             "ssi_earned_income",
@@ -364,8 +366,8 @@ class TestTxSsiPeInput(TxPeInputTestBase):
         people = result["household"]["people"]
         head_id = str(self.head.id)
 
-        self.assertIn("ssi", people[head_id])
-        self.assertIsInstance(people[head_id]["ssi"], dict)
+        self.assertIn("ssi_if_takes_up", people[head_id])
+        self.assertIsInstance(people[head_id]["ssi_if_takes_up"], dict)
 
     def test_disability_fields_populated(self):
         """Test that disability fields are populated correctly."""
@@ -652,7 +654,7 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
 
         # TxSnap fields
         self.assertIn("snap_assets", spm_unit)
-        self.assertIn("snap", spm_unit)
+        self.assertIn("snap_if_takes_up", spm_unit)
 
     def test_eitc_and_snap_combined(self):
         """Test that pe_input handles both Eitc and TxSnap together."""
@@ -666,7 +668,7 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
         self.assertIn("eitc", tax_units[MAIN_TAX_UNIT])
 
         # TxSnap fields
-        self.assertIn("snap", spm_unit)
+        self.assertIn("snap_if_takes_up", spm_unit)
 
     def test_ssi_and_snap_combined(self):
         """Test that pe_input handles both TxSsi and TxSnap together."""
@@ -681,7 +683,7 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
         self.assertIn("ssi_countable_resources", people[head_id])
 
         # TxSnap fields
-        self.assertIn("snap", spm_unit)
+        self.assertIn("snap_if_takes_up", spm_unit)
 
     def test_chip_and_snap_combined(self):
         """Test that pe_input handles both TxChip and TxSnap together."""
@@ -695,7 +697,7 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
         self.assertIn("chip", people[head_id])
 
         # TxSnap fields
-        self.assertIn("snap", spm_unit)
+        self.assertIn("snap_if_takes_up", spm_unit)
 
     def test_aca_and_snap_combined(self):
         """Test that pe_input handles both TxAca and TxSnap together."""
@@ -708,7 +710,7 @@ class TestTxCombinedCalculatorsPeInput(TxPeInputTestBase):
         self.assertIn("aca_ptc", tax_units[MAIN_TAX_UNIT])
 
         # TxSnap fields
-        self.assertIn("snap", spm_unit)
+        self.assertIn("snap_if_takes_up", spm_unit)
 
     def test_all_state_codes_match(self):
         """Test that state_code is TX regardless of which calculator is used."""

--- a/programs/programs/tx/pe/tests/test_integration.py
+++ b/programs/programs/tx/pe/tests/test_integration.py
@@ -299,7 +299,7 @@ class TestTxWicPeInput(TxPeInputTestBase):
         people = result["household"]["people"]
 
         for member_id in [str(self.head.id), str(self.spouse.id), str(self.child.id)]:
-            self.assertIn("wic_if_takes_up", people[member_id])
+            self.assertIn("wic", people[member_id])
             self.assertIn("wic_category", people[member_id])
 
     def test_pregnancy_fields_for_pregnant_member(self):
@@ -333,7 +333,7 @@ class TestTxWicPeInput(TxPeInputTestBase):
         infant_id = str(infant.id)
 
         self.assertIn("age", people[infant_id])
-        self.assertIn("wic_if_takes_up", people[infant_id])
+        self.assertIn("wic", people[infant_id])
 
 
 class TestTxSsiPeInput(TxPeInputTestBase):

--- a/programs/programs/tx/pe/tests/test_member.py
+++ b/programs/programs/tx/pe/tests/test_member.py
@@ -52,7 +52,7 @@ class TestTxWic(TestCase):
         self.assertTrue(issubclass(TxWic, Wic))
 
         # Verify it has the expected properties
-        self.assertEqual(TxWic.pe_name, "wic")
+        self.assertEqual(TxWic.pe_name, "wic_if_takes_up")
         self.assertIsNotNone(TxWic.pe_inputs)
         self.assertGreater(len(TxWic.pe_inputs), 0)
 
@@ -151,7 +151,7 @@ class TestTxSsi(TestCase):
         self.assertTrue(issubclass(TxSsi, Ssi))
 
         # Verify it has the expected properties
-        self.assertEqual(TxSsi.pe_name, "ssi")
+        self.assertEqual(TxSsi.pe_name, "ssi_if_takes_up")
         self.assertIsNotNone(TxSsi.pe_inputs)
         self.assertGreater(len(TxSsi.pe_inputs), 0)
 
@@ -202,11 +202,12 @@ class TestTxSsi(TestCase):
 
         self.assertIn(SsiCountableResourcesDependency, TxSsi.pe_inputs)
 
-    def test_pe_inputs_includes_ssi_reported_dependency(self):
-        """Test that TxSsi inherits SsiReportedDependency from parent Ssi class."""
-        from programs.programs.policyengine.calculators.dependencies.member import SsiReportedDependency
+    def test_pe_inputs_includes_the_receipt_contract(self):
+        """TxSsi inherits the reported-amount and take-up inputs from the federal Ssi class."""
+        from programs.programs.policyengine.calculators.dependencies import receipt_contract
 
-        self.assertIn(SsiReportedDependency, TxSsi.pe_inputs)
+        for dep in receipt_contract:
+            self.assertIn(dep, TxSsi.pe_inputs)
 
     def test_pe_inputs_includes_is_blind_dependency(self):
         """Test that TxSsi inherits IsBlindDependency from parent Ssi class."""

--- a/programs/programs/tx/pe/tests/test_member.py
+++ b/programs/programs/tx/pe/tests/test_member.py
@@ -52,7 +52,7 @@ class TestTxWic(TestCase):
         self.assertTrue(issubclass(TxWic, Wic))
 
         # Verify it has the expected properties
-        self.assertEqual(TxWic.pe_name, "wic_if_takes_up")
+        self.assertEqual(TxWic.pe_name, "wic")
         self.assertIsNotNone(TxWic.pe_inputs)
         self.assertGreater(len(TxWic.pe_inputs), 0)
 

--- a/programs/programs/tx/pe/tests/test_spm.py
+++ b/programs/programs/tx/pe/tests/test_spm.py
@@ -359,10 +359,10 @@ class TestTxCeap(TestCase):
 
     def test_receipt_inputs_are_version_gated(self):
         """
-        Every field the contract adds landed in policyengine-us 1.779.3, so each carries
-        that floor and is never sent to an earlier model — an unknown input 400s the whole
-        request, taking every PE program in it down with it. The amount inputs (`ssi`,
-        `tanf`) have existed for years, so they stay ungated.
+        Every field the contract adds carries the floor of the release that introduced it, so
+        none is ever sent to an earlier model — an unknown input 400s the whole request, taking
+        every PE program in it down. The amount inputs (`ssi`, `tanf`) predate it and stay
+        ungated.
         """
         for dep in receipt_contract:
             expected = () if dep.field in ("ssi", "tanf") else (1, 779, 3)

--- a/programs/programs/tx/pe/tests/test_spm.py
+++ b/programs/programs/tx/pe/tests/test_spm.py
@@ -350,9 +350,6 @@ class TestTxCeap(TestCase):
         contract supplies the household's reported amount where they report one, and
         suppresses PolicyEngine's simulated SSI otherwise — without it, modeled SSI counts
         as income and SS/SSI households land in the wrong (too-generous) benefit tier.
-
-        This replaced the ssi_reported / use_reported_ssi bridge, which solved the same
-        problem through a separate reported-SSI channel.
         """
         for dep in receipt_contract:
             self.assertIn(dep, TxCeap.pe_inputs)

--- a/programs/programs/tx/pe/tests/test_spm.py
+++ b/programs/programs/tx/pe/tests/test_spm.py
@@ -12,7 +12,13 @@ as they test Screen model methods, not TX-specific logic.
 from django.test import TestCase
 
 from programs.programs.federal.pe.spm import Lifeline, Snap, SchoolLunch, Tanf
-from programs.programs.policyengine.calculators.dependencies import household, irs_gross_income, member, spm
+from programs.programs.policyengine.calculators.dependencies import (
+    household,
+    irs_gross_income,
+    member,
+    receipt_contract,
+    spm,
+)
 from programs.programs.policyengine.calculators.dependencies.household import TxStateCodeDependency
 from programs.programs.tx.pe import tx_pe_calculators
 from programs.programs.tx.pe.spm import TxCeap, TxLifeline, TxSnap, TxNslp, TxTanf
@@ -31,7 +37,7 @@ class TestTxSnap(TestCase):
         self.assertTrue(issubclass(TxSnap, Snap))
 
         # Verify it has the expected properties
-        self.assertEqual(TxSnap.pe_name, "snap")
+        self.assertEqual(TxSnap.pe_name, "snap_if_takes_up")
         self.assertIsNotNone(TxSnap.pe_inputs)
         self.assertGreater(len(TxSnap.pe_inputs), 0)
 
@@ -338,28 +344,26 @@ class TestTxCeap(TestCase):
         self.assertIn(spm.TxCeap, TxCeap.pe_outputs)
         self.assertEqual(spm.TxCeap.field, "tx_ceap")
 
-    def test_pe_inputs_includes_reported_ssi_inputs(self):
+    def test_pe_inputs_includes_the_receipt_contract(self):
         """
-        MFB-1146: tx_ceap counts applicable_ssi, which only reflects the household's
-        *reported* SSI when use_reported_ssi is sent True. Both the reported amount
-        and the toggle must be in pe_inputs, otherwise PE counts modeled SSI and
-        SS/SSI households land in the wrong (too-generous) benefit tier.
-        """
-        self.assertIn(member.SsiReportedDependency, TxCeap.pe_inputs)
-        self.assertIn(member.UseReportedSsiDependency, TxCeap.pe_inputs)
-        self.assertEqual(member.UseReportedSsiDependency.field, "use_reported_ssi")
+        tx_ceap counts SSI via applicable_ssi, which follows the `ssi` input. The receipt
+        contract supplies the household's reported amount where they report one, and
+        suppresses PolicyEngine's simulated SSI otherwise — without it, modeled SSI counts
+        as income and SS/SSI households land in the wrong (too-generous) benefit tier.
 
-    def test_use_reported_ssi_is_version_gated(self):
+        This replaced the ssi_reported / use_reported_ssi bridge, which solved the same
+        problem through a separate reported-SSI channel.
         """
-        use_reported_ssi / applicable_ssi were added in policyengine-us 1.742.0.
-        The dependency must carry that floor so it is never sent to an earlier model
-        (which would 400 the whole request). The reported-amount input (ssi_reported)
-        has existed since 2022, so it stays ungated.
-        """
-        self.assertEqual(member.UseReportedSsiDependency.min_pe_version, (1, 742, 0))
-        self.assertEqual(member.SsiReportedDependency.min_pe_version, ())
+        for dep in receipt_contract:
+            self.assertIn(dep, TxCeap.pe_inputs)
 
-    def test_use_reported_ssi_value_is_true(self):
-        """The toggle is always True so the screener's reported SSI drives the income test."""
-        dep = member.UseReportedSsiDependency(None, None, {})
-        self.assertTrue(dep.value())
+    def test_receipt_inputs_are_version_gated(self):
+        """
+        Every field the contract adds landed in policyengine-us 1.779.3, so each carries
+        that floor and is never sent to an earlier model — an unknown input 400s the whole
+        request, taking every PE program in it down with it. The amount inputs (`ssi`,
+        `tanf`) have existed for years, so they stay ungated.
+        """
+        for dep in receipt_contract:
+            expected = () if dep.field in ("ssi", "tanf") else (1, 779, 3)
+            self.assertEqual(dep.min_pe_version, expected, dep.field)

--- a/programs/programs/wa/pe/tests/test_member.py
+++ b/programs/programs/wa/pe/tests/test_member.py
@@ -453,7 +453,7 @@ class TestWaSsi(TestCase):
 
     def test_pe_name_is_ssi(self):
         """pe_name is inherited from Ssi and resolves to PolicyEngine's `ssi` variable."""
-        self.assertEqual(WaSsi.pe_name, "ssi")
+        self.assertEqual(WaSsi.pe_name, "ssi_if_takes_up")
 
     def test_is_registered_in_wa_pe_calculators(self):
         """WaSsi is registered in the WA PE calculators dictionary as `wa_ssi`."""

--- a/programs/programs/wa/pe/tests/test_spm.py
+++ b/programs/programs/wa/pe/tests/test_spm.py
@@ -24,7 +24,7 @@ class TestWaSnap(TestCase):
 
     def test_pe_name_is_snap(self):
         """Test that pe_name is snap."""
-        self.assertEqual(WaSnap.pe_name, "snap")
+        self.assertEqual(WaSnap.pe_name, "snap_if_takes_up")
 
     def test_is_registered_in_wa_pe_calculators(self):
         """Test that WaSnap is registered in the calculators dictionary."""


### PR DESCRIPTION
## Context & Motivation

PolicyEngine used to feed **simulated** (would-be-eligible) SSI, TANF and SNAP into *other* programs' calculations — both as countable income and to confer categorical eligibility (SNAP categorical via SSI/TANF, WIC adjunctive, Head Start categorical, Medicaid's SSI category). Being *eligible* for a benefit is not the same as *receiving* it, so downstream eligibility and income were over-stated: a household PolicyEngine merely models as SSI-eligible was blocked from IL AABD by income they never got, and picked up categorical eligibility from a benefit they don't have.

As of `policyengine-us` **1.779.3** PE ties both to actual receipt. This adopts that contract across all four programs and every downstream consumer.

- Fixes [MFB-1312](https://linear.app/myfriendben/issue/MFB-1312/d-program-adopt-actual-receipt-vs-would-be-eligibility-contract-for)
- Unblocks [MFB-1315](https://linear.app/myfriendben/issue/MFB-1315) (KS programs with categorical scenarios) and [MFB-1260](https://linear.app/myfriendben/issue/MFB-1260) (MO SNAP)
- Related: #1606 (KS SNAP — deferred the SSI-categorical piece to here), #1681 ([MFB-1604](https://linear.app/myfriendben/issue/MFB-1604) `has_base_benefit` cleanup, merged — prerequisite), #1684 ([MFB-1571](https://linear.app/myfriendben/issue/MFB-1571) WIC income sources, open)
- [MFB-1382](https://linear.app/myfriendben/issue/MFB-1382) (SNAP/WIC income capture) was **cancelled**: PolicyEngine uses reported SNAP/WIC *amounts* for only two programs, neither of which MFB implements. So SNAP and WIC are two-state here (receipt boolean / take-up off) rather than the three-state shape the ticket originally described.

### The contract

| User reports | SSI / TANF | SNAP | WIC |
|---|---|---|---|
| Receiving, amount known | `ssi` / `tanf` = reported amount + `receives_X: true` | n/a — no amount capture | n/a — no amount capture |
| Receiving, no amount | `receives_X: true`, amount computed | `receives_snap: true`, amount computed | *(no input — see below)* |
| Receiving per the Current Benefits tile only | SSI: no member credited, `takes_up_ssi_if_eligible` held at default; TANF: `receives_tanf: true` | `receives_snap: true` | n/a |
| Not receiving | `takes_up_X_if_eligible: false` | `takes_up_snap_if_eligible: false` | *(no flag — see below)* |
| Display | `ssi_if_takes_up` / `tanf_if_takes_up` | `snap_if_takes_up` | `wic` (already ungated) |

## Changes Made

Three commits, one per workstream.

**1. Dependency layer** (`b333bde8`)

- New `dependencies/receipt.py` — single home for what "receiving" means, so all six inputs agree.
- New dependencies, all gated `min_pe_version = (1, 779, 3)`: `receives_ssi`, `receives_snap`, `receives_tanf`, `takes_up_ssi_if_eligible`, `takes_up_tanf_if_eligible`, and the `ssi_if_takes_up` / `snap_if_takes_up` / `tanf_if_takes_up` outputs (WIC keeps the ungated `wic` — see below). `TakesUpSnapIfEligibleDependency` already existed, defined-but-unwired with a hardcoded `True`; it now has a real `value()` and a version gate.
- `is_tanf_enrolled` is **not** sent — PE defaults it to `receives_tanf`.
- `Tanf` no longer requires the Current Benefits tile: a reported cash-assistance amount is itself proof of receipt. Without this we'd have sent `takes_up_tanf_if_eligible: false` alongside a household's own reported TANF amount.

**2. Program wiring** (`904d5553`)

- Shared `receipt_contract` bundle (next to `irs_gross_income`) applied to: SNAP (all 8 variants via `SNAP_BASE_INPUTS`), Head Start / Early Head Start, WIC, Medicaid, MSP, Lifeline, KS TANF, IL AABD, CO ANDCS, TX CEAP. PE requests are a single shared payload, so the bundle is applied broadly on purpose — behavior shouldn't depend on which programs a white label happens to enable.
- Three programs move to their would-be output: `Snap.pe_name → snap_if_takes_up`, `Tanf → tanf_if_takes_up`, `Ssi → ssi_if_takes_up`. `Wic` keeps `wic`, which is already ungated. **This half cannot ship separately** — once `takes_up_X_if_eligible: false` goes out, the receipt-gated fields read 0 for exactly the households the programs should be recommended to, and the frontend filters out anything valued at $0.
- `member.Ssi` now reaches all 7 SNAP states (only KS wired it before).
- **TX CEAP** migrated off `ssi_reported` / `use_reported_ssi`; `applicable_ssi` follows the `ssi` input.
- Deleted: `SsiReportedDependency`, `UseReportedSsiDependency`, `SsiAmountIfEligible`, the `spm.Snap` `1`-sentinel input and the `member.Wic` output dependency.

**3. Tests** (`9f99d390`)

- New `policyengine/tests/test_receipt_contract.py` — the cross-cutting wiring: every consumer adopts the bundle, each program reads the right output (including WIC staying ungated), every 1.779.3 field carries its gate, and the superseded reported-SSI inputs stay absent.
- New dependency tests covering member scoping (a spouse's SSI is not this member's), receipt from an amount without the tile, and the unattributable case.
- Updated the suites that pinned the old shape (`pe_name`, `ssi_reported`, the `snap: 1` sentinel).

**4. Guard against an unreadable output** (`46d26155`)

Found while responding to review. The `*_if_takes_up` fields are the **first version-gated `pe_outputs` in the codebase**, and gating an output is not like gating an input:

- a withheld *input* just leaves PolicyEngine to model the value itself — harmless, and the only case that existed before this PR;
- a withheld *output* is never returned, `Sim.value()` is a bare dict lookup, and `all_eligibility()` has no per-program error handling — so one unreadable program raises `KeyError` into `calc_pe_eligibility`'s catch-all, which returns an empty result. **Every** PolicyEngine program then drops off the screen, not just the gated ones.

Reproduced locally: at `pe_version="1.750.0"` the SNAP payload carries no `snap_if_takes_up` at all. Reachable two ways — an exact `PolicyEngineConfig` pin below a floor, or PE's `/versions/us` being unreachable while `/calculate` is healthy (separate endpoints; an unresolvable version withholds every gated field).

`_drop_unreadable_programs()` filters those programs out alongside the existing `can_calc()` pass and reports the drop to Sentry, so the failure degrades to "these are unavailable" instead of "no PolicyEngine programs at all". Also folds `pe_input`'s inline version resolution into the shared helper both paths now need.

**Scope of that degradation — 14 programs, not 4.** The gated outputs are declared on the federal base classes, but state variants inherit `pe_outputs`, so the drop set is every SNAP variant and every SSI variant:

```
snap_if_takes_up   snap, co_snap, il_snap, ks_snap, ma_snap, nc_snap, tx_snap, wa_snap   (8)
ssi_if_takes_up    ssi, ks_ssi, mo_ssi, tx_ssi, wa_ssi                                    (5)
tanf_if_takes_up   tanf                                                                   (1)
```

State TANF is **not** affected: `CoTanf` / `IlTanf` / `KsTanf` / `NcTanf` / `TxTanf` / `WaTanf` each override `pe_outputs` with their own `{st}_tanf` field, which carries no floor. Only the federal `tanf` calculator reads the gated output.

So if `/versions/us` is unreachable while `/calculate` is healthy, SNAP and SSI disappear across all their states simultaneously and silently from the user's side (omitted from results, not shown ineligible; only `missing_programs: true` is set). Still a large improvement on the pre-guard behavior — *every* PE program gone — and the Sentry `capture_message` names the withheld field, so it's diagnosable. But whoever sees that warning should expect two whole program families missing, not four programs. Version resolution failures are not cached, so every request re-attempts the fetch for the duration of an outage.

**5. SSI receipt is read from a reported amount only** (`224371b7`)

`receives_ssi` is person-level; the Current Benefits tile is household-level. A ticked tile with no dollar amount names no recipient, and with more than one plausible member the screener holds nothing to tell them apart — so no member is asserted as a recipient.

Guessing is not cheap. PolicyEngine treats `receives_ssi` as conclusive: measured against the live API, the flag alone flips `medicaid_category` to `SSI_RECIPIENT` with no demographic or income test — worth **$15,167** to a non-disabled 30-year-old at $90k income and **$10,222** to a 3-year-old. Crediting the wrong member both grants a benefit they don't qualify for and pushes their computed SSI into the income aggregate SNAP's income test reads, so a bad guess can add one benefit while reducing another.

Attributing it from a 65+/blind/disabled test would also put an SSI eligibility rule in the dependency layer, where it wouldn't track changes to SSI's actual rules.

Little is lost by not guessing. Every consumer tests `(ssi > 0) | receives_ssi` — `meets_snap_categorical_eligibility`, `is_ssi_recipient_for_medicaid` and its 209(b) variant. A tile-only household keeps `takes_up_ssi_if_eligible: true`, so PolicyEngine models their SSI, `ssi > 0`, and those tests fire anyway. The boolean only decides the case where PolicyEngine computes the amount as $0 (see Known limitations).

The tile is not discarded: `screen_reports_ssi_without_amount` holds take-up at PolicyEngine's default for the whole household, so a real recipient's SSI is never zeroed.

**WIC stays on the ungated `wic`.** `wic` is `wic_if_takes_up` gated on `takes_up_wic_if_eligible`, which defaults True and which we never send — and `receives_wic` is measurably inert — so the two fields return the same number for every payload we submit. There is no WIC take-up suppression for a would-be output to route around. Staying ungated also keeps WIC clear of the `1.779.3` floor, and so out of `_drop_unreadable_programs`.

## Testing

- **Migrations to run:** none
- **Configuration updates needed:** none. Requires the served PolicyEngine model to be ≥ 1.779.3 — see Deployment.
- **Environment variables/settings to add:** none
- **Automated:** `3145 passed, 8 skipped`. The 7 failures in `programs/management/commands/tests/test_import_all_program_configs.py` (a `content_hash` NOT NULL violation) are **pre-existing and unrelated** — they reproduce on untouched `origin/main`.
- **Manual testing steps** (each run twice: once reporting the benefit, once not):
  1. **KS SNAP Sc 8** — 1 person, age 45, disabled, SSI `$900`/mo, assets `$6,000`, ZIP `66102`/Wyandotte → **eligible, $1,080/yr**. Verified end-to-end against live PE: `meets_snap_categorical_eligibility: true`, `snap_if_takes_up` `$90.70`/mo.
  2. **KS SNAP Sc 22** — same, plus pension `$2,000`/mo → **eligible, $288/yr** (minimum allotment). Verified: categorical still fires even though PE computes the household's own SSI as `$0`. These are the two scenarios #1606 deferred.
  3. **Simulated suppression** — identical household that does *not* report SNAP but which PE would model as SNAP-eligible: Head Start / EHS categorical must **not** fire.
  4. **Reported-but-$0** — report receipt with income high enough that PE computes `$0`: categorical must still fire (via `receives_X`).
  5. **Regression guard** — a non-reporter still sees a would-be amount for SNAP / SSI / TANF / WIC rather than `$0`.
  6. **IL AABD** — age 67, disabled, `$0` income: previously `$0` (blocked by phantom simulated SSI), now **$10,153**.
  7. **Tile-only SSI, no amount** — tick the SSI tile, enter **no** SSI amount, 1 person aged 67, assets `$6,000`. Confirm no member is sent `receives_ssi: true`, `takes_up_ssi_if_eligible` stays `true` for everyone, and PolicyEngine's own modelled SSI still drives SNAP categorical eligibility. Then add a non-disabled working-age second adult and confirm neither member picks up the SSI-recipient Medicaid pathway.

> ### ⚠️ Read the categorical scenarios with this in mind
>
> SNAP categorical eligibility requires **every** member of the household to receive SSI/TANF — the federal pure-PA-household rule. Measured with the contract's take-up flags applied:
>
> | Household | `meets_snap_categorical_eligibility` |
> | -- | -- |
> | aged 67 reporting an SSI amount, alone | **true** |
> | 67 (SSI amount) + child 3 | false |
> | 67 (SSI amount) + adult 40 | false |
>
> This is why `ks/snap/spec.md` S8 is phrased "All Members Receive SSI" at household size 1. Multi-member households that look categorically eligible on `main` are firing off **simulated TANF** ($0 income + a child is TANF-eligible), which this contract deliberately suppresses — so those going to `false` is the intended change, not a regression. Note also that crediting a single member would not have been sufficient — the rule reads `spm_unit.all(receives_ssi)`.

## Deployment

- **Post-deployment scripts needed:** none
- **Production config updates:** none — **verified**. Both staging and prod ride PolicyEngine's `current` (1.784.3) unpinned, which satisfies the `1.779.3` floor, so every gated input is sent. Worth re-checking only if someone pins an exact version later: an exact pin below 1.779.3 silently withholds all of them and turns the contract into a no-op.
  ```
  heroku run --app cobenefits-api python manage.py shell -c \
    "from configuration.models import PolicyEngineConfig; print(repr(PolicyEngineConfig.current_version()))"
  ```
- **Admin updates needed:** none
- **Notify team/users of:** benefit **values change** for a large share of households — this is intended, but it is not a silent refactor:
  - **SNAP rises in all 7 states** for any household not reporting SSI (phantom simulated SSI stops counting as income). Measured `$62.50 → $298`/mo and `$243 → $546`/mo on two sweep households.
  - **IL AABD** `$0 → $10,153`, **CO OAP** `$456 → $12,384`, and state TANF (IL/KS/NC/TX) all rise, same cause.
  - **WIC eligibility narrows** in CO/IL/MA/NC/TX/MO: its adjunct test loses the computed-SNAP/TANF branch for non-reporters. The Medicaid branch and the income test are unaffected. The `wic` value itself is read from the same field as today — only the inputs feeding that test change.
  - Households reporting SNAP no longer have their SNAP pinned to `$1`/mo in PolicyEngine's income (the retired sentinel), so programs reading household benefit income shift slightly for them.

## Notes for Reviewers

Worth a close look: `dependencies/receipt.py` (the receipt rules and why each is drawn where it is), and `federal/pe/spm.py` / `federal/pe/member.py` for the output switches (and why WIC is not one of them).

Three ticket assertions turned out to be wrong when checked against the live private API; the ticket has been corrected:

1. **`applicable_ssi` is not inert.** `ssi_reported` + `use_reported_ssi` still drive it (11,928 → 6,000 with `ssi_reported=6000`). TX CEAP would *not* have silently broken — migrating it is cleanup, not a fix. What did change is IL AABD, which no longer reads it; only `takes_up_ssi_if_eligible` moves it.
2. **`receives_wic` is a no-op** — it changes nothing measurable, not even `wic` under `takes_up_wic_if_eligible: false`. Not wired. Together with our never sending `takes_up_wic_if_eligible`, this is why WIC needs no would-be output: there is no suppression to route around.
3. **An explicit `ssi`/`tanf` amount wins over the take-up flag** — the flag only suppresses PE's own computed value. So a household that reports an amount without ticking the tile is never silently zeroed.

On the bundle's **non-uniform version gating** (raised in review): flooring `member.Ssi` and `spm.Tanf` at 1.779.3 alongside the receipt fields would stop sending reported SSI/TANF amounts to older models — a regression, since those two predate the contract by years and are load-bearing today. The asymmetry is safe because *the suppressing half is the gated half*: below the floor we send amounts with no take-up flags, which is the pre-contract behavior, and there is no resolvable version at which we zero a benefit without also sending the evidence for it. The inverse shape is unreachable, and `test_the_suppressing_half_is_the_gated_half` pins that direction.

- **Known limitations:**
  - **A ticked SSI tile with no amount confers no categorical eligibility where PolicyEngine computes the household's SSI as $0.** Accepted, not a bug — please don't file it from QA. Such a household keeps `takes_up_ssi_if_eligible: true`, so PolicyEngine models their SSI and `(ssi > 0)` satisfies the categorical tests in the ordinary case; the gap is only the $0-computed one, where `receives_ssi` would have been the sole signal. Closing it needs per-member receipt capture at the tile, not an inferred recipient — the screener cannot currently say *who* in a multi-adult household receives SSI.
  - **SNAP receipt is tile-only** — there's no SNAP amount to fall back on, so an unticked tile reads as "not receiving".
  - TANF receipt is deliberately *not* derived into `CurrentBenefit`. "Cash Assistance Grant" is a broader label than TANF, and treating it as TANF receipt would drop the state's TANF program from those households' results via `already_has`.
  - **Pre-existing, not touched here:** `all_eligibility()` has no per-program error handling, so *any* calculator that raises empties the PE result for the whole screen — every PolicyEngine program at once, silently from the user's side (they're omitted from results, not shown as ineligible; the response only sets `missing_programs: true`). Commit `46d26155` removes the instance this PR would have introduced; the general fragility remains and probably deserves its own ticket.
- **Future considerations:**
  - Follow-ups from the ticket, intentionally not in this diff: IL AABD `spec.md` + scenario test, Head Start / EHS test directories (KS/TX/MA), and un-skipping the KS EHS/HS categorical Scenario 4 with its Known-limitation notes removed.
  - If SNAP/WIC amount capture is ever revived, the amount inputs belong in the `receipt_contract` bundle alongside `ssi` and `tanf`; `test_receipt_contract.py` pins that absence today so it can't drift unnoticed.
  - #1684 has merged, so WIC QA here runs against income-sensitive WIC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Eligibility calculations now distinguish reported benefit receipt from modeled eligibility and take-up for SSI, SNAP, and TANF.
  * Programs including WIC, Medicaid, Head Start, Lifeline, MSP, and selected state benefits use consistent receipt information.
  * Benefit outputs now indicate when assistance is received or taken up.
* **Bug Fixes**
  * Improved handling of benefit receipts reported through income or benefit records.
  * Unsupported program versions are now excluded safely, with consistent version handling across calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
