### PR TITLE
MFB-1310: Seed UrgentNeedCategory rows for NC homeless services & health care needs

### DIFF
--- a/programs/migrations/0166_add_nc_homeless_and_health_care_categories.py
+++ b/programs/migrations/0166_add_nc_homeless_and_health_care_categories.py
@@ -30,12 +30,6 @@ def add_urgent_need_categories(apps, schema_editor):
         UrgentNeedCategory.objects.get_or_create(name=name)
 
 
-def remove_urgent_need_categories(apps, schema_editor):
-    UrgentNeedCategory = apps.get_model("programs", "UrgentNeedCategory")
-
-    UrgentNeedCategory.objects.filter(name__in=NEW_URGENT_NEED_CATEGORIES).delete()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -43,5 +37,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_urgent_need_categories, remove_urgent_need_categories),
+        # Reverse is a no-op, not a delete-by-name: UrgentNeedCategory has no field
+        # that distinguishes a row created here from one that already existed or was
+        # reused later (e.g. import_urgent_need_config.py's _set_categories also
+        # get_or_create()s by this same name). Deleting by name on rollback would
+        # silently strip type_short off any real UrgentNeed resource that had since
+        # attached itself to one of these categories.
+        migrations.RunPython(add_urgent_need_categories, migrations.RunPython.noop),
     ]

--- a/programs/migrations/0166_add_nc_homeless_and_health_care_categories.py
+++ b/programs/migrations/0166_add_nc_homeless_and_health_care_categories.py
@@ -1,0 +1,47 @@
+# Generated manually to seed the "Type short" (UrgentNeedCategory) tags needed
+# for MFB-1310: NC - Add two new urgent need types to NC white label:
+#   Homeless Services & Free/Low-Cost Medical Care
+#
+# 0165 already created the two UrgentNeedType ("Type") rows used for admin
+# categorization, but that field is separate from the one that actually drives
+# results-page matching: screener/views.py's urgent_need_results() filters
+# UrgentNeed.type_short__name against a fixed set of strings, and neither of
+# the two new strings ("homeless services", "free low cost medical care")
+# existed as UrgentNeedCategory rows anywhere in the system.
+#
+# UrgentNeedCategory has no white_label field (it's a shared, platform-wide
+# list), so creating new rows through the admin is restricted to superusers.
+# Seeding them here via migration avoids that bottleneck and guarantees the
+# exact string values match what possible_needs expects -- no risk of a typo
+# from someone hand-typing them into the admin.
+
+from django.db import migrations
+
+NEW_URGENT_NEED_CATEGORIES = [
+    "homeless services",
+    "free low cost medical care",
+]
+
+
+def add_urgent_need_categories(apps, schema_editor):
+    UrgentNeedCategory = apps.get_model("programs", "UrgentNeedCategory")
+
+    for name in NEW_URGENT_NEED_CATEGORIES:
+        UrgentNeedCategory.objects.get_or_create(name=name)
+
+
+def remove_urgent_need_categories(apps, schema_editor):
+    UrgentNeedCategory = apps.get_model("programs", "UrgentNeedCategory")
+
+    UrgentNeedCategory.objects.filter(name__in=NEW_URGENT_NEED_CATEGORIES).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0165_add_nc_homeless_and_health_care_urgent_need_types"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_urgent_need_categories, remove_urgent_need_categories),
+    ]

--- a/programs/migrations/0167_add_nc_homeless_and_health_care_categories.py
+++ b/programs/migrations/0167_add_nc_homeless_and_health_care_categories.py
@@ -33,7 +33,7 @@ def add_urgent_need_categories(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("programs", "0165_add_nc_homeless_and_health_care_urgent_need_types"),
+        ("programs", "0166_programconfigimport_content_hash"),
     ]
 
     operations = [


### PR DESCRIPTION
## Context & Motivation

  - **Related**: [MFB-1310](https://linear.app/myfriendben/issue/MFB-1310/nc-add-two-new-urgent-need-types-to-nc-white-label-homeless-services)
  - **Related PR**: #1665

**Follow-up fix**: PR 1665 created the `UrgentNeedType` ("Type") rows for NC's two new needs (homeless services, free/low-cost medical care), but never seeded the matching `UrgentNeedCategory` ("Type short") tags that `screener/views.py`'s `urgent_need_results()` actually uses to match a resource to a need. Without this, no resource could ever be linked to either need.

`UrgentNeedCategory` has no `white_label` field (it's a shared, platform-wide list), so creating new rows through the admin defaults to superuser-only, this migration removes that bottleneck.

  ## Changes Made

  - Added migration `0167_add_nc_homeless_and_health_care_categories.py`, seeding two `UrgentNeedCategory` rows: `homeless services` and `free low cost medical care`
  - Idempotent (`get_or_create`) and reversible

  ## Testing

  - Migrations to run: `python manage.py migrate`
  - Configuration updates needed: None
  - Environment variables/settings to add: None
 - Manual testing steps:
    - `UrgentNeedCategory.objects.filter(name__in=["homeless services", "free low cost medical care"]).count()` returns `2`
    - Re-running `migrate` is a no-op, and is safe even if a superuser already added these manually in the meantime
    - `migrate programs 0166` (rollback) completes without error and intentionally leaves both rows in place; re-applying is a no-op since they already exist
    - Confirmed locally that a test `UrgentNeed` resource tagged with the new category and category type is correctly returned by the same filter `urgent_need_results()` uses

  ## Deployment

  - Post-deployment scripts needed: **No** — the migration applies automatically on merge
  - Production config updates: **No**
  - Admin updates needed: **No** — that's the point of this fix; no superuser action required to unblock content work
  - Notify team/users of: NC content admins that the "Type short" options for these two needs are now available to link when creating Urgent Need Resource entries

  ## Notes for Reviewers
  - Known limitations: this only seeds the tag infrastructure — no actual `UrgentNeed` resources are created. Real NC content (shelters, clinics)
  still needs to be added manually.
  - Future considerations: if/when real resources are added for these needs, revisit whether the NC211 external link should still show alongside them, since both would render together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “homeless services” and “free low-cost medical care” options to urgent-need categories.
  * Categories are available for use across relevant services and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->