### PR TITLE
MFB-1585: Stop recording skipped config imports as successful; add additive reconcile

### DIFF
--- a/programs/management/commands/import_all_program_configs.py
+++ b/programs/management/commands/import_all_program_configs.py
@@ -2,12 +2,24 @@ from dataclasses import dataclass
 
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
+from programs.management.commands.import_program_config import RECONCILE_SECTIONS
 from programs.models import ProgramConfigImport, Program
 from screener.models import WhiteLabel
 from pathlib import Path
 from typing import Any
 import argparse
+import hashlib
 import json
+
+
+def config_content_hash(config_file: Path) -> str:
+    """
+    Return the SHA-256 of a config file's raw bytes.
+
+    Recorded alongside the tracking row so that editing a config re-opens it as
+    pending. Migration 0166 duplicates this to backfill existing rows.
+    """
+    return hashlib.sha256(config_file.read_bytes()).hexdigest()
 
 
 @dataclass
@@ -15,6 +27,7 @@ class ImportResults:
     successful: int = 0
     failed: int = 0
     skipped: int = 0
+    reconciled: int = 0
 
 
 class Command(BaseCommand):
@@ -29,11 +42,23 @@ class Command(BaseCommand):
       python manage.py import_all_program_configs
       python manage.py import_all_program_configs --dry-run
       python manage.py import_all_program_configs --list
+      python manage.py import_all_program_configs --reconcile --dry-run
+      python manage.py import_all_program_configs --reconcile --only navigators
 
     Options:
-      --dry-run    Show which configs would be imported without making changes
+      --dry-run    Show what would change without making changes
       --list       Show status of all config files (imported or pending)
-      --file       Import a specific file only (still tracks it)
+      --file       Process a specific file only
+      --reconcile  Additively apply configs to programs that already exist
+      --only       With --reconcile, limit to given sections (repeatable)
+
+    A config whose program already exists is skipped and left pending — a skip is
+    never recorded as an import, so nothing becomes permanently unreachable. Use
+    --reconcile to additively apply such a config's warning messages, documents and
+    navigators to the existing program without touching anything already there.
+
+    Tracking rows store a hash of the config file, so editing a config re-opens it
+    as pending on the next run.
     """
 
     # Path to the data directory containing JSON config files
@@ -57,6 +82,19 @@ class Command(BaseCommand):
             dest="single_file",
             help="Import a specific file only (by filename, not full path)",
         )
+        parser.add_argument(
+            "--reconcile",
+            action="store_true",
+            help="Additively apply configs to programs that already exist, creating missing "
+            "warning messages, documents and navigators and their links. Never updates or "
+            "deletes anything. Combine with --dry-run to preview.",
+        )
+        parser.add_argument(
+            "--only",
+            action="append",
+            choices=list(RECONCILE_SECTIONS),
+            help="With --reconcile, limit the pass to these sections. Repeatable. Defaults to all of them.",
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
         """Orchestrates the import process based on command options."""
@@ -68,25 +106,35 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("No JSON configuration files found in data directory."))
             return
 
-        imported_files = self._get_imported_filenames()
+        import_records = self._get_import_records()
 
         if options["list_status"]:
-            return self._show_status(json_files, imported_files)
+            return self._show_status(json_files, import_records)
 
-        pending_files = self._filter_pending_files(json_files, imported_files, options.get("single_file"))
-        if pending_files is None:  # error already written to stderr
+        reconcile = options.get("reconcile", False)
+        only = options.get("only")
+        if only and not reconcile:
+            self.stderr.write(self.style.ERROR("--only has no effect without --reconcile."))
             return
 
-        if not pending_files:
+        dry_run = options["dry_run"]
+
+        target_files = self._select_target_files(json_files, import_records, options.get("single_file"), reconcile)
+        if target_files is None:  # error already written to stderr
+            return
+
+        if not target_files:
             self.stdout.write(self.style.SUCCESS("\n✓ All program configurations have already been imported.\n"))
             self._show_summary(len(json_files), len(json_files), 0)
             return
 
-        if options["dry_run"]:
-            return self._handle_dry_run(pending_files)
+        # A reconcile dry run has to invoke the importer to report what it would change,
+        # so it goes through the normal execution path rather than the file listing.
+        if dry_run and not reconcile:
+            return self._handle_dry_run(target_files)
 
-        results = self._execute_imports(pending_files)
-        self._display_final_summary(results)
+        results = self._execute_imports(target_files, reconcile=reconcile, only=only, dry_run=dry_run)
+        self._display_final_summary(results, dry_run=dry_run)
 
     def _validate_data_directory(self) -> bool:
         """Return False and write an error if the data directory doesn't exist."""
@@ -99,25 +147,55 @@ class Command(BaseCommand):
         """Return a sorted list of JSON config files in the data directory."""
         return sorted(self.DATA_DIR.glob("*.json"))
 
-    def _get_imported_filenames(self) -> set[str]:
-        """Return the set of filenames already recorded as imported."""
-        return set(ProgramConfigImport.objects.values_list("filename", flat=True))
+    def _get_import_records(self) -> dict[str, str]:
+        """Return {filename: content_hash} for every config already recorded as imported."""
+        return dict(ProgramConfigImport.objects.values_list("filename", "content_hash"))
 
-    def _filter_pending_files(
-        self, json_files: list[Path], imported_files: set[str], single_file: str | None
+    def _is_pending(self, config_file: Path, import_records: dict[str, str]) -> bool:
+        """
+        Whether a config still needs to be applied.
+
+        Never recorded means pending. A record with an empty hash predates hashing and is
+        taken at face value. A record whose hash no longer matches the file means the config
+        was edited since it was applied, so it is pending again — the same guarantee Django
+        migrations give, and the reason a skip must never write a record.
+        """
+        if config_file.name not in import_records:
+            return True
+
+        recorded_hash = import_records[config_file.name]
+        if not recorded_hash:
+            return False
+
+        return recorded_hash != config_content_hash(config_file)
+
+    def _select_target_files(
+        self,
+        json_files: list[Path],
+        import_records: dict[str, str],
+        single_file: str | None,
+        reconcile: bool,
     ) -> list[Path] | None:
         """
-        Return files that haven't been imported yet.
+        Return the files this run should process.
 
-        If single_file is given, filters to just that file. Returns None (writing
-        to stderr) if a requested single file isn't found in the data directory.
+        A normal run processes pending files only. A --reconcile run considers every
+        config, since the point of reconciling is to repair programs whose config was
+        recorded but never actually applied.
+
+        If single_file is given, filters to just that file. Returns None (writing to
+        stderr) if a requested single file isn't found in the data directory.
         """
         if single_file:
             json_files = [f for f in json_files if f.name == single_file]
             if not json_files:
                 self.stderr.write(self.style.ERROR(f"File not found: {single_file}"))
                 return None
-        return [f for f in json_files if f.name not in imported_files]
+
+        if reconcile:
+            return json_files
+
+        return [f for f in json_files if self._is_pending(f, import_records)]
 
     def _handle_dry_run(self, pending_files: list[Path]) -> None:
         """Display what would be imported without making any changes."""
@@ -134,14 +212,23 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.WARNING("\n[Dry run] No imports executed.\n"))
 
-    def _execute_imports(self, pending_files: list[Path]) -> ImportResults:
-        """Process each pending config file and return import results."""
+    def _execute_imports(
+        self,
+        target_files: list[Path],
+        reconcile: bool = False,
+        only: list[str] | None = None,
+        dry_run: bool = False,
+    ) -> ImportResults:
+        """Process each target config file and return the results."""
         results = ImportResults()
 
+        verb = "reconcile" if reconcile else "import"
         self.stdout.write(self.style.WARNING(f"\n{'=' * 60}"))
+        if dry_run:
+            self.stdout.write(self.style.WARNING(f"DRY RUN - No changes will be made"))
         self.stdout.write(self.style.WARNING(f"{'=' * 60}\n"))
-        self.stdout.write(f"Found {len(pending_files)} pending import(s):\n")
-        for f in pending_files:
+        self.stdout.write(f"Found {len(target_files)} config(s) to {verb}:\n")
+        for f in target_files:
             program_info = self._get_program_info(f)
             self.stdout.write(f"  • {f.name}")
             if program_info:
@@ -149,34 +236,35 @@ class Command(BaseCommand):
 
         self.stdout.write("")
 
-        for config_file in pending_files:
+        for config_file in target_files:
             self.stdout.write(self.style.WARNING(f"\n{'─' * 60}"))
-            self.stdout.write(f"Importing: {config_file.name}")
+            self.stdout.write(f"{verb.capitalize()}: {config_file.name}")
             self.stdout.write(self.style.WARNING(f"{'─' * 60}"))
 
             try:
-                result = self._import_config(config_file)
-                if result["status"] == "success":
+                result = self._import_config(config_file, reconcile=reconcile, only=only, dry_run=dry_run)
+                status = result["status"]
+
+                if status == "success":
                     results.successful += 1
-                    ProgramConfigImport.objects.get_or_create(
-                        filename=config_file.name,
-                        defaults={
-                            "program_name": result["program_name"],
-                            "white_label_code": result["white_label_code"],
-                        },
-                    )
+                    self._record_import(config_file, result)
                     self.stdout.write(self.style.SUCCESS(f"✓ Imported and recorded: {config_file.name}"))
-                elif result["status"] == "skipped":
+                elif status == "reconciled":
+                    results.reconciled += 1
+                    if dry_run:
+                        self.stdout.write(self.style.WARNING(f"⋯ Would reconcile: {config_file.name}"))
+                    else:
+                        self._record_import(config_file, result)
+                        self.stdout.write(self.style.SUCCESS(f"✓ Reconciled and recorded: {config_file.name}"))
+                elif status == "skipped":
+                    # Deliberately no tracking row: nothing in this config was applied, so
+                    # recording it would exclude it from every future run.
                     results.skipped += 1
-                    ProgramConfigImport.objects.get_or_create(
-                        filename=config_file.name,
-                        defaults={
-                            "program_name": result["program_name"],
-                            "white_label_code": result["white_label_code"],
-                        },
-                    )
                     self.stdout.write(
-                        self.style.WARNING(f"⊘ Skipped (program exists): {config_file.name} - recorded as imported")
+                        self.style.WARNING(
+                            f"⊘ Skipped: {config_file.name} - {result.get('reason', 'program already exists')} "
+                            f"(left pending, nothing applied)"
+                        )
                     )
                 else:
                     results.failed += 1
@@ -189,17 +277,42 @@ class Command(BaseCommand):
 
         return results
 
-    def _display_final_summary(self, results: ImportResults) -> None:
-        """Display a summary of the completed import run."""
+    def _record_import(self, config_file: Path, result: dict[str, Any]) -> None:
+        """
+        Record a config as applied, stamping the content hash it was applied from.
+
+        update_or_create rather than get_or_create so that re-applying an edited config
+        refreshes the hash — otherwise the file would stay pending forever.
+        """
+        ProgramConfigImport.objects.update_or_create(
+            filename=config_file.name,
+            defaults={
+                "program_name": result["program_name"],
+                "white_label_code": result["white_label_code"],
+                "content_hash": config_content_hash(config_file),
+            },
+        )
+
+    def _display_final_summary(self, results: ImportResults, dry_run: bool = False) -> None:
+        """Display a summary of the completed run."""
         self.stdout.write(self.style.WARNING(f"\n{'=' * 60}"))
-        self.stdout.write(self.style.SUCCESS("Import Complete"))
+        self.stdout.write(self.style.SUCCESS("Dry Run Complete" if dry_run else "Import Complete"))
         self.stdout.write(self.style.WARNING(f"{'=' * 60}"))
         self.stdout.write(f"  Successful: {results.successful}")
-        self.stdout.write(f"  Skipped:    {results.skipped}")
+        if results.reconciled:
+            self.stdout.write(f"  Reconciled: {results.reconciled}")
+        self.stdout.write(f"  Skipped:    {results.skipped}  (still pending — nothing was applied)")
         self.stdout.write(f"  Failed:     {results.failed}")
+        if results.skipped:
+            self.stdout.write(
+                self.style.WARNING(
+                    "\nSkipped configs were not applied. Run with --reconcile to additively apply "
+                    "their warning messages, documents and navigators to the existing programs."
+                )
+            )
         self.stdout.write("")
 
-    def _show_status(self, json_files: list[Path], imported_files: set[str]) -> None:
+    def _show_status(self, json_files: list[Path], import_records: dict[str, str]) -> None:
         """Display the import status of all config files."""
         self.stdout.write(self.style.WARNING(f"\n{'=' * 60}"))
         self.stdout.write("Program Config Import Status")
@@ -214,9 +327,11 @@ class Command(BaseCommand):
             if program_info:
                 program_desc = f" ({program_info['white_label']}/{program_info['program_name']})"
 
-            if config_file.name in imported_files:
+            recorded = config_file.name in import_records
+            pending = self._is_pending(config_file, import_records)
+
+            if not pending:
                 imported_count += 1
-                # Get import record for timestamp
                 record = ProgramConfigImport.objects.filter(filename=config_file.name).first()
                 timestamp = record.imported_at.strftime("%Y-%m-%d %H:%M") if record else "unknown"
                 self.stdout.write(self.style.SUCCESS(f"  ✓ {config_file.name}{program_desc}"))
@@ -224,7 +339,10 @@ class Command(BaseCommand):
             else:
                 pending_count += 1
                 self.stdout.write(self.style.WARNING(f"  ○ {config_file.name}{program_desc}"))
-                self.stdout.write("      Status: pending")
+                if recorded:
+                    self.stdout.write("      Status: pending (file edited since it was imported)")
+                else:
+                    self.stdout.write("      Status: pending")
 
         self._show_summary(len(json_files), imported_count, pending_count)
 
@@ -246,14 +364,21 @@ class Command(BaseCommand):
         except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
             return None
 
-    def _import_config(self, config_file: Path) -> dict[str, Any]:
+    def _import_config(
+        self,
+        config_file: Path,
+        reconcile: bool = False,
+        only: list[str] | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
         """
-        Import a single configuration file.
+        Import or reconcile a single configuration file.
 
         Returns a dict with:
-            status: 'success', 'skipped', or 'error'
+            status: 'success', 'reconciled', 'skipped', or 'error'
             program_name: the program's name_abbreviated
             white_label_code: the white label code
+            reason: why it was skipped, if status is 'skipped'
             error: error message if status is 'error'
         """
         # Read and parse the config file
@@ -277,13 +402,6 @@ class Command(BaseCommand):
         try:
             white_label = WhiteLabel.objects.get(code=white_label_code)
             existing_program = Program.objects.filter(name_abbreviated=program_name, white_label=white_label).first()
-
-            if existing_program:
-                return {
-                    "status": "skipped",
-                    "program_name": program_name,
-                    "white_label_code": white_label_code,
-                }
         except WhiteLabel.DoesNotExist:
             return {
                 "status": "error",
@@ -292,16 +410,36 @@ class Command(BaseCommand):
                 "white_label_code": white_label_code,
             }
 
-        # Call the import_program_config command
-        try:
-            call_command(
-                "import_program_config",
-                str(config_file),
-                stdout=self.stdout,
-                stderr=self.stderr,
-            )
+        if existing_program and not reconcile:
             return {
-                "status": "success",
+                "status": "skipped",
+                "reason": f"program already exists (ID: {existing_program.id})",
+                "program_name": program_name,
+                "white_label_code": white_label_code,
+            }
+
+        if reconcile and not existing_program:
+            # Reconcile repairs existing programs; it never creates one, so that a repair
+            # run can't quietly introduce programs nobody asked for.
+            return {
+                "status": "skipped",
+                "reason": "program does not exist yet — run without --reconcile to create it",
+                "program_name": program_name,
+                "white_label_code": white_label_code,
+            }
+
+        # Call the import_program_config command
+        command_options: dict[str, Any] = {"stdout": self.stdout, "stderr": self.stderr}
+        if reconcile:
+            command_options["reconcile"] = True
+            command_options["dry_run"] = dry_run
+            if only:
+                command_options["only"] = list(only)
+
+        try:
+            call_command("import_program_config", str(config_file), **command_options)
+            return {
+                "status": "reconciled" if reconcile else "success",
                 "program_name": program_name,
                 "white_label_code": white_label_code,
             }

--- a/programs/management/commands/import_all_program_configs.py
+++ b/programs/management/commands/import_all_program_configs.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
@@ -33,7 +33,9 @@ class ImportResults:
     reconciled: int = 0
     already_current: int = 0
     links_to_add: int = 0
-    entities_to_create: int = 0
+    # Held by identity, not counted, so an entity declared by several configs is one entity.
+    entities_to_create: set[tuple[str, str]] = field(default_factory=set)
+    reconcile: bool = False
     partial_pass: bool = False
 
 
@@ -235,12 +237,13 @@ class Command(BaseCommand):
         # whole file — recording a partial apply as complete is the same defect as recording
         # a skip. Reconcile ignores tracking state when selecting files, so a partial pass
         # loses nothing by recording nothing.
+        results.reconcile = reconcile
         results.partial_pass = bool(only) and set(only) != set(RECONCILE_SECTIONS)
 
         verb = "reconcile" if reconcile else "import"
         self.stdout.write(self.style.WARNING(f"\n{'=' * 60}"))
         if dry_run:
-            self.stdout.write(self.style.WARNING(f"DRY RUN - No changes will be made"))
+            self.stdout.write(self.style.WARNING("DRY RUN - No changes will be made"))
         self.stdout.write(self.style.WARNING(f"{'=' * 60}\n"))
         self.stdout.write(f"Found {len(target_files)} config(s) to {verb}:\n")
         for f in target_files:
@@ -266,7 +269,7 @@ class Command(BaseCommand):
                     self.stdout.write(self.style.SUCCESS(f"✓ Imported and recorded: {config_file.name}"))
                 elif status == "reconciled":
                     results.links_to_add += result.get("links_to_add", 0)
-                    results.entities_to_create += result.get("entities_to_create", 0)
+                    results.entities_to_create.update(result.get("entities_to_create", ()))
                     record = not dry_run and not results.partial_pass
 
                     if not result.get("changed"):
@@ -317,15 +320,22 @@ class Command(BaseCommand):
 
         Plan building is a read-only classification, so running it here as well as inside
         the importer costs a few queries and keeps the run summary honest.
+
+        Two things keep the totals comparable between a dry run and an apply. An entity that
+        has to be created also gets a link, so it counts towards both. And entities are
+        returned by identity rather than counted, because one entity is commonly declared by
+        several configs — `wa_211` by five — and a dry run classifies it as missing every
+        time, having applied nothing in between. Deduplicating across the run is what makes
+        `Entities to create` mean entities rather than declarations.
         """
         sections = tuple(s for s in RECONCILE_SECTIONS if s in (only or RECONCILE_SECTIONS))
         plan = ImportProgramConfigCommand()._build_reconcile_plan(program, config, sections)
-        actions = [action for items in plan.values() for _, action in items]
+        declarations = [(section, name, action) for section, items in plan.items() for name, action in items]
 
         return {
-            "links_to_add": actions.count("link"),
-            "entities_to_create": actions.count("create"),
-            "changed": any(action != "linked" for action in actions),
+            "links_to_add": sum(1 for _, _, action in declarations if action != "linked"),
+            "entities_to_create": {(section, name) for section, name, action in declarations if action == "create"},
+            "changed": any(action != "linked" for _, _, action in declarations),
         }
 
     def _record_import(self, config_file: Path, result: dict[str, Any]) -> None:
@@ -350,18 +360,20 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("Dry Run Complete" if dry_run else "Import Complete"))
         self.stdout.write(self.style.WARNING(f"{'=' * 60}"))
 
-        self.stdout.write(f"  Successful:     {results.successful}")
-        if results.reconciled or results.already_current:
-            reconcile_label = "To reconcile:  " if dry_run else "Reconciled:    "
-            self.stdout.write(f"  {reconcile_label} {results.reconciled}")
-            self.stdout.write(f"  Already current: {results.already_current}")
-        self.stdout.write(f"  Skipped:        {results.skipped}  (still pending — nothing was applied)")
-        self.stdout.write(f"  Failed:         {results.failed}")
+        self.stdout.write(f"  {'Successful:':<17} {results.successful}")
+        if results.reconcile:
+            reconcile_label = "To reconcile:" if dry_run else "Reconciled:"
+            self.stdout.write(f"  {reconcile_label:<17} {results.reconciled}")
+            self.stdout.write(f"  {'Already current:':<17} {results.already_current}")
+        self.stdout.write(f"  {'Skipped:':<17} {results.skipped}  (still pending — nothing was applied)")
+        self.stdout.write(f"  {'Failed:':<17} {results.failed}")
 
-        if results.reconciled or results.already_current:
+        # Printed for every reconcile run, including one where everything skipped, so that the
+        # two lines a production repair is gated on are never simply absent from the output.
+        if results.reconcile:
             self.stdout.write("")
-            self.stdout.write(f"  Links to add:      {results.links_to_add}")
-            create_line = f"  Entities to create: {results.entities_to_create}"
+            self.stdout.write(f"  {'Links to add:':<20} {results.links_to_add}")
+            create_line = f"  {'Entities to create:':<20} {len(results.entities_to_create)}"
             # An unexpected entity creation is the signal to stop and look before applying,
             # so it never gets to hide in a wall of green.
             self.stdout.write(self.style.WARNING(create_line) if results.entities_to_create else create_line)
@@ -375,12 +387,20 @@ class Command(BaseCommand):
             )
 
         if results.skipped:
-            self.stdout.write(
-                self.style.WARNING(
-                    "\nSkipped configs were not applied. Run with --reconcile to additively apply "
-                    "their warning messages, documents and navigators to the existing programs."
+            # The two modes skip for opposite reasons — a plain run skips programs that already
+            # exist, a reconcile run skips programs that don't — so the remedy differs. Telling a
+            # reconcile run to try --reconcile is circular, and it says so at the repair gate.
+            if results.reconcile:
+                remedy = (
+                    "A reconcile pass only repairs programs that already exist. Run without "
+                    "--reconcile to create the missing ones."
                 )
-            )
+            else:
+                remedy = (
+                    "Run with --reconcile to additively apply their warning messages, documents "
+                    "and navigators to the existing programs."
+                )
+            self.stdout.write(self.style.WARNING(f"\nSkipped configs were not applied. {remedy}"))
         self.stdout.write("")
 
     def _show_status(self, json_files: list[Path], import_records: dict[str, str]) -> None:

--- a/programs/management/commands/import_all_program_configs.py
+++ b/programs/management/commands/import_all_program_configs.py
@@ -34,6 +34,7 @@ class ImportResults:
     already_current: int = 0
     links_to_add: int = 0
     entities_to_create: int = 0
+    partial_pass: bool = False
 
 
 class Command(BaseCommand):
@@ -64,7 +65,8 @@ class Command(BaseCommand):
     navigators to the existing program without touching anything already there.
 
     Tracking rows store a hash of the config file, so editing a config re-opens it
-    as pending on the next run.
+    as pending on the next run. A row is only written when the whole config was
+    applied, so a --only pass records nothing.
     """
 
     # Path to the data directory containing JSON config files
@@ -99,7 +101,8 @@ class Command(BaseCommand):
             "--only",
             action="append",
             choices=list(RECONCILE_SECTIONS),
-            help="With --reconcile, limit the pass to these sections. Repeatable. Defaults to all of them.",
+            help="With --reconcile, limit the pass to these sections. Repeatable. Defaults to all of them. "
+            "A partial pass records nothing, since only part of each config is applied.",
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
@@ -228,6 +231,12 @@ class Command(BaseCommand):
         """Process each target config file and return the results."""
         results = ImportResults()
 
+        # A --only pass applies part of a config, so it must not stamp a hash covering the
+        # whole file — recording a partial apply as complete is the same defect as recording
+        # a skip. Reconcile ignores tracking state when selecting files, so a partial pass
+        # loses nothing by recording nothing.
+        results.partial_pass = bool(only) and set(only) != set(RECONCILE_SECTIONS)
+
         verb = "reconcile" if reconcile else "import"
         self.stdout.write(self.style.WARNING(f"\n{'=' * 60}"))
         if dry_run:
@@ -258,19 +267,27 @@ class Command(BaseCommand):
                 elif status == "reconciled":
                     results.links_to_add += result.get("links_to_add", 0)
                     results.entities_to_create += result.get("entities_to_create", 0)
+                    record = not dry_run and not results.partial_pass
 
                     if not result.get("changed"):
                         results.already_current += 1
-                        if not dry_run:
+                        if record:
                             self._record_import(config_file, result)
                         continue
 
                     results.reconciled += 1
                     if dry_run:
                         self.stdout.write(self.style.WARNING(f"⋯ Would reconcile: {config_file.name}"))
-                    else:
+                    elif record:
                         self._record_import(config_file, result)
                         self.stdout.write(self.style.SUCCESS(f"✓ Reconciled and recorded: {config_file.name}"))
+                    else:
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"✓ Reconciled: {config_file.name} "
+                                f"(left pending — only part of the config was applied)"
+                            )
+                        )
                 elif status == "skipped":
                     # Deliberately no tracking row: nothing in this config was applied, so
                     # recording it would exclude it from every future run.
@@ -348,6 +365,14 @@ class Command(BaseCommand):
             # An unexpected entity creation is the signal to stop and look before applying,
             # so it never gets to hide in a wall of green.
             self.stdout.write(self.style.WARNING(create_line) if results.entities_to_create else create_line)
+
+        if results.partial_pass and (results.reconciled or results.already_current):
+            self.stdout.write(
+                self.style.WARNING(
+                    "\n--only applies part of each config, so no config is recorded as imported. "
+                    "The remaining sections need their own --reconcile run."
+                )
+            )
 
         if results.skipped:
             self.stdout.write(

--- a/programs/management/commands/import_all_program_configs.py
+++ b/programs/management/commands/import_all_program_configs.py
@@ -2,7 +2,10 @@ from dataclasses import dataclass
 
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
-from programs.management.commands.import_program_config import RECONCILE_SECTIONS
+from programs.management.commands.import_program_config import (
+    RECONCILE_SECTIONS,
+    Command as ImportProgramConfigCommand,
+)
 from programs.models import ProgramConfigImport, Program
 from screener.models import WhiteLabel
 from pathlib import Path
@@ -28,6 +31,9 @@ class ImportResults:
     failed: int = 0
     skipped: int = 0
     reconciled: int = 0
+    already_current: int = 0
+    links_to_add: int = 0
+    entities_to_create: int = 0
 
 
 class Command(BaseCommand):
@@ -250,6 +256,15 @@ class Command(BaseCommand):
                     self._record_import(config_file, result)
                     self.stdout.write(self.style.SUCCESS(f"✓ Imported and recorded: {config_file.name}"))
                 elif status == "reconciled":
+                    results.links_to_add += result.get("links_to_add", 0)
+                    results.entities_to_create += result.get("entities_to_create", 0)
+
+                    if not result.get("changed"):
+                        results.already_current += 1
+                        if not dry_run:
+                            self._record_import(config_file, result)
+                        continue
+
                     results.reconciled += 1
                     if dry_run:
                         self.stdout.write(self.style.WARNING(f"⋯ Would reconcile: {config_file.name}"))
@@ -277,6 +292,25 @@ class Command(BaseCommand):
 
         return results
 
+    def _summarize_reconcile_plan(
+        self, program: Program, config: dict[str, Any], only: list[str] | None
+    ) -> dict[str, Any]:
+        """
+        Count what a reconcile pass would change for one program.
+
+        Plan building is a read-only classification, so running it here as well as inside
+        the importer costs a few queries and keeps the run summary honest.
+        """
+        sections = tuple(s for s in RECONCILE_SECTIONS if s in (only or RECONCILE_SECTIONS))
+        plan = ImportProgramConfigCommand()._build_reconcile_plan(program, config, sections)
+        actions = [action for items in plan.values() for _, action in items]
+
+        return {
+            "links_to_add": actions.count("link"),
+            "entities_to_create": actions.count("create"),
+            "changed": any(action != "linked" for action in actions),
+        }
+
     def _record_import(self, config_file: Path, result: dict[str, Any]) -> None:
         """
         Record a config as applied, stamping the content hash it was applied from.
@@ -298,11 +332,23 @@ class Command(BaseCommand):
         self.stdout.write(self.style.WARNING(f"\n{'=' * 60}"))
         self.stdout.write(self.style.SUCCESS("Dry Run Complete" if dry_run else "Import Complete"))
         self.stdout.write(self.style.WARNING(f"{'=' * 60}"))
-        self.stdout.write(f"  Successful: {results.successful}")
-        if results.reconciled:
-            self.stdout.write(f"  Reconciled: {results.reconciled}")
-        self.stdout.write(f"  Skipped:    {results.skipped}  (still pending — nothing was applied)")
-        self.stdout.write(f"  Failed:     {results.failed}")
+
+        self.stdout.write(f"  Successful:     {results.successful}")
+        if results.reconciled or results.already_current:
+            reconcile_label = "To reconcile:  " if dry_run else "Reconciled:    "
+            self.stdout.write(f"  {reconcile_label} {results.reconciled}")
+            self.stdout.write(f"  Already current: {results.already_current}")
+        self.stdout.write(f"  Skipped:        {results.skipped}  (still pending — nothing was applied)")
+        self.stdout.write(f"  Failed:         {results.failed}")
+
+        if results.reconciled or results.already_current:
+            self.stdout.write("")
+            self.stdout.write(f"  Links to add:      {results.links_to_add}")
+            create_line = f"  Entities to create: {results.entities_to_create}"
+            # An unexpected entity creation is the signal to stop and look before applying,
+            # so it never gets to hide in a wall of green.
+            self.stdout.write(self.style.WARNING(create_line) if results.entities_to_create else create_line)
+
         if results.skipped:
             self.stdout.write(
                 self.style.WARNING(
@@ -430,11 +476,15 @@ class Command(BaseCommand):
 
         # Call the import_program_config command
         command_options: dict[str, Any] = {"stdout": self.stdout, "stderr": self.stderr}
+        plan_totals: dict[str, Any] = {}
         if reconcile:
             command_options["reconcile"] = True
             command_options["dry_run"] = dry_run
             if only:
                 command_options["only"] = list(only)
+            # Build the same plan the importer will, so the run summary can report real
+            # counts rather than treating every processed config as a change.
+            plan_totals = self._summarize_reconcile_plan(existing_program, config, only)
 
         try:
             call_command("import_program_config", str(config_file), **command_options)
@@ -442,6 +492,7 @@ class Command(BaseCommand):
                 "status": "reconciled" if reconcile else "success",
                 "program_name": program_name,
                 "white_label_code": white_label_code,
+                **plan_totals,
             }
         except Exception as e:
             return {

--- a/programs/management/commands/import_program_config.py
+++ b/programs/management/commands/import_program_config.py
@@ -147,6 +147,13 @@ class Command(BaseCommand):
         overriding = bool(existing_program and override)
 
         if existing_program and reconcile:
+            # Reconcile creates navigators the config declares but the database lacks, and
+            # creating one writes its counties — so the county guard has to run here too, or a
+            # repair pass becomes a way to reintroduce exactly the mismatch it exists to block.
+            # Scoped like the guard itself: only when this pass will touch navigators at all, and
+            # with overriding=False, since reconcile never recreates an existing navigator.
+            if "navigators" in sections:
+                self._validate_counties(config, white_label, existing_program=existing_program, overriding=False)
             self._reconcile_program(existing_program, config, sections=sections, dry_run=dry_run)
             return
 
@@ -282,7 +289,13 @@ class Command(BaseCommand):
             return True
         if not overriding:
             return False
-        return not existing_nav.programs.exclude(id=existing_program.id).exists()
+        # Both relations, matching the delete guard: a navigator linked through the
+        # ProgramNavigator table is shared even though the legacy M2M says nothing.
+        shared = any(
+            getattr(existing_nav, relation).exclude(id=existing_program.id).exists()
+            for relation in ("programs_ordered", "programs")
+        )
+        return not shared
 
     def _validate_counties(
         self,

--- a/programs/management/commands/import_program_config.py
+++ b/programs/management/commands/import_program_config.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from django.db.models import Max
 from translations.models import Translation
 from programs.models import (
     Program,
@@ -28,6 +29,10 @@ def truncate(text: str, max_length: int = 50) -> str:
     return f"{text[:max_length]}..." if len(text) > max_length else text
 
 
+# Sections a --reconcile pass can apply, in the order they must run.
+RECONCILE_SECTIONS = ("warning_messages", "documents", "navigators")
+
+
 class Command(BaseCommand):
     help = """
     Import a new program from a JSON configuration file.
@@ -40,6 +45,12 @@ class Command(BaseCommand):
       python manage.py import_program_config <path/to/config.json>
       python manage.py import_program_config <path/to/config.json> --dry-run
       python manage.py import_program_config <path/to/config.json> --skip-translation
+      python manage.py import_program_config <path/to/config.json> --reconcile --dry-run
+      python manage.py import_program_config <path/to/config.json> --reconcile
+
+    If the program already exists the import is skipped. Use --reconcile to additively
+    apply the config's warning messages, documents and navigators to it, or --override
+    to delete and recreate it from scratch.
 
     For detailed documentation on JSON configuration format and examples,
     see: programs/management/commands/import_program_config_data/README.md
@@ -62,6 +73,20 @@ class Command(BaseCommand):
             help="Delete existing program and its navigators/documents before importing",
         )
         parser.add_argument(
+            "--reconcile",
+            action="store_true",
+            help="For a program that already exists, additively apply the warning messages, documents "
+            "and navigators declared in the config. Creates missing entities and missing links only; "
+            "never updates an existing entity, removes a link absent from the config, or touches "
+            "program fields or translations. Combine with --dry-run to preview.",
+        )
+        parser.add_argument(
+            "--only",
+            action="append",
+            choices=list(RECONCILE_SECTIONS),
+            help="With --reconcile, limit the pass to these sections. Repeatable. Defaults to all of them.",
+        )
+        parser.add_argument(
             "--skip-translation",
             action="store_true",
             help="Copy English text to all languages instead of calling Google Translate "
@@ -72,7 +97,19 @@ class Command(BaseCommand):
         config_file = options["config_file"]
         dry_run = options.get("dry_run", False)
         override = options.get("override", False)
+        reconcile = options.get("reconcile", False)
         self.skip_translation = bool(options.get("skip_translation", False))
+
+        if override and reconcile:
+            raise CommandError(
+                "--override and --reconcile are mutually exclusive. "
+                "--override recreates the program from scratch; --reconcile only adds what is missing."
+            )
+
+        only = options.get("only")
+        if only and not reconcile:
+            raise CommandError("--only has no effect without --reconcile.")
+        sections = tuple(s for s in RECONCILE_SECTIONS if s in (only or RECONCILE_SECTIONS))
 
         try:
             config = json.load(config_file)
@@ -109,12 +146,29 @@ class Command(BaseCommand):
         existing_program = Program.objects.filter(name_abbreviated=program_name, white_label=white_label).first()
         overriding = bool(existing_program and override)
 
+        if existing_program and reconcile:
+            self._reconcile_program(existing_program, config, sections=sections, dry_run=dry_run)
+            return
+
+        if reconcile:
+            # Reconcile repairs existing programs. Refusing to create keeps a repair run
+            # from quietly introducing programs nobody asked for.
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\n⊘ Skipped: program '{program_name}' does not exist for white label "
+                    f"'{white_label_code}'. --reconcile only repairs existing programs; "
+                    f"run without it to create this one.\n"
+                )
+            )
+            return
+
         if existing_program and not override:
             self.stdout.write(
                 self.style.WARNING(
                     f"\nProgram '{program_name}' already exists for white label '{white_label_code}' "
                     f"(ID: {existing_program.id}). Skipping import.\n"
-                    f"Use --override to delete and recreate the program."
+                    f"Use --reconcile to additively apply the config's warning messages, documents and "
+                    f"navigators, or --override to delete and recreate the program."
                 )
             )
             return
@@ -156,23 +210,8 @@ class Command(BaseCommand):
                 )
 
                 # Step 3: Import warning message(s) (after program exists)
-                # Supports both:
-                #   - "warning_message"  (singular, object)  — original shape
-                #   - "warning_messages" (plural,   array)   — multi-warning shape
-                # Mutually exclusive; raises if both are present.
-                if "warning_message" in config and "warning_messages" in config:
-                    raise CommandError(
-                        "Config contains both 'warning_message' (singular) and 'warning_messages' (plural). "
-                        "Use one or the other, not both."
-                    )
-                if "warning_message" in config:
-                    self._import_warning_message(program, config["warning_message"])
-                elif "warning_messages" in config:
-                    warning_messages = config["warning_messages"]
-                    if not isinstance(warning_messages, list):
-                        raise CommandError("'warning_messages' must be an array")
-                    for warning_config in warning_messages:
-                        self._import_warning_message(program, warning_config)
+                for warning_config in self._warning_message_configs(config):
+                    self._import_warning_message(program, warning_config)
 
                 # Step 4: Import documents (after program exists)
                 if "documents" in config:
@@ -317,9 +356,13 @@ class Command(BaseCommand):
         program_name = program.name_abbreviated
 
         # Delete navigators and documents specified in config
-        for entity_type, model, config_key, related_name in [
-            ("navigator", Navigator, "navigators", "programs"),
-            ("document", Document, "documents", "program_documents"),
+        for entity_type, model, config_key, related_names in [
+            # Navigators live in two tables during the EXPAND phase of migration 0126:
+            # the app reads `programs_ordered` (the ProgramNavigator through table),
+            # while `programs` is the legacy M2M nothing on the import path populates.
+            # An entity linked in either table is still in use by another program.
+            ("navigator", Navigator, "navigators", ("programs_ordered", "programs")),
+            ("document", Document, "documents", ("program_documents",)),
         ]:
             for item_config in config.get(config_key, []):
                 external_name = item_config.get("external_name")
@@ -328,7 +371,8 @@ class Command(BaseCommand):
                 entity = model.objects.filter(external_name=external_name).first()
                 if not entity:
                     continue
-                if getattr(entity, related_name).exclude(id=program.id).exists():
+                shared = any(getattr(entity, rel).exclude(id=program.id).exists() for rel in related_names)
+                if shared:
                     self.stdout.write(f"  Keeping {entity_type} '{external_name}' (used by other programs)")
                 else:
                     entity.delete()
@@ -343,6 +387,169 @@ class Command(BaseCommand):
         # Delete the program
         program.delete()
         self.stdout.write(f"  Deleted program: {program_name}\n")
+
+    def _warning_message_configs(self, config: dict[str, Any]) -> list[dict[str, Any]]:
+        """
+        Return the warning messages declared in a config.
+
+        Supports both:
+          - "warning_message"  (singular, object)  — original shape
+          - "warning_messages" (plural,   array)   — multi-warning shape
+        Mutually exclusive; raises if both are present.
+        """
+        if "warning_message" in config and "warning_messages" in config:
+            raise CommandError(
+                "Config contains both 'warning_message' (singular) and 'warning_messages' (plural). "
+                "Use one or the other, not both."
+            )
+
+        if "warning_message" in config:
+            return [config["warning_message"]]
+
+        warning_messages = config.get("warning_messages", [])
+        if not isinstance(warning_messages, list):
+            raise CommandError("'warning_messages' must be an array")
+        return warning_messages
+
+    def _reconcile_program(
+        self,
+        program: Program,
+        config: dict[str, Any],
+        sections: tuple[str, ...] = RECONCILE_SECTIONS,
+        dry_run: bool = False,
+    ) -> None:
+        """
+        Additively apply a config to a program that already exists.
+
+        Creates the entities a config declares but the database lacks, and creates the
+        missing program associations. Existing entities are never updated and existing
+        associations are never removed, so navigators, documents and warning messages
+        added or hand-edited in the admin survive intact. Program fields, category and
+        translations are not touched at all.
+        """
+        header = "[Reconcile — dry run]" if dry_run else "[Reconcile]"
+        self.stdout.write(self.style.SUCCESS(f"\n{header} {program.name_abbreviated} (ID: {program.id})"))
+        if set(sections) != set(RECONCILE_SECTIONS):
+            self.stdout.write(f"Sections: {', '.join(sections)}")
+
+        plan = self._build_reconcile_plan(program, config, sections)
+        self._print_reconcile_plan(plan)
+
+        to_apply = [(name, action) for items in plan.values() for name, action in items if action != "linked"]
+        if not to_apply:
+            self.stdout.write(self.style.SUCCESS("\n✓ Already up to date — nothing to apply.\n"))
+            return
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("\n[Dry run] No changes applied.\n"))
+            return
+
+        try:
+            with transaction.atomic():
+                if "warning_messages" in sections:
+                    for warning_config in self._warning_message_configs(config):
+                        self._import_warning_message(program, warning_config)
+
+                if "documents" in sections and "documents" in config:
+                    self._import_documents(program, config["documents"])
+
+                if "navigators" in sections and "navigators" in config:
+                    # Append after any existing links so reconciling never reshuffles
+                    # an ordering someone set in the admin.
+                    self._import_navigators(
+                        program,
+                        config["navigators"],
+                        order_offset=self._next_navigator_order(program),
+                    )
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"\nError during reconcile: {e}\nAll changes have been rolled back."))
+            raise
+
+        links = sum(1 for _, action in to_apply if action == "link")
+        created = sum(1 for _, action in to_apply if action == "create")
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\n✓ Reconciled {program.name_abbreviated}: " f"{links} link(s) added, {created} entity(ies) created\n"
+            )
+        )
+
+    def _build_reconcile_plan(
+        self, program: Program, config: dict[str, Any], sections: tuple[str, ...] = RECONCILE_SECTIONS
+    ) -> dict[str, list[tuple[str, str]]]:
+        """
+        Classify every entity a config declares against the program's current state.
+
+        Returns {section title: [(external_name, action)]} where action is "linked" (already
+        associated), "link" (entity exists but the association is missing) or "create"
+        (no such entity yet).
+
+        Navigators are checked against ProgramNavigator only. A navigator present just in
+        the legacy `programs` M2M is invisible to the results endpoint, so it is correctly
+        reported as still needing a link.
+        """
+        specs = [
+            (
+                "warning_messages",
+                "Warning messages",
+                self._warning_message_configs(config),
+                WarningMessage,
+                lambda entity: entity.programs.filter(id=program.id).exists(),
+            ),
+            (
+                "documents",
+                "Documents",
+                config.get("documents", []),
+                Document,
+                lambda entity: program.documents.filter(id=entity.id).exists(),
+            ),
+            (
+                "navigators",
+                "Navigators",
+                config.get("navigators", []),
+                Navigator,
+                lambda entity: ProgramNavigator.objects.filter(program=program, navigator=entity).exists(),
+            ),
+        ]
+
+        plan: dict[str, list[tuple[str, str]]] = {}
+        for key, title, item_configs, model, is_linked in specs:
+            if key not in sections:
+                continue
+            items: list[tuple[str, str]] = []
+            for item_config in item_configs:
+                external_name = item_config.get("external_name")
+                if not external_name:
+                    continue
+                entity = model.objects.filter(external_name=external_name).first()
+                if entity is None:
+                    items.append((external_name, "create"))
+                else:
+                    items.append((external_name, "linked" if is_linked(entity) else "link"))
+            plan[title] = items
+
+        return plan
+
+    def _print_reconcile_plan(self, plan: dict[str, list[tuple[str, str]]]) -> None:
+        """Print what reconciling would change, section by section."""
+        markers = {
+            "linked": ("✓", "already linked"),
+            "link": ("+", "link to add"),
+            "create": ("★", "entity to create"),
+        }
+
+        for section, items in plan.items():
+            if not items:
+                continue
+            self.stdout.write(self.style.SUCCESS(f"\n[{section}]"))
+            for external_name, action in items:
+                marker, description = markers[action]
+                line = f"  {marker} {external_name} ({description})"
+                self.stdout.write(line if action == "linked" else self.style.WARNING(line))
+
+    def _next_navigator_order(self, program: Program) -> int:
+        """Return the order value new navigator links should start at, appending after existing ones."""
+        highest = ProgramNavigator.objects.filter(program=program).aggregate(Max("order"))["order__max"]
+        return 0 if highest is None else highest + 1
 
     def _separate_program_fields(self, program_config: dict[str, Any]) -> tuple[dict[str, str], dict[str, Any]]:
         """
@@ -890,7 +1097,9 @@ class Command(BaseCommand):
         translated_fields = Document.objects.translated_fields
         self._bulk_update_entity_translations(document, translations, "document", translated_fields)
 
-    def _import_navigators(self, program: Program, navigators_config: list[dict[str, Any]]) -> None:
+    def _import_navigators(
+        self, program: Program, navigators_config: list[dict[str, Any]], order_offset: int = 0
+    ) -> None:
         """
         Import navigators for a program.
 
@@ -905,6 +1114,9 @@ class Command(BaseCommand):
         Args:
             program: The Program instance to associate navigators with
             navigators_config: List of navigator configurations from JSON
+            order_offset: Starting value for the order of newly created links. Defaults to 0
+                for a fresh import; reconcile passes the next free order so existing links
+                keep their position.
         """
         self.stdout.write(self.style.SUCCESS("\n[Navigators]"))
 
@@ -994,7 +1206,7 @@ class Command(BaseCommand):
                 ProgramNavigator.objects.get_or_create(
                     program=program,
                     navigator=navigator,
-                    defaults={"order": idx},
+                    defaults={"order": order_offset + idx},
                 )
             self.stdout.write(f"  Associated {len(navigators_to_associate)} navigator(s) with program")
 

--- a/programs/management/commands/import_program_config.py
+++ b/programs/management/commands/import_program_config.py
@@ -486,6 +486,11 @@ class Command(BaseCommand):
         Navigators are checked against ProgramNavigator only. A navigator present just in
         the legacy `programs` M2M is invisible to the results endpoint, so it is correctly
         reported as still needing a link.
+
+        A declaration without an external_name raises, matching the validation the import
+        path already applies. Skipping it instead would drop it from the plan, and an empty
+        plan reads as "already up to date" — so a malformed config would report clean and
+        then be recorded as applied without anything having been applied.
         """
         specs = [
             (
@@ -516,10 +521,10 @@ class Command(BaseCommand):
             if key not in sections:
                 continue
             items: list[tuple[str, str]] = []
-            for item_config in item_configs:
+            for i, item_config in enumerate(item_configs):
                 external_name = item_config.get("external_name")
                 if not external_name:
-                    continue
+                    raise CommandError(f"Missing required field 'external_name' in {key}[{i}]")
                 entity = model.objects.filter(external_name=external_name).first()
                 if entity is None:
                     items.append((external_name, "create"))

--- a/programs/management/commands/import_urgent_need_config.py
+++ b/programs/management/commands/import_urgent_need_config.py
@@ -104,9 +104,13 @@ class Command(TranslationImportMixin, BaseCommand):
 
         # --- REAL EXECUTION VALIDATION ---
         if existing_need and not override:
+            # Nothing in the config is applied on this path. Say so plainly rather than
+            # letting a skip read as a completed import.
             self.stdout.write(
                 self.style.WARNING(
-                    f"Urgent Need '{external_name}' already exists (ID: {existing_need.id}). "
+                    f"⊘ Skipped: Urgent Need '{external_name}' already exists (ID: {existing_need.id}). "
+                    f"Nothing in this config was applied — its counties, functions and translations "
+                    f"were not read.\n"
                     f"Use --override to delete and recreate it."
                 )
             )

--- a/programs/management/commands/tests/test_import_all_program_configs.py
+++ b/programs/management/commands/tests/test_import_all_program_configs.py
@@ -9,7 +9,7 @@ from django.db import IntegrityError
 from django.test import TestCase
 
 from programs.management.commands.import_all_program_configs import config_content_hash
-from programs.models import Program, ProgramConfigImport, ProgramCategory, ProgramNavigator
+from programs.models import Navigator, Program, ProgramConfigImport, ProgramCategory, ProgramNavigator
 from screener.models import WhiteLabel
 
 
@@ -365,20 +365,99 @@ class SkippedConfigTrackingTest(TestCase):
 
         self.assertTrue(ProgramConfigImport.objects.filter(filename="existing_program.json").exists())
 
+    def test_dry_run_counts_a_shared_navigator_as_one_entity_and_two_links(self):
+        """
+        Two configs declaring one missing navigator is one entity and two links.
+
+        A dry run applies nothing between configs, so both classify the navigator as missing.
+        Counting declarations would report two entities and no links — wrong in both
+        directions, and wrong in the number a production repair is gated on.
+        """
+        self._write_config_with_navigator()
+        self._create_existing_program()
+        self._write_second_config_sharing_the_navigator()
+
+        output = self._run("--reconcile", "--dry-run")
+
+        self.assertRegex(output, r"Entities to create:\s+1")
+        self.assertRegex(output, r"Links to add:\s+2")
+
+    def test_dry_run_totals_match_the_apply(self):
+        """The gate is only meaningful if applying produces what the dry run predicted."""
+        self._write_config_with_navigator()
+        self._create_existing_program()
+        self._write_second_config_sharing_the_navigator()
+
+        dry_run = self._run("--reconcile", "--dry-run")
+        applied = self._run("--reconcile")
+
+        for expected in (r"Entities to create:\s+1", r"Links to add:\s+2"):
+            self.assertRegex(dry_run, expected)
+            self.assertRegex(applied, expected)
+
+        self.assertEqual(Navigator.objects.filter(external_name="test_navigator").count(), 1)
+        self.assertEqual(ProgramNavigator.objects.filter(navigator__external_name="test_navigator").count(), 2)
+
+    def test_reconcile_skip_advice_does_not_point_back_at_reconcile(self):
+        """
+        A reconcile run skips programs that do not exist, so advising --reconcile is circular.
+
+        The gate lines are printed too, since a run where everything skipped must still show
+        the two totals a repair is approved against rather than omitting them.
+        """
+        output = self._run("--reconcile")
+
+        self.assertRegex(output, r"Skipped:\s+1")
+        self.assertIn("Run without --reconcile to create the missing ones", output)
+        self.assertNotIn("Run with --reconcile to additively apply", output)
+        self.assertRegex(output, r"Links to add:\s+0")
+        self.assertRegex(output, r"Entities to create:\s+0")
+
+    def test_malformed_declaration_fails_instead_of_being_recorded(self):
+        """
+        A config the plan cannot classify counts as Failed, not as already current.
+
+        Before, a navigator missing its external_name dropped out of the plan, the config read
+        as "already up to date", and a tracking row then claimed it had been applied — nothing
+        linked, and the config excluded from the honest accounting the rest of this change adds.
+        """
+        config = dict(self.config)
+        config["navigators"] = [{k: v for k, v in self.NAVIGATOR.items() if k != "external_name"}]
+        self.config_file.write_text(json.dumps(config), encoding="utf-8")
+        program = self._create_existing_program()
+
+        output = self._run("--reconcile")
+
+        self.assertRegex(output, r"Failed:\s+1")
+        self.assertRegex(output, r"Already current:\s+0")
+        self.assertFalse(
+            ProgramConfigImport.objects.filter(filename="existing_program.json").exists(),
+            "A config that failed to reconcile must not be recorded as imported",
+        )
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+
+    NAVIGATOR = {
+        "external_name": "test_navigator",
+        "name": "Test Navigator",
+        "email": "navigator@example.com",
+        "description": "Helps people apply",
+        "assistance_link": "https://example.com/help",
+    }
+
     def _write_config_with_navigator(self, with_document: bool = False):
         config = dict(self.config)
-        config["navigators"] = [
-            {
-                "external_name": "test_navigator",
-                "name": "Test Navigator",
-                "email": "navigator@example.com",
-                "description": "Helps people apply",
-                "assistance_link": "https://example.com/help",
-            }
-        ]
+        config["navigators"] = [self.NAVIGATOR]
         if with_document:
             config["documents"] = [{"external_name": "test_document", "text": "Bring photo ID"}]
         self.config_file.write_text(json.dumps(config), encoding="utf-8")
+
+    def _write_second_config_sharing_the_navigator(self, program_name: str = "second_program"):
+        """A second existing program whose config declares the same navigator."""
+        config = dict(self.config)
+        config["program"] = {"name_abbreviated": program_name}
+        config["navigators"] = [self.NAVIGATOR]
+        (self.data_dir / f"{program_name}.json").write_text(json.dumps(config), encoding="utf-8")
+        return Program.objects.new_program(white_label="co", name_abbreviated=program_name)
 
     def _pending_filenames(self):
         command = self._command_class()()

--- a/programs/management/commands/tests/test_import_all_program_configs.py
+++ b/programs/management/commands/tests/test_import_all_program_configs.py
@@ -263,7 +263,7 @@ class SkippedConfigTrackingTest(TestCase):
 
         self.assertIn("Skipped", output)
         self.assertIn("still pending", output)
-        self.assertIn("Successful: 0", output)
+        self.assertRegex(output, r"Successful:\s+0")
         self.assertNotIn("recorded as imported", output)
 
     def test_successful_import_records_a_content_hash(self):

--- a/programs/management/commands/tests/test_import_all_program_configs.py
+++ b/programs/management/commands/tests/test_import_all_program_configs.py
@@ -220,6 +220,18 @@ class SkippedConfigTrackingTest(TestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
+        # Any test here that imports a config for a program that does not yet exist will
+        # create one, and creating a program translates its fields. Translate() reads
+        # GOOGLE_APPLICATION_CREDENTIALS at construction and does not consult
+        # ENABLE_GOOGLE_INTEGRATIONS, so without this the tests reach the real API where
+        # credentials exist and fail outright in CI, where they do not.
+        translate_patcher = patch("programs.management.commands.import_program_config.Translate")
+        translate = translate_patcher.start()
+        translate.return_value.bulk_translate.side_effect = lambda langs, texts: {
+            text: {lang: text for lang in langs} for text in texts
+        }
+        self.addCleanup(translate_patcher.stop)
+
     @staticmethod
     def _command_class():
         from programs.management.commands.import_all_program_configs import Command
@@ -301,12 +313,6 @@ class SkippedConfigTrackingTest(TestCase):
         End-to-end repair: a program that exists but never had its config applied gets
         its navigators linked by a --reconcile run, and only then is it recorded.
         """
-        translate = patch("programs.management.commands.import_program_config.Translate").start()
-        translate.return_value.bulk_translate.side_effect = lambda langs, texts: {
-            text: {lang: text for lang in langs} for text in texts
-        }
-        self.addCleanup(patch.stopall)
-
         with_navigator = dict(self.config)
         with_navigator["navigators"] = [
             {

--- a/programs/management/commands/tests/test_import_all_program_configs.py
+++ b/programs/management/commands/tests/test_import_all_program_configs.py
@@ -8,7 +8,8 @@ from django.core.management import call_command
 from django.db import IntegrityError
 from django.test import TestCase
 
-from programs.models import Program, ProgramConfigImport, ProgramCategory
+from programs.management.commands.import_all_program_configs import config_content_hash
+from programs.models import Program, ProgramConfigImport, ProgramCategory, ProgramNavigator
 from screener.models import WhiteLabel
 
 
@@ -185,6 +186,160 @@ class ImportAllProgramConfigsCommandTest(TestCase):
 
         output = self.err.getvalue()
         self.assertIn("File not found", output)
+
+
+class SkippedConfigTrackingTest(TestCase):
+    """
+    A skipped config must stay pending.
+
+    Recording a skip as an import is what permanently excluded configs from future runs,
+    so their navigators, documents and warning messages were never applied. These tests
+    pin the corrected behaviour: nothing applied means nothing recorded.
+    """
+
+    def setUp(self):
+        self.out = StringIO()
+        self.err = StringIO()
+        ProgramConfigImport.objects.all().delete()
+        WhiteLabel.objects.get_or_create(code="co", defaults={"name": "Colorado", "state_code": "CO"})
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.data_dir = Path(self.temp_dir.name) / "data"
+        self.data_dir.mkdir()
+
+        self.config = {
+            "white_label": {"code": "co"},
+            "program_category": {"external_name": "test_category", "icon": "icon", "name": "Test Category"},
+            "program": {"name_abbreviated": "existing_program"},
+        }
+        self.config_file = self.data_dir / "existing_program.json"
+        self.config_file.write_text(json.dumps(self.config), encoding="utf-8")
+
+        patcher = patch.object(self._command_class(), "DATA_DIR", self.data_dir)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @staticmethod
+    def _command_class():
+        from programs.management.commands.import_all_program_configs import Command
+
+        return Command
+
+    def _create_existing_program(self):
+        return Program.objects.new_program(white_label="co", name_abbreviated="existing_program")
+
+    def _run(self, *args):
+        out = StringIO()
+        call_command("import_all_program_configs", *args, stdout=out, stderr=self.err)
+        return out.getvalue()
+
+    def test_skipped_config_is_not_recorded_as_imported(self):
+        """The config a skip touched must not gain a tracking row."""
+        self._create_existing_program()
+
+        self._run()
+
+        self.assertFalse(
+            ProgramConfigImport.objects.filter(filename="existing_program.json").exists(),
+            "A skipped config must not be recorded as imported",
+        )
+
+    def test_skipped_config_stays_pending_on_the_next_run(self):
+        """The exclusion must not be permanent — a skipped config comes back as pending."""
+        self._create_existing_program()
+        self._run()
+
+        output = self._run("--list")
+
+        self.assertIn("existing_program.json", output)
+        self.assertIn("Status: pending", output)
+
+    def test_skip_is_reported_distinctly_from_success(self):
+        """A run where everything skipped must not read as a clean import."""
+        self._create_existing_program()
+
+        output = self._run()
+
+        self.assertIn("Skipped", output)
+        self.assertIn("still pending", output)
+        self.assertIn("Successful: 0", output)
+        self.assertNotIn("recorded as imported", output)
+
+    def test_successful_import_records_a_content_hash(self):
+        output = self._run()
+
+        record = ProgramConfigImport.objects.get(filename="existing_program.json")
+        self.assertEqual(record.content_hash, config_content_hash(self.config_file))
+        self.assertIn("Imported and recorded", output)
+
+    def test_edited_config_becomes_pending_again(self):
+        """A tracking row is a claim about specific content, so edits re-open the config."""
+        self._run()
+        self.assertFalse(self._pending_filenames())
+
+        edited = dict(self.config)
+        edited["documents"] = [{"external_name": "new_document", "text": "Bring photo ID"}]
+        self.config_file.write_text(json.dumps(edited), encoding="utf-8")
+
+        self.assertIn("existing_program.json", self._pending_filenames())
+        self.assertIn("file edited since it was imported", self._run("--list"))
+
+    def test_legacy_record_without_a_hash_is_treated_as_applied(self):
+        """Rows that predate hashing must not all re-open at once."""
+        ProgramConfigImport.objects.create(
+            filename="existing_program.json",
+            program_name="existing_program",
+            white_label_code="co",
+            content_hash="",
+        )
+
+        self.assertEqual(self._pending_filenames(), [])
+
+    def test_reconcile_repairs_a_config_that_was_skipped(self):
+        """
+        End-to-end repair: a program that exists but never had its config applied gets
+        its navigators linked by a --reconcile run, and only then is it recorded.
+        """
+        translate = patch("programs.management.commands.import_program_config.Translate").start()
+        translate.return_value.bulk_translate.side_effect = lambda langs, texts: {
+            text: {lang: text for lang in langs} for text in texts
+        }
+        self.addCleanup(patch.stopall)
+
+        with_navigator = dict(self.config)
+        with_navigator["navigators"] = [
+            {
+                "external_name": "test_navigator",
+                "name": "Test Navigator",
+                "email": "navigator@example.com",
+                "description": "Helps people apply",
+                "assistance_link": "https://example.com/help",
+            }
+        ]
+        self.config_file.write_text(json.dumps(with_navigator), encoding="utf-8")
+
+        program = self._create_existing_program()
+        self._run()
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+
+        output = self._run("--reconcile")
+
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 1)
+        self.assertIn("Reconciled and recorded", output)
+        self.assertTrue(ProgramConfigImport.objects.filter(filename="existing_program.json").exists())
+
+    def test_reconcile_dry_run_records_nothing(self):
+        self._create_existing_program()
+
+        self._run("--reconcile", "--dry-run")
+
+        self.assertFalse(ProgramConfigImport.objects.filter(filename="existing_program.json").exists())
+
+    def _pending_filenames(self):
+        command = self._command_class()()
+        records = command._get_import_records()
+        return [f.name for f in self.data_dir.glob("*.json") if command._is_pending(f, records)]
 
 
 class ProgramConfigImportModelTest(TestCase):

--- a/programs/management/commands/tests/test_import_all_program_configs.py
+++ b/programs/management/commands/tests/test_import_all_program_configs.py
@@ -313,17 +313,7 @@ class SkippedConfigTrackingTest(TestCase):
         End-to-end repair: a program that exists but never had its config applied gets
         its navigators linked by a --reconcile run, and only then is it recorded.
         """
-        with_navigator = dict(self.config)
-        with_navigator["navigators"] = [
-            {
-                "external_name": "test_navigator",
-                "name": "Test Navigator",
-                "email": "navigator@example.com",
-                "description": "Helps people apply",
-                "assistance_link": "https://example.com/help",
-            }
-        ]
-        self.config_file.write_text(json.dumps(with_navigator), encoding="utf-8")
+        self._write_config_with_navigator()
 
         program = self._create_existing_program()
         self._run()
@@ -341,6 +331,54 @@ class SkippedConfigTrackingTest(TestCase):
         self._run("--reconcile", "--dry-run")
 
         self.assertFalse(ProgramConfigImport.objects.filter(filename="existing_program.json").exists())
+
+    def test_partial_reconcile_is_not_recorded_as_imported(self):
+        """
+        --only applies part of a config, so recording it would hide the rest.
+
+        A hash covering the whole file is a claim that the whole file was applied. Writing
+        one after a sectional pass is the same defect as recording a skip: the sections that
+        were never applied stop showing up as outstanding work.
+        """
+        self._write_config_with_navigator(with_document=True)
+        program = self._create_existing_program()
+
+        output = self._run("--reconcile", "--only", "navigators")
+
+        # The navigators section really was applied, and the documents section really wasn't.
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 1)
+        self.assertEqual(program.documents.count(), 0)
+
+        self.assertFalse(
+            ProgramConfigImport.objects.filter(filename="existing_program.json").exists(),
+            "A partial (--only) pass must not record the config as imported",
+        )
+        self.assertIn("existing_program.json", self._pending_filenames())
+        self.assertIn("no config is recorded as imported", output)
+
+    def test_reconcile_naming_every_section_is_a_full_pass(self):
+        """--only listing all sections applies the whole config, so it records normally."""
+        self._write_config_with_navigator(with_document=True)
+        self._create_existing_program()
+
+        self._run("--reconcile", "--only", "warning_messages", "--only", "documents", "--only", "navigators")
+
+        self.assertTrue(ProgramConfigImport.objects.filter(filename="existing_program.json").exists())
+
+    def _write_config_with_navigator(self, with_document: bool = False):
+        config = dict(self.config)
+        config["navigators"] = [
+            {
+                "external_name": "test_navigator",
+                "name": "Test Navigator",
+                "email": "navigator@example.com",
+                "description": "Helps people apply",
+                "assistance_link": "https://example.com/help",
+            }
+        ]
+        if with_document:
+            config["documents"] = [{"external_name": "test_document", "text": "Bring photo ID"}]
+        self.config_file.write_text(json.dumps(config), encoding="utf-8")
 
     def _pending_filenames(self):
         command = self._command_class()()

--- a/programs/management/commands/tests/test_import_program_config.py
+++ b/programs/management/commands/tests/test_import_program_config.py
@@ -653,6 +653,30 @@ class ReconcileProgramConfigTestCase(TransactionTestCase):
         self.assertFalse(Program.objects.filter(name_abbreviated="test_program").exists())
         self.assertIn("does not exist", out.getvalue())
 
+    def test_reconcile_rejects_a_declaration_without_an_external_name(self):
+        """
+        A malformed declaration must fail loudly, not vanish from the plan.
+
+        Dropping it silently leaves an empty plan, which reads as "already up to date" — so
+        the config would report clean, apply nothing, and then be recorded as applied. That
+        is the defect this whole change exists to remove, so the plan validates the same
+        fields the import path does.
+        """
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+        program = Program.objects.get(name_abbreviated="test_program")
+
+        malformed = copy.deepcopy(self.base_config)
+        del malformed["navigators"][0]["external_name"]
+
+        with self.assertRaises(CommandError) as raised:
+            call_command("import_program_config", self._create_temp_config(malformed), "--reconcile", stdout=StringIO())
+
+        self.assertIn("external_name", str(raised.exception))
+        self.assertIn("navigators[0]", str(raised.exception))
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+
     def test_reconcile_and_override_are_mutually_exclusive(self):
         with self.assertRaises(CommandError):
             call_command(

--- a/programs/management/commands/tests/test_import_program_config.py
+++ b/programs/management/commands/tests/test_import_program_config.py
@@ -425,6 +425,7 @@ class ImportProgramConfigTestCase(TransactionTestCase):
         finally:
             Path(config_file).unlink()
 
+
 class ReconcileProgramConfigTestCase(TransactionTestCase):
     """
     Tests for `import_program_config --reconcile` and the --override delete guard.
@@ -498,6 +499,93 @@ class ReconcileProgramConfigTestCase(TransactionTestCase):
 
     def _english(self, translation: Translation) -> str:
         return Translation.objects.language(settings.LANGUAGE_CODE).get(pk=translation.pk).text
+
+    def _require_suffixed_counties(self) -> None:
+        """Make this white label's screener convention the suffixed form."""
+        Configuration.objects.create(
+            name="counties_by_zipcode",
+            white_label=self.white_label,
+            data={"80202": {"Denver County": "Denver County"}},
+            active=True,
+        )
+
+    def _config_with_bad_county(self) -> dict:
+        config = copy.deepcopy(self.base_config)
+        config["navigators"][0]["counties"] = ["Denver"]
+        return config
+
+    def test_reconcile_validates_navigator_counties(self):
+        """
+        Reconcile creates navigators, and creating one writes its counties, so the county
+        guard has to cover this path too — otherwise a repair pass is a way to reintroduce
+        the exact mismatch the guard exists to block.
+        """
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+        program = Program.objects.get(name_abbreviated="test_program")
+        self._require_suffixed_counties()
+
+        with self.assertRaises(CommandError) as raised:
+            call_command(
+                "import_program_config",
+                self._create_temp_config(self._config_with_bad_county()),
+                "--reconcile",
+                stdout=StringIO(),
+            )
+
+        self.assertIn("did you mean 'Denver County'", str(raised.exception))
+        self.assertFalse(Navigator.objects.filter(external_name="test_navigator").exists())
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+
+    def test_reconcile_only_documents_does_not_validate_navigator_counties(self):
+        """
+        The guard is scoped to what a run will write. A documents-only pass never touches
+        navigators, so it must not be blocked by a navigator's county names.
+        """
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+        program = Program.objects.get(name_abbreviated="test_program")
+        self._require_suffixed_counties()
+
+        config = self._config_with_bad_county()
+        config["documents"] = [{"external_name": "test_document", "text": "Bring photo ID"}]
+
+        call_command(
+            "import_program_config",
+            self._create_temp_config(config),
+            "--reconcile",
+            "--only",
+            "documents",
+            stdout=StringIO(),
+        )
+
+        self.assertEqual(program.documents.count(), 1)
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+
+    def test_override_skips_county_validation_for_a_navigator_it_will_not_recreate(self):
+        """
+        County validation is scoped to navigators a run will recreate, and that scoping has to
+        read the same relation the delete guard does. A navigator shared only through
+        ProgramNavigator is kept, so its counties are never rewritten — validating them would
+        block an override over a field this run does not touch.
+        """
+        call_command("import_program_config", self._create_temp_config(self.base_config), stdout=StringIO())
+        navigator = Navigator.objects.get(external_name="test_navigator")
+
+        other_program = Program.objects.new_program(white_label="test_wl", name_abbreviated="other_program")
+        ProgramNavigator.objects.create(program=other_program, navigator=navigator, order=0)
+
+        self._require_suffixed_counties()
+
+        out = StringIO()
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_with_bad_county()), "--override", stdout=out
+        )
+
+        self.assertIn("Keeping navigator", out.getvalue())
+        self.assertTrue(Navigator.objects.filter(external_name="test_navigator").exists())
 
     def test_reconcile_creates_missing_navigator_link(self):
         """A program imported without its navigators gets them linked by a reconcile pass."""

--- a/programs/management/commands/tests/test_import_program_config.py
+++ b/programs/management/commands/tests/test_import_program_config.py
@@ -1,16 +1,19 @@
+import copy
 import json
 import tempfile
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase, TransactionTestCase
 
-from programs.models import Program, ProgramCategory, Navigator, County
+from programs.models import County, Navigator, Program, ProgramCategory, ProgramNavigator
 from screener.models import WhiteLabel
 from configuration.models import Configuration
+from translations.models import Translation
 
 
 class ImportProgramConfigTestCase(TransactionTestCase):
@@ -176,9 +179,10 @@ class ImportProgramConfigTestCase(TransactionTestCase):
         call_command("import_program_config", config_file, stdout=out)
         output = out.getvalue()
 
-        # Verify warning message
+        # Verify warning message offers both recovery paths
         self.assertIn("already exists", output)
-        self.assertIn("Use --override", output)
+        self.assertIn("--reconcile", output)
+        self.assertIn("--override", output)
 
         # Verify original program unchanged
         program = Program.objects.get(name_abbreviated="test_program")
@@ -420,3 +424,265 @@ class ImportProgramConfigTestCase(TransactionTestCase):
             self.assertIn("must be a JSON object", str(ctx.exception))
         finally:
             Path(config_file).unlink()
+
+class ReconcileProgramConfigTestCase(TransactionTestCase):
+    """
+    Tests for `import_program_config --reconcile` and the --override delete guard.
+
+    Reconcile repairs programs whose config was recorded as imported but never actually
+    applied. It has to be strictly additive: navigators created or hand-edited in the
+    admin, and any ordering curated there, must survive it untouched.
+    """
+
+    def setUp(self):
+        self.white_label = WhiteLabel.objects.create(code="test_wl", name="Test White Label")
+
+        self.base_config = {
+            "white_label": {"code": "test_wl"},
+            "program_category": {
+                "external_name": "test_category",
+                "icon": "test_icon",
+                "name": "Test Category",
+                "description": "Test category description",
+            },
+            "program": {
+                "name_abbreviated": "test_program",
+                "external_name": "test_program",
+                "name": "Test Program Name",
+                "description": "Test program description",
+                "active": True,
+            },
+            "navigators": [
+                {
+                    "external_name": "test_navigator",
+                    "name": "Test Navigator",
+                    "email": "navigator@example.com",
+                    "description": "Helps people apply",
+                    "assistance_link": "https://example.com/help",
+                    "counties": ["Denver County"],
+                }
+            ],
+        }
+
+        self.translate_patcher = patch("programs.management.commands.import_program_config.Translate")
+        mock_instance = self.translate_patcher.start().return_value
+        mock_instance.bulk_translate.side_effect = lambda langs, texts: {
+            text: {lang: f"{text} (translated to {lang})" for lang in langs} for text in texts
+        }
+        self.addCleanup(self.translate_patcher.stop)
+
+        self._temp_files: list[str] = []
+        self.addCleanup(self._cleanup_temp_files)
+
+    def _cleanup_temp_files(self):
+        for path in self._temp_files:
+            Path(path).unlink(missing_ok=True)
+
+    def _create_temp_config(self, config: dict) -> str:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config, f)
+            self._temp_files.append(f.name)
+            return f.name
+
+    def _config_without_navigators(self) -> dict:
+        config = copy.deepcopy(self.base_config)
+        config.pop("navigators")
+        return config
+
+    def _make_admin_navigator(self, external_name: str) -> Navigator:
+        """Stand in for a navigator someone created by hand in the admin portal."""
+        navigator = Navigator.objects.new_navigator(white_label="test_wl", name=external_name, phone_number=None)
+        navigator.external_name = external_name
+        navigator.save()
+        return navigator
+
+    def _english(self, translation: Translation) -> str:
+        return Translation.objects.language(settings.LANGUAGE_CODE).get(pk=translation.pk).text
+
+    def test_reconcile_creates_missing_navigator_link(self):
+        """A program imported without its navigators gets them linked by a reconcile pass."""
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+
+        program = Program.objects.get(name_abbreviated="test_program")
+        original_id = program.id
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+
+        out = StringIO()
+        call_command("import_program_config", self._create_temp_config(self.base_config), "--reconcile", stdout=out)
+
+        links = ProgramNavigator.objects.filter(program=program)
+        self.assertEqual(links.count(), 1)
+        self.assertEqual(links.first().navigator.external_name, "test_navigator")
+
+        # The program itself is reused, not recreated
+        self.assertEqual(Program.objects.get(name_abbreviated="test_program").id, original_id)
+        self.assertIn("Reconciled", out.getvalue())
+
+    def test_reconcile_preserves_navigator_absent_from_config(self):
+        """An admin-created navigator is neither deleted nor unlinked by a reconcile pass."""
+        call_command("import_program_config", self._create_temp_config(self.base_config), stdout=StringIO())
+        program = Program.objects.get(name_abbreviated="test_program")
+
+        admin_navigator = self._make_admin_navigator("admin_only_navigator")
+        ProgramNavigator.objects.create(program=program, navigator=admin_navigator, order=1000)
+
+        call_command(
+            "import_program_config", self._create_temp_config(self.base_config), "--reconcile", stdout=StringIO()
+        )
+
+        self.assertTrue(Navigator.objects.filter(external_name="admin_only_navigator").exists())
+        self.assertTrue(ProgramNavigator.objects.filter(program=program, navigator=admin_navigator).exists())
+
+    def test_reconcile_does_not_overwrite_existing_navigator_fields(self):
+        """A hand-edited navigator name survives a reconcile pass that declares a different one."""
+        call_command("import_program_config", self._create_temp_config(self.base_config), stdout=StringIO())
+
+        navigator = Navigator.objects.get(external_name="test_navigator")
+        Translation.objects.edit_translation_by_id(
+            navigator.name.id, settings.LANGUAGE_CODE, "Hand Edited In Admin", manual=True
+        )
+
+        renamed = copy.deepcopy(self.base_config)
+        renamed["navigators"][0]["name"] = "Name From Config"
+        call_command("import_program_config", self._create_temp_config(renamed), "--reconcile", stdout=StringIO())
+
+        navigator.refresh_from_db()
+        self.assertEqual(self._english(navigator.name), "Hand Edited In Admin")
+
+    def test_reconcile_appends_new_links_after_existing_ones(self):
+        """New links go after existing ones so admin-curated ordering is not reshuffled."""
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+        program = Program.objects.get(name_abbreviated="test_program")
+
+        admin_navigator = self._make_admin_navigator("admin_only_navigator")
+        ProgramNavigator.objects.create(program=program, navigator=admin_navigator, order=5)
+
+        call_command(
+            "import_program_config", self._create_temp_config(self.base_config), "--reconcile", stdout=StringIO()
+        )
+
+        config_link = ProgramNavigator.objects.get(program=program, navigator__external_name="test_navigator")
+        self.assertGreater(config_link.order, 5)
+
+    def test_reconcile_dry_run_reports_without_applying(self):
+        """A reconcile dry run names what it would add and changes nothing."""
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+        program = Program.objects.get(name_abbreviated="test_program")
+
+        out = StringIO()
+        call_command(
+            "import_program_config",
+            self._create_temp_config(self.base_config),
+            "--reconcile",
+            "--dry-run",
+            stdout=out,
+        )
+        output = out.getvalue()
+
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 0)
+        self.assertIn("test_navigator", output)
+        self.assertIn("Dry run", output)
+
+    def test_reconcile_reports_entities_it_would_create(self):
+        """A navigator that does not exist yet is flagged distinctly from one that just needs a link."""
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+
+        out = StringIO()
+        call_command(
+            "import_program_config",
+            self._create_temp_config(self.base_config),
+            "--reconcile",
+            "--dry-run",
+            stdout=out,
+        )
+
+        self.assertIn("entity to create", out.getvalue())
+
+    def test_reconcile_only_limits_sections(self):
+        """--only navigators leaves the config's documents alone."""
+        with_documents = copy.deepcopy(self._config_without_navigators())
+        with_documents["documents"] = [{"external_name": "test_document", "text": "Bring photo ID"}]
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+
+        both = copy.deepcopy(self.base_config)
+        both["documents"] = with_documents["documents"]
+
+        program = Program.objects.get(name_abbreviated="test_program")
+        call_command(
+            "import_program_config",
+            self._create_temp_config(both),
+            "--reconcile",
+            "--only",
+            "navigators",
+            stdout=StringIO(),
+        )
+
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 1)
+        self.assertEqual(program.documents.count(), 0)
+
+    def test_reconcile_is_idempotent(self):
+        """Running reconcile twice does not duplicate links."""
+        call_command(
+            "import_program_config", self._create_temp_config(self._config_without_navigators()), stdout=StringIO()
+        )
+        config_file = self._create_temp_config(self.base_config)
+
+        call_command("import_program_config", config_file, "--reconcile", stdout=StringIO())
+        out = StringIO()
+        call_command("import_program_config", config_file, "--reconcile", stdout=out)
+
+        program = Program.objects.get(name_abbreviated="test_program")
+        self.assertEqual(ProgramNavigator.objects.filter(program=program).count(), 1)
+        self.assertIn("Already up to date", out.getvalue())
+
+    def test_reconcile_refuses_to_create_a_missing_program(self):
+        """Reconcile repairs existing programs only; it never creates one."""
+        out = StringIO()
+        call_command("import_program_config", self._create_temp_config(self.base_config), "--reconcile", stdout=out)
+
+        self.assertFalse(Program.objects.filter(name_abbreviated="test_program").exists())
+        self.assertIn("does not exist", out.getvalue())
+
+    def test_reconcile_and_override_are_mutually_exclusive(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "import_program_config",
+                self._create_temp_config(self.base_config),
+                "--reconcile",
+                "--override",
+                stdout=StringIO(),
+            )
+
+    def test_override_keeps_navigator_shared_through_program_navigator(self):
+        """
+        The --override delete guard has to read the relation the importer actually writes.
+
+        The importer and the admin both populate ProgramNavigator, never the legacy
+        `programs` M2M, so a guard that checks only the legacy relation sees every shared
+        navigator as unshared and deletes it.
+        """
+        call_command("import_program_config", self._create_temp_config(self.base_config), stdout=StringIO())
+        navigator = Navigator.objects.get(external_name="test_navigator")
+
+        other_program = Program.objects.new_program(white_label="test_wl", name_abbreviated="other_program")
+        ProgramNavigator.objects.create(program=other_program, navigator=navigator, order=0)
+
+        out = StringIO()
+        call_command("import_program_config", self._create_temp_config(self.base_config), "--override", stdout=out)
+
+        self.assertTrue(
+            Navigator.objects.filter(external_name="test_navigator").exists(),
+            "A navigator shared with another program must survive --override",
+        )
+        self.assertTrue(ProgramNavigator.objects.filter(program=other_program, navigator=navigator).exists())
+        self.assertIn("Keeping navigator", out.getvalue())

--- a/programs/migrations/0166_programconfigimport_content_hash.py
+++ b/programs/migrations/0166_programconfigimport_content_hash.py
@@ -1,0 +1,64 @@
+import hashlib
+from pathlib import Path
+
+from django.db import migrations, models
+
+# Kept in sync with `config_content_hash` in
+# programs/management/commands/import_all_program_configs.py.
+# Duplicated deliberately: migrations must stay self-contained.
+DATA_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "management"
+    / "commands"
+    / "import_program_config_data"
+    / "data"
+)
+
+
+def backfill_content_hashes(apps, schema_editor):
+    """
+    Stamp existing tracking rows with the current hash of their config file.
+
+    An empty hash means "applied before hashing existed" and is treated as
+    up to date, so this backfill is what makes future edits to those configs
+    detectable. Rows whose file no longer exists keep an empty hash.
+    """
+    ProgramConfigImport = apps.get_model("programs", "ProgramConfigImport")
+
+    updated = []
+    for record in ProgramConfigImport.objects.all():
+        config_file = DATA_DIR / record.filename
+        if not config_file.is_file():
+            continue
+        record.content_hash = hashlib.sha256(config_file.read_bytes()).hexdigest()
+        updated.append(record)
+
+    if updated:
+        ProgramConfigImport.objects.bulk_update(updated, ["content_hash"])
+        print(f"✓ Backfilled content_hash for {len(updated)} program config import record(s)")
+
+
+def clear_content_hashes(apps, schema_editor):
+    ProgramConfigImport = apps.get_model("programs", "ProgramConfigImport")
+    ProgramConfigImport.objects.update(content_hash="")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("programs", "0165_add_nc_homeless_and_health_care_urgent_need_types"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="programconfigimport",
+            name="content_hash",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="SHA-256 of the config file when it was applied. A file whose hash no longer "
+                "matches is treated as pending again, so edits to a config are picked up on the next run.",
+                max_length=64,
+            ),
+        ),
+        migrations.RunPython(backfill_content_hashes, clear_content_hashes),
+    ]

--- a/programs/models.py
+++ b/programs/models.py
@@ -1945,6 +1945,13 @@ class ProgramConfigImport(models.Model):
         auto_now_add=True,
         help_text="When this configuration was imported",
     )
+    content_hash = models.CharField(
+        max_length=64,
+        blank=True,
+        default="",
+        help_text="SHA-256 of the config file when it was applied. A file whose hash no longer matches "
+        "is treated as pending again, so edits to a config are picked up on the next run.",
+    )
 
     class Meta:
         ordering = ["-imported_at"]


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes MFB-1585
- Related PR: n/a

`import_all_program_configs` recorded a config as successfully imported even when the underlying
import was **skipped**. Because the pending-file check keys off that record, those configs were
permanently excluded from every future run — their navigators, documents and warning messages were
never read.

Net effect in production: **76 navigator→program links were never created, across 39 programs in 7
white labels.** Those navigators exist as rows with correct names, phones and counties, but are
attached to no program, so they can never render in the "Get Help Applying" section of a results
card. WA is worst hit: 26 orphaned navigators against 2 working ones.

> The ticket says 75 links across 38 programs. Audited against live production, it is 76 across 39
> — see [Environment audit](#environment-audit) for why the ticket's own query cannot find the
> extra one.

`_import_config` returns `"skipped"` before `call_command("import_program_config", ...)` is ever
reached, so nothing in the config is processed. The orchestrator then wrote a tracking row anyway.
The command is explicitly modelled on Django migrations but inverted the core guarantee: a
migration that skips does not mark itself applied.

A second, latent defect is fixed here too. The `--override` delete guard read
`Navigator.programs` — the legacy M2M that nothing on the import path populates — so it asked an
unpopulated relation "is this navigator shared?" and fell through to `delete()`. Seven navigators
are declared by more than one config (`wa_211` × 5, `get_covered_illinois` × 3, and five others);
`--override` on any one of their programs would have deleted the navigator outright and
cascade-removed every link. This is currently masked only because the legacy table still holds rows
from migration `0126`, and would have fired as soon as its CONTRACT phase emptied it.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

**`import_all_program_configs.py`**

- A skipped config no longer gets a `ProgramConfigImport` row. Nothing applied means nothing
  recorded, so the config stays pending instead of becoming permanently unreachable.
- Skips are reported distinctly from successes in the run summary and in `--list`, so a run where
  every config skipped no longer reads as clean. The summary names the remedy that actually applies:
  the two modes skip for opposite reasons — a plain run skips programs that already exist, a
  reconcile run skips programs that don't — so a reconcile run points at running *without*
  `--reconcile` rather than circularly back at itself.
- The summary counts configs that actually changed separately from those already current, and
  reports the two totals a reviewer gates a production repair on: **links to add** and **entities
  to create**. The entity count is highlighted when non-zero, since an unexpected entity creation
  is the signal to stop before applying. The orchestrator builds the reconcile plan itself for
  this — a read-only classification, so it costs a few queries and keeps the count honest rather
  than treating every processed config as a change. Both lines print for every reconcile run,
  including one where every config skipped, so the two numbers the repair is approved against are
  never simply absent from the output.
- **The two totals mean the same thing in a dry run as in an apply.** Counted naively they did not.
  An entity that has to be created also gets a link, so it counts towards both totals — otherwise
  `Links to add` under-reported. And entities are accumulated by identity rather than summed per
  config, because one entity is commonly declared by several configs (`wa_211` by five) and a dry
  run classifies it as missing every time, having applied nothing in between; an apply run would
  create it once and report the rest as links. A shared missing navigator across two configs now
  reports `1` entity and `2` links in both modes, where before it reported `2` and `0`. Immaterial
  to this repair, where the gate is `Entities to create: 0` — but it is the number the gate is
  defined on, so it should mean what it says.
- Tracking rows now store a hash of the config file. Editing a config re-opens it as pending on the
  next run — the Django-migration semantic the command was reaching for. Recording uses
  `update_or_create` so the hash refreshes on re-apply.
- New `--reconcile` flag: additively applies configs to programs that already exist. New `--only`
  flag limits a reconcile pass to given sections (`warning_messages`, `documents`, `navigators`),
  which is what makes a staged production repair possible.
- A `--only` pass records nothing. A content hash covers the whole file, so stamping one after a
  sectional apply would be the same defect as recording a skip — it would claim the documents and
  warning messages were applied when they were not. Naming every section explicitly still counts as
  a full pass and records normally. Since `--reconcile` considers every config regardless of
  tracking state, recording nothing costs a partial pass nothing.
- A reconcile run refuses to create a program that doesn't exist, so a repair pass can't quietly
  introduce programs nobody asked for.

**`import_program_config.py`**

- New `--reconcile` / `--only` flags. Reconcile is strictly additive by construction: it creates
  missing entities and missing links only. It never updates an existing entity's fields, never
  removes a link absent from the config, and never touches program fields, category or
  translations. Mutually exclusive with `--override`.
- `--reconcile --dry-run` prints a per-section plan classifying every declared entity as
  `already linked`, `link to add`, or `entity to create`. This is the review gate for the
  production repair — an unexpected `entity to create` line is a stop signal.
- The plan validates `external_name` on every declaration, the same field the import path already
  requires, and raises rather than skipping a declaration that lacks it. Skipping would drop it
  from the plan, and an empty plan reads as "already up to date" — so a malformed config would have
  reported clean, applied nothing, and then been recorded as applied. Through the orchestrator it
  now counts as `Failed`, which the deployment gate already checks.
- **Delete guard fixed.** It now treats a navigator as shared if it is linked through *either*
  `programs_ordered` (the `ProgramNavigator` table the results endpoint actually reads) or the
  legacy `programs` M2M. Both are checked deliberately while migration `0126`'s EXPAND phase is
  live.
- New navigator links append after `max(order)` rather than starting at 0, so reconciling never
  reshuffles an ordering someone set in the admin.
- Extracted `_warning_message_configs()`, which de-duplicates the singular/plural warning-message
  handling now that both the import and reconcile paths need it.

**`import_urgent_need_config.py`**

- Skip message now states plainly that nothing in the config was applied. No reconcile mode here on
  purpose: an urgent need's counties and functions are its own attributes rather than shared links,
  so "reconcile" would mean overwriting admin edits — the opposite of the goal.

**Model + migration**

- `ProgramConfigImport.content_hash`, with migration `0166` backfilling existing rows so that
  deploying this doesn't re-open all 123 configs at once.

**Tests** — 21 new regression tests:

- A skipped config gains no tracking row, and is still pending on the next run.
- A run where everything skipped does not read as a successful import.
- Reconcile creates the missing navigator link on an existing program, and is idempotent.
- Reconcile preserves a navigator that exists only in the admin and is absent from the config.
- Reconcile does not overwrite a hand-edited navigator name.
- Reconcile appends after existing links rather than reshuffling admin-curated order.
- Reconcile dry run reports without applying and records nothing.
- `--only navigators` leaves the config's documents alone.
- `--override` keeps a navigator shared with another program through `ProgramNavigator`.
- An edited config becomes pending again; a legacy row without a hash does not.
- A `--only navigators` pass applies the navigators, leaves the documents alone, records no tracking
  row and leaves the config pending.
- A `--only` pass naming all three sections is treated as a full pass and does record.
- One navigator declared by two configs and missing from the database counts as one entity and two
  links, not two entities and no links.
- The dry-run totals equal the apply's totals for that same shared navigator, and the apply really
  does produce one `Navigator` row and two `ProgramNavigator` rows.
- A reconcile run's skip advice points away from `--reconcile`, and still prints both gate lines.
- A declaration missing its `external_name` raises instead of vanishing from the plan.
- Through the orchestrator that config counts as `Failed`, links nothing, and is not recorded.

## Testing

<!-- Steps needed to test this PR locally -->

- **Migrations to run:** `python manage.py migrate programs 0166`. Adds `content_hash` and
  backfills it from the current config files. Reversible.
- **Configuration updates needed:** none.
- **Environment variables/settings to add:** none.
- **Manual testing steps:**

```bash
# Full suite for the touched commands (48 tests) and the whole programs app (2629 tests)
pytest programs/management/commands/tests/ -q
pytest programs/ -q

# Confirm the delete-guard test actually catches the bug: change the navigator tuple in
# _delete_program_and_related from ("programs_ordered", "programs") to ("programs",) and run
pytest programs/management/commands/tests/test_import_program_config.py -q -k override_keeps
# -> test_override_keeps_navigator_shared_through_program_navigator must FAIL. Revert.

# Inspect status honestly — previously-skipped configs should read as pending
python manage.py import_all_program_configs --list

# Preview the repair without touching anything
python manage.py import_all_program_configs --reconcile --dry-run --only navigators
```

The dry run prints, per config, every declared navigator as `already linked`, `link to add`, or
`entity to create`, then totals them.

**This was rehearsed end to end against a local database** (272 programs, 240 navigators, 299
links) before any shared environment. The dry run predicted 92 links to add and 0 entities to
create; the apply produced exactly that:

| Metric | Before | After | Δ |
| -- | -- | -- | -- |
| Navigator links (`ProgramNavigator`) | 299 | 391 | **+92**, matching the prediction exactly |
| Navigators | 240 | 240 | 0 — none created, none deleted |
| Documents / document links | 371 / 1126 | 371 / 1126 | 0 — `--only navigators` held |
| Warning messages | 94 | 94 | 0 |
| Navigators with no live link | 129 | 48 | −81 |

WA went from 28 orphaned navigators to 1, TX from 15 to 0. A second run reported
`Reconciled: 0 / Already current: 118`, confirming idempotency.

<a name="environment-audit"></a>

### Environment audit — staging vs production

Both environments were audited read-only before merge, using a declaration-centric query generated
from the config files — SELECTs only, run against the production `GRAY` follower and the staging
database. The query is held locally by David alongside the deployment session rather than committed
to this branch; see Future considerations for where it should eventually live. **The go/no-go gate
passed in both: zero navigators missing, zero programs missing.** Every declared navigator already
exists as a row, so the repair is pure link creation — no entity creation, therefore no Google
Translate calls and no new `Translation` rows.

| | Staging | Production |
| -- | -- | -- |
| Declarations resolved | 105 | 105 |
| Links to add | **77** | **76** |
| Already linked | 28 | 29 |
| Navigators missing (gate) | **0** | **0** |
| Legacy M2M rows | — | 290 |
| Links from migration 0126 / admin portal | — | 276 / 34 |

**The two environments have genuinely drifted.** They are not identical, so each needs its own dry
run rather than assuming the staging result carries over:

| Link | Status |
| -- | -- |
| `ks/ks_snap/ks_harvesters` | Present in prod, **missing in staging** |
| `ks/ks_snap/ks_mirror_inc` | Present in prod, **missing in staging** |
| `wa/wa_apple_health_medicaid/wa_healthplanfinder_support` | Present in staging, **missing in prod** |

The two KS links are the KS SNAP fix applied by hand directly to production during MFB-1049 QA;
staging never received it. The WA link exists only in staging. Reconciling converges both
environments onto the configs, which is the point.

The ticket reported staging and prod as "identical, 74 of 75". That was measured with a
navigator-centric query; measured per declaration they differ by three links in both directions.

### Why the count is 76, not 75

The extra link is **`wa_lifeline` → `lifeline_support_center`**. That navigator is declared by two
configs, `ks_lifeline` and `wa_lifeline`. It already holds its KS link, so `live_links > 0`, and
the ticket's audit query filters on `WHERE nav.live_links = 0`. Being navigator-centric, it can
only surface navigators linked to *nothing* — a navigator linked to some but not all of its
declared programs is invisible to it.

The arithmetic closes exactly: 75 orphaned navigators, less the 8 that appear in no config, leaves
67 config-declared orphans. The 76 links cover 68 distinct navigators (`wa_211`×5,
`get_covered_illinois`×3, `il_fcrc`×2, `211_texas`×2 account for 8 duplicate declarations).
68 − 67 = 1, which is `lifeline_support_center`.

**This matters beyond the one row.** Shared entities are far more common among documents than
navigators, so the same blind spot will under-report the documents pass. Use the
declaration-centric query for it, not the one in the ticket.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

> **Owner: David.** These steps are not for the merger or the on-call to pick up — David is running
> them personally, from the working session that produced the pre-merge audit, using the local
> audit artifacts referenced below. Please do not run the repair independently; a second concurrent
> run is harmless (everything is `get_or_create`) but would muddy the before/after evidence.

**Merging this PR fixes the bug but repairs no data.** The 76 missing links are created by a
manual, gated step that must be run per environment. Nothing below is automatic.

Migration `0166` *is* automatic — the deploy workflow's `heroku-migrations` step runs it. It only
adds and backfills a column and creates no links. It must land before `--reconcile` will run at
all, since the pending check reads `content_hash`.

### Step 1 — Staging (`cobenefits-api-staging`), after the auto-deploy completes

```bash
# 1a. Confirm the migration landed.
heroku run -a cobenefits-api-staging -- python manage.py showmigrations programs | tail -3
#     Expect: [X] 0166_programconfigimport_content_hash

# 1b. Single program first — smallest possible blast radius.
heroku run -a cobenefits-api-staging -- python manage.py import_all_program_configs \
  --reconcile --dry-run --only navigators --file wa_snap_initial_config.json

# 1c. Full preview. Capture it — 123 configs is a lot of scrollback.
heroku run -a cobenefits-api-staging -- python manage.py import_all_program_configs \
  --reconcile --dry-run --only navigators > staging-dryrun.txt
```

**Gate — do not proceed unless all three hold:**

- `Entities to create: 0`. Any `★ entity to create` line means stop and investigate; the audit
  confirmed every declared navigator already exists, so a creation contradicts known state.
- `Links to add: 77` (staging's audited figure — **not** 76, see the drift table above).
- `Failed: 0`.

The audited figures are unchanged by the counting fix above: `Links to add` now includes declarations
whose entity must be created, and the audit established there are none, so 77 / 76 still stand.

```bash
# 1d. Apply, then re-run to confirm convergence.
heroku run -a cobenefits-api-staging -- python manage.py import_all_program_configs \
  --reconcile --only navigators
heroku run -a cobenefits-api-staging -- python manage.py import_all_program_configs \
  --reconcile --dry-run --only navigators | tail -15
#     Expect: Reconciled: 0 / Already current: 118 / Links to add: 0
```

### Step 2 — Verify on staging

- The step 1d re-run is the primary check: `Links to add: 0` and `Already current: 118` means every
  declared navigator link now exists.
- Cross-check with the local audit query (`qa/mfb1585_prod_audit.sql`) against staging. Section 1
  should show all 105 declarations as `already linked`, with no `link to add` remaining. This is
  worth running as well as the dry run, since it reaches the database independently of the code
  path being repaired.
- Load a results card per affected white label, for a county the navigator covers, and confirm the
  "Get Help Applying" section renders. WA is the clearest signal — it goes from 2 working
  navigators to 28.
- Confirm admin-curated ordering survived: navigators added through the admin portal should still
  appear before the newly linked ones.
- `--list` will still report these configs as pending after a successful `--only navigators` repair.
  That is expected, not a failure: a partial pass records nothing, and the documents and warning
  messages genuinely have not been applied yet. Use the step 1d re-run, not `--list`, as the
  convergence check.

### Step 3 — Production (`cobenefits-api`), only after staging is verified

Identical sequence, substituting the app name, with one changed expectation:

- `Links to add: 76`, not 77.
- `Entities to create: 0`.

Note the production audit must use the read-only follower, not the primary:

```bash
heroku pg:psql HEROKU_POSTGRESQL_GRAY_URL -a cobenefits-api -f qa/mfb1585_prod_audit.sql
```

Then repeat the results-card checks.

### Step 4 — Documents and warning messages, as a separate pass

Deliberately excluded from the runs above via `--only navigators`. The same bug orphaned these too
(597 document links and 31 warning messages are declared across the configs), but the blast radius
is much larger and some may have been intentionally curated away in the admin since. Audit first,
then run `--reconcile --only documents` and `--reconcile --only warning_messages` under the same
dry-run gate.

This still works after the navigators pass: a `--reconcile` run considers every config regardless
of tracking state, and step 1 records no hash at all, so nothing is stranded.

### Rollback

The repair creates rows in `programs_program_navigators_ordered` and nothing else. To undo, delete
the links created by the run, identified from the captured dry-run output — `staging-dryrun.txt` and
its production equivalent itemise every `link to add` the repair then created, by program and
navigator. **Do not identify them by `order` value.** New links take `max(order) + 1` for the
program, and migration `0126` copied all 276 pre-existing links in at exactly `999`, so on any
program holding a `0126`-era link the repair's rows land at `1000+` — indistinguishable by `order`
from admin-portal links — while on a program with no prior links they land at `0, 1, 2, …`. Neither
band is unique to the repair. (Same reason section 4 of the audit query, which buckets links by
`order` as a provenance proxy, stops being meaningful once the repair has run.)

Migration `0166` is reversible (`migrate programs 0165`), which drops the column.

### Other

- **Production config updates:** none.
- **Admin updates needed:** none. The repair is additive — no navigator, document, warning message
  or link is modified or removed, and admin-curated navigator ordering is preserved.
- **Notify team/users of:** the 7 white labels whose results cards will start showing navigator
  contacts after the repair (`cesn`, `co`, `il`, `ks`, `ma`, `tx`, `wa`). WA changes most
  noticeably — from 2 working navigators to 28.
- **Not fixed by this repair:** the 8 navigators appearing in no config, the
  `il_east_central_illinois_...` county-name mismatch, and the duplicate Greater Chicago Food
  Depository pair. All three need a human decision and are tracked in the ticket. Note the GCFD
  item is *not* a blocker — audited on both environments, `GCFD` serves `il_aca_adults`,
  `il_all_kids`, `il_family_care`, `il_moms_and_babies` and `il_snap`, and `il_csfp` is not among
  them, so linking `greater_chicago_food_depository` puts no duplicate on any single card.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- **Worth focusing on:** whether reconcile is genuinely non-destructive. The argument is that all
  three sub-entity importers already treat existing entities as read-only — `_import_navigators`,
  `_import_documents` and `_import_warning_message` each hit an "use existing, do not update"
  branch — so a reconcile pass adds association rows and nothing else. If that premise is wrong
  anywhere, reconcile is wrong.
- **Known limitations:**
  - Reconcile is one-way. It never removes a link that the config no longer declares. That is
    deliberate: production has navigators created purely through the admin center, some without
    any matching config, and they must not be erased.
  - `--only` gates which sections are applied, and a partial pass records nothing, so running
    `--only navigators` and stopping leaves those configs reading as pending in `--list` even though
    the navigators really were applied. That is the honest state — the documents and warning messages
    were not applied — but it means "pending" is not by itself evidence that step 1 failed. The
    documents pass is an explicit second `--reconcile` run either way.
  - The reconcile plan is built twice per config — once by the orchestrator for the run totals, once
    by the importer for its per-section output. It is a read-only classification either way, so the
    cost is a few extra queries per config and the two cannot disagree, but a single pass would be
    tidier. `call_command` returning a value from `handle()` is the obvious route and is awkward
    enough (`BaseCommand.execute` writes a truthy return to stdout) that it wasn't worth it here.
  - The `NavigatorDataController.to_model_data` export still reads the legacy `programs` M2M, so
    exported navigator→program lists remain incomplete. Out of scope here; it belongs with the
    CONTRACT-phase migration.
  - The dry run's per-config plan reports what will be *linked*, not whether the result will be
    *visible*. A navigator whose county names can never match a real `Screen.county` renders
    nowhere even once correctly linked — the ticket's separate county-convention issue. The audit
    query in MFB-1585 covers this and should be run after the repair. It cannot be checked
    meaningfully against a local database, whose `Screen` table has too few distinct counties
    (2 for WA, 10 for IL) for the substring filter to be exercised.
- **Future considerations:**
  - The CONTRACT phase for migration `0126` can proceed once the delete guard fix is deployed; the
    guard was the blocker that would have started deleting shared navigators.
  - Three items from the ticket deliberately excluded, as they need a human who knows the launch
    history: the 8 navigators appearing in no config at all, the `il_east_central_illinois_...`
    county-name mismatch, and the duplicate `Greater Chicago Food Depository` pair to consolidate.
  - Minor correction to the ticket: `il_liheap` has no config file, so it is not the "importer-era
    program that worked" counter-example cited there. The diagnosis stands on the 105 declared
    navigator links across 58 configs.
  - The ticket's audit query is navigator-centric (`WHERE nav.live_links = 0`) and so cannot see a
    navigator linked to some but not all of its declared programs. That is how it missed
    `wa_lifeline`, and it will under-report the documents pass more severely, since shared
    documents are common. The declaration-centric replacement used for the audit above is generated
    from the config files rather than hand-maintained, but it lives outside the repo — there is no
    SQL or one-off-script convention here to put it in. That is fine for this deployment, since
    David holds it and is running the steps, but the documents pass needs the same query and
    shouldn't depend on one person's working directory. A `manage.py` audit command would be the
    idiomatic home. Worth a follow-up ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reconciliation mode to apply missing warnings, documents, and navigators without overwriting existing program data.
  - Added section filtering and dry-run support for targeted, previewable imports.
  - Import tracking now detects configuration changes and reports planned additions, current programs, skipped files, and partial runs.
- **Bug Fixes**
  - Prevented reconciliation from creating missing programs.
  - Improved protection of shared navigation data during overrides.
  - Clarified when urgent-need imports are skipped without applying configuration.
- **Tests**
  - Added coverage for reconciliation, hashing, dry runs, partial imports, and data preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


