### PR TITLE
MFB-1211: Add MO Lifeline and standardize the Lifeline configs across all eight states

### DIFF
--- a/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
@@ -66,7 +66,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         },

--- a/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
@@ -76,7 +76,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_lifeline_initial_config.json
@@ -1,14 +1,14 @@
 {
     "white_label": {
-        "code": "mo"
+        "code": "co"
     },
     "program_category": {
-        "external_name": "mo_housing",
+        "external_name": "housing",
         "name": "Housing and Utilities",
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "mo_lifeline",
+        "name_abbreviated": "lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",
@@ -33,7 +33,7 @@
         "show_on_current_benefits": true,
         "has_calculator": true,
         "show_in_has_benefits_step": false,
-        "external_name": "mo_lifeline"
+        "external_name": "lifeline"
     },
     "documents": [
         {
@@ -69,6 +69,9 @@
             "phone_number": "+18005626150",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
+        },
+        {
+            "external_name": "bia"
         }
     ],
     "warning_messages": [

--- a/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
@@ -1,14 +1,14 @@
 {
     "white_label": {
-        "code": "mo"
+        "code": "il"
     },
     "program_category": {
-        "external_name": "mo_housing",
+        "external_name": "il_housing",
         "name": "Housing and Utilities",
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "mo_lifeline",
+        "name_abbreviated": "lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",
@@ -33,7 +33,7 @@
         "show_on_current_benefits": true,
         "has_calculator": true,
         "show_in_has_benefits_step": false,
-        "external_name": "mo_lifeline"
+        "external_name": "il_lifeline"
     },
     "documents": [
         {
@@ -69,6 +69,9 @@
             "phone_number": "+18005626150",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
+        },
+        {
+            "external_name": "mana_a_mana"
         }
     ],
     "warning_messages": [

--- a/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
@@ -66,7 +66,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         },

--- a/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_lifeline_initial_config.json
@@ -76,7 +76,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -32,7 +32,8 @@
         "value_format": null,
         "show_on_current_benefits": true,
         "has_calculator": true,
-        "show_in_has_benefits_step": false
+        "show_in_has_benefits_step": false,
+        "external_name": "ks_lifeline"
     },
     "documents": [
         {

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -66,7 +66,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         },

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -81,7 +81,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_lifeline_initial_config.json
@@ -1,81 +1,88 @@
 {
-  "white_label": {
-    "code": "ks"
-  },
-  "program_category": {
-    "external_name": "ks_housing",
-    "name": "Housing and Utilities",
-    "icon": "housing"
-  },
-  "program": {
-    "name_abbreviated": "ks_lifeline",
-    "year": "2026",
-    "legal_status_required": [
-      "citizen",
-      "gc_5plus",
-      "gc_5less",
-      "refugee",
-      "otherWithWorkPermission",
-      "non_citizen"
+    "white_label": {
+        "code": "ks"
+    },
+    "program_category": {
+        "external_name": "ks_housing",
+        "name": "Housing and Utilities",
+        "icon": "housing"
+    },
+    "program": {
+        "name_abbreviated": "ks_lifeline",
+        "year": "2026",
+        "legal_status_required": [
+            "citizen",
+            "non_citizen",
+            "gc_5plus",
+            "gc_5less",
+            "refugee",
+            "otherWithWorkPermission"
+        ],
+        "name": "Lifeline",
+        "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. You may not get a discount on both phone and internet unless you have a bundled service. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs.\n\nTo get this benefit, choose an approved company in your state and sign up for service. The company will then apply the discount directly to your bill every month.\n\nOnly one Lifeline benefit is allowed per household, and you may not get Lifeline from more than one company. A household is a group of people who live together and share money. This might be different from how other programs count your household.\n\nYou may qualify based on your household income, or if anyone in your household gets SNAP, Medicaid, SSI, Federal Public Housing Assistance, or Veterans Pension and Survivors Benefit. You may also qualify through certain Tribal programs.\n\nOnce you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
+        "description_short": "Discount on monthly phone or internet service",
+        "learn_more_link": "https://www.lifelinesupport.org/how-to-qualify/",
+        "apply_button_link": "https://www.lifelinesupport.org/how-to-apply/",
+        "apply_button_description": "",
+        "estimated_application_time": "10 minutes",
+        "estimated_delivery_time": "",
+        "estimated_value": "",
+        "website_description": "Discount on monthly phone or internet service",
+        "base_program": "lifeline",
+        "value_format": null,
+        "show_on_current_benefits": true,
+        "has_calculator": true,
+        "show_in_has_benefits_step": false
+    },
+    "documents": [
+        {
+            "external_name": "lifeline_program_participation",
+            "text": "Proof of participation in a qualifying program, if requested (ex: SNAP, Medicaid, SSI, or Federal Public Housing Assistance award letter)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_income_proof",
+            "text": "Proof of household income, if requested (ex: pay stubs, prior-year tax return, or a Social Security, unemployment, or benefits statement)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_id_proof",
+            "text": "Proof of identity, if requested (ex: driver's license, state ID, passport, or Tribal ID)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_home",
+            "text": "Proof of home address, if requested (ex: lease, utility bill, or mortgage statement)",
+            "link_url": "",
+            "link_text": ""
+        }
     ],
-    "name": "Kansas Lifeline Phone and Internet Discount",
-    "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. Kansas adds an extra discount for phone service on top of the federal amount. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs.\n\nTo get this benefit, you must choose an approved company in Kansas and sign up for service. The company will then apply the discount directly to your bill every month. You must be at least 18 years old to apply.\n\nOnly one Lifeline benefit is allowed per household. A household is a group of people who live together and share money. This might be different from how other programs count your household. You can also qualify through Tribal assistance programs.\n\nYou can apply online at the Lifeline Support website by clicking \"Apply Now\", or by contacting an approved phone company in Kansas. You will need to show a photo ID and proof of income. Once you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
-    "description_short": "Discount on monthly phone or internet service",
-    "learn_more_link": "https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program",
-    "apply_button_link": "https://www.lifelinesupport.org/",
-    "apply_button_description": "Apply Now",
-    "estimated_application_time": "10 minutes",
-    "estimated_delivery_time": "",
-    "estimated_value": "",
-    "website_description": "Discount on monthly phone or internet service",
-    "base_program": "lifeline",
-    "value_format": null,
-    "show_on_current_benefits": true,
-    "has_calculator": true,
-    "show_in_has_benefits_step": false
-  },
-  "documents": [
-    {
-      "external_name": "ks_id_proof",
-      "text": "Proof of identity (ex: driver's license, state ID, passport)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "ks_home",
-      "text": "Proof of home address (ex: lease, utility bill, mortgage statement)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "ks_earned_income",
-      "text": "Proof of income (ex: pay stubs, tax return, benefits letter)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "ks_qualifying_program_proof",
-      "text": "Proof of participation in a qualifying program such as SNAP, Medicaid, SSI, or Federal Public Housing Assistance (ex: award letter, benefits statement)",
-      "link_url": "",
-      "link_text": ""
-    }
-  ],
-  "navigators": [
-    {
-      "external_name": "lifeline_support_center",
-      "name": "Universal Service Administrative Co - Lifeline Support Center",
-      "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-      "phone_number": "+18002349473",
-      "email": "LifelineSupport@usac.org",
-      "assistance_link": "https://www.lifelinesupport.org/get-help/"
-    },
-    {
-      "external_name": "ks_kcc_consumer_protection",
-      "name": "Kansas Corporation Commission - Office of Public Affairs and Consumer Protection",
-      "description": "State agency that administers the Kansas Lifeline supplement and can answer questions about applying for or using the Kansas Lifeline Program.",
-      "phone_number": "+18006620027",
-      "email": "kcc.public.affairs@ks.gov",
-      "assistance_link": "https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program"
-    }
-  ]
+    "navigators": [
+        {
+            "external_name": "lifeline_support_center",
+            "name": "Universal Service Administrative Co - Lifeline Support Center",
+            "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
+            "phone_number": "+18005626150",
+            "email": "LifelineSupport@usac.org",
+            "assistance_link": "https://www.lifelinesupport.org/"
+        },
+        {
+            "external_name": "ks_kcc_consumer_protection",
+            "name": "Kansas Corporation Commission - Office of Public Affairs and Consumer Protection",
+            "description": "State agency that administers the Kansas Lifeline supplement and can answer questions about applying for or using the Kansas Lifeline Program.",
+            "phone_number": "+18006620027",
+            "email": "kcc.public.affairs@ks.gov",
+            "assistance_link": "https://www.kcc.ks.gov/public-affairs-and-consumer-protection/kansas-lifeline-program"
+        }
+    ],
+    "warning_messages": [
+        {
+            "external_name": "wa_lifeline_snap_enrollment",
+            "calculator": "_show",
+            "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
+        }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
@@ -1,14 +1,14 @@
 {
     "white_label": {
-        "code": "mo"
+        "code": "ma"
     },
     "program_category": {
-        "external_name": "mo_housing",
+        "external_name": "ma_housing",
         "name": "Housing and Utilities",
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "mo_lifeline",
+        "name_abbreviated": "lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",
@@ -33,7 +33,7 @@
         "show_on_current_benefits": true,
         "has_calculator": true,
         "show_in_has_benefits_step": false,
-        "external_name": "mo_lifeline"
+        "external_name": "ma_lifeline"
     },
     "documents": [
         {

--- a/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
@@ -73,7 +73,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_lifeline_initial_config.json
@@ -66,7 +66,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         }

--- a/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
@@ -1,74 +1,80 @@
 {
-  "white_label": {
-    "code": "mo"
-  },
-  "program_category": {
-    "external_name": "mo_housing",
-    "name": "Housing and Utilities",
-    "icon": "housing"
-  },
-  "program": {
-    "name_abbreviated": "mo_lifeline",
-    "year": "2026",
-    "legal_status_required": [
-      "citizen",
-      "gc_5plus",
-      "gc_5less",
-      "refugee",
-      "otherWithWorkPermission",
-      "non_citizen"
+    "white_label": {
+        "code": "mo"
+    },
+    "program_category": {
+        "external_name": "mo_housing",
+        "name": "Housing and Utilities",
+        "icon": "housing"
+    },
+    "program": {
+        "name_abbreviated": "mo_lifeline",
+        "year": "2026",
+        "legal_status_required": [
+            "citizen",
+            "non_citizen",
+            "gc_5plus",
+            "gc_5less",
+            "refugee",
+            "otherWithWorkPermission"
+        ],
+        "name": "Lifeline",
+        "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. You may not get a discount on both phone and internet unless you have a bundled service. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs.\n\nTo get this benefit, choose an approved company in your state and sign up for service. The company will then apply the discount directly to your bill every month.\n\nOnly one Lifeline benefit is allowed per household, and you may not get Lifeline from more than one company. A household is a group of people who live together and share money. This might be different from how other programs count your household.\n\nYou may qualify based on your household income, or if anyone in your household gets SNAP, Medicaid, SSI, Federal Public Housing Assistance, or Veterans Pension and Survivors Benefit. You may also qualify through certain Tribal programs.\n\nOnce you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
+        "description_short": "Discount on monthly phone or internet service",
+        "learn_more_link": "https://www.lifelinesupport.org/how-to-qualify/",
+        "apply_button_link": "https://www.lifelinesupport.org/how-to-apply/",
+        "apply_button_description": "",
+        "estimated_application_time": "10 minutes",
+        "estimated_delivery_time": "",
+        "estimated_value": "",
+        "website_description": "Discount on monthly phone or internet service",
+        "base_program": "lifeline",
+        "value_format": null,
+        "show_on_current_benefits": true,
+        "has_calculator": true,
+        "show_in_has_benefits_step": false
+    },
+    "documents": [
+        {
+            "external_name": "lifeline_program_participation",
+            "text": "Proof of participation in a qualifying program, if requested (ex: SNAP, Medicaid, SSI, or Federal Public Housing Assistance award letter)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_income_proof",
+            "text": "Proof of household income, if requested (ex: pay stubs, prior-year tax return, or a Social Security, unemployment, or benefits statement)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_id_proof",
+            "text": "Proof of identity, if requested (ex: driver's license, state ID, passport, or Tribal ID)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_home",
+            "text": "Proof of home address, if requested (ex: lease, utility bill, or mortgage statement)",
+            "link_url": "",
+            "link_text": ""
+        }
     ],
-    "name": "Lifeline",
-    "description": "Lifeline is a federal program that lowers the monthly cost of qualifying phone, internet, or bundled service. People living on qualifying Tribal lands may get a larger discount. Missouri may also provide an extra discount for some landline services.\n\nAfter you qualify, choose a participating phone or internet company. The company applies the Lifeline discount to your monthly bill.\n\nEach household can get only one Lifeline benefit. Lifeline has special rules for deciding who counts as one household. There are also other ways to qualify for Lifeline. You may qualify through certain Tribal programs or Veterans Pension and Survivors Benefit. Special rules may also help survivors qualify.\n\nTo apply, select \"Apply Now\" to start your Lifeline application through Lifeline Support.",
-    "description_short": "Discount on monthly phone or internet service",
-    "learn_more_link": "https://psc.mo.gov/Telecommunications/Lifeline_and_Disabled_Programs_1",
-    "apply_button_link": "https://www.lifelinesupport.org/how-to-apply/",
-    "apply_button_description": "",
-    "estimated_application_time": "10 minutes",
-    "estimated_delivery_time": "",
-    "estimated_value": "",
-    "website_description": "Discount on monthly phone or internet service",
-    "base_program": "lifeline",
-    "value_format": null,
-    "value_type": "benefit",
-    "show_on_current_benefits": true,
-    "has_calculator": true,
-    "show_in_has_benefits_step": false
-  },
-  "documents": [
-    {
-      "external_name": "mo_id_proof",
-      "text": "Proof of identity, if requested (ex: driver's license, state ID, passport, or Tribal ID)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "mo_home",
-      "text": "Proof of home address, if requested (ex: lease, utility bill, or mortgage statement)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "mo_earned_income",
-      "text": "Proof of household income, if requested (ex: pay stubs, tax return, or benefits letter)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "mo_lifeline_program_participation",
-      "text": "Proof of benefits, if requested (ex: SNAP, Medicaid, or SSI)",
-      "link_url": "",
-      "link_text": ""
-    }
-  ],
-  "navigators": [
-    {
-      "external_name": "lifeline_support_center",
-      "name": "Lifeline Support Center",
-      "description": "Get help with your Lifeline application, documents, or application status.",
-      "phone_number": "+18002349473",
-      "email": "LifelineSupport@usac.org",
-      "assistance_link": "https://www.lifelinesupport.org/get-help/"
-    }
-  ]
+    "navigators": [
+        {
+            "external_name": "lifeline_support_center",
+            "name": "Universal Service Administrative Co - Lifeline Support Center",
+            "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
+            "phone_number": "+18005626150",
+            "email": "LifelineSupport@usac.org",
+            "assistance_link": "https://www.lifelinesupport.org/"
+        }
+    ],
+    "warning_messages": [
+        {
+            "external_name": "wa_lifeline_snap_enrollment",
+            "calculator": "_show",
+            "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
+        }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
@@ -73,7 +73,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
@@ -66,7 +66,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         }

--- a/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/mo_lifeline_initial_config.json
@@ -1,0 +1,74 @@
+{
+  "white_label": {
+    "code": "mo"
+  },
+  "program_category": {
+    "external_name": "mo_housing",
+    "name": "Housing and Utilities",
+    "icon": "housing"
+  },
+  "program": {
+    "name_abbreviated": "mo_lifeline",
+    "year": "2026",
+    "legal_status_required": [
+      "citizen",
+      "gc_5plus",
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission",
+      "non_citizen"
+    ],
+    "name": "Lifeline",
+    "description": "Lifeline is a federal program that lowers the monthly cost of qualifying phone, internet, or bundled service. People living on qualifying Tribal lands may get a larger discount. Missouri may also provide an extra discount for some landline services.\n\nAfter you qualify, choose a participating phone or internet company. The company applies the Lifeline discount to your monthly bill.\n\nEach household can get only one Lifeline benefit. Lifeline has special rules for deciding who counts as one household. There are also other ways to qualify for Lifeline. You may qualify through certain Tribal programs or Veterans Pension and Survivors Benefit. Special rules may also help survivors qualify.\n\nTo apply, select \"Apply Now\" to start your Lifeline application through Lifeline Support.",
+    "description_short": "Discount on monthly phone or internet service",
+    "learn_more_link": "https://psc.mo.gov/Telecommunications/Lifeline_and_Disabled_Programs_1",
+    "apply_button_link": "https://www.lifelinesupport.org/how-to-apply/",
+    "apply_button_description": "",
+    "estimated_application_time": "10 minutes",
+    "estimated_delivery_time": "",
+    "estimated_value": "",
+    "website_description": "Discount on monthly phone or internet service",
+    "base_program": "lifeline",
+    "value_format": null,
+    "value_type": "benefit",
+    "show_on_current_benefits": true,
+    "has_calculator": true,
+    "show_in_has_benefits_step": false
+  },
+  "documents": [
+    {
+      "external_name": "mo_id_proof",
+      "text": "Proof of identity, if requested (ex: driver's license, state ID, passport, or Tribal ID)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_home",
+      "text": "Proof of home address, if requested (ex: lease, utility bill, or mortgage statement)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_earned_income",
+      "text": "Proof of household income, if requested (ex: pay stubs, tax return, or benefits letter)",
+      "link_url": "",
+      "link_text": ""
+    },
+    {
+      "external_name": "mo_lifeline_program_participation",
+      "text": "Proof of benefits, if requested (ex: SNAP, Medicaid, or SSI)",
+      "link_url": "",
+      "link_text": ""
+    }
+  ],
+  "navigators": [
+    {
+      "external_name": "lifeline_support_center",
+      "name": "Lifeline Support Center",
+      "description": "Get help with your Lifeline application, documents, or application status.",
+      "phone_number": "+18002349473",
+      "email": "LifelineSupport@usac.org",
+      "assistance_link": "https://www.lifelinesupport.org/get-help/"
+    }
+  ]
+}

--- a/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
@@ -73,7 +73,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
@@ -1,14 +1,14 @@
 {
     "white_label": {
-        "code": "mo"
+        "code": "nc"
     },
     "program_category": {
-        "external_name": "mo_housing",
+        "external_name": "nc_housing",
         "name": "Housing and Utilities",
         "icon": "housing"
     },
     "program": {
-        "name_abbreviated": "mo_lifeline",
+        "name_abbreviated": "lifeline",
         "year": "2026",
         "legal_status_required": [
             "citizen",
@@ -33,7 +33,7 @@
         "show_on_current_benefits": true,
         "has_calculator": true,
         "show_in_has_benefits_step": false,
-        "external_name": "mo_lifeline"
+        "external_name": "nc_lifeline"
     },
     "documents": [
         {

--- a/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_lifeline_initial_config.json
@@ -66,7 +66,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         }

--- a/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
@@ -63,7 +63,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
@@ -73,7 +73,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         }

--- a/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
@@ -1,5 +1,7 @@
 {
-    "white_label": {"code": "tx"},
+    "white_label": {
+        "code": "tx"
+    },
     "program_category": {
         "external_name": "tx_housing",
         "name": "Housing and Utilities",
@@ -7,48 +9,71 @@
     },
     "program": {
         "name_abbreviated": "tx_lifeline",
-        "year": "2025",
-        "legal_status_required": ["citizen", "refugee", "gc_5plus", "gc_18plus_no5", "gc_under18_no5"],
+        "year": "2026",
+        "legal_status_required": [
+            "citizen",
+            "non_citizen",
+            "gc_5plus",
+            "gc_5less",
+            "refugee",
+            "otherWithWorkPermission"
+        ],
         "name": "Lifeline",
-        "description_short": "Phone or internet discount",
-        "description": "Phone or internet discount. Lifeline can give your household a monthly discount on phone or internet service. You may not get a discount on both unless you have a bundled service.\n\nYou may get only one Lifeline benefit per household, and you may not get Lifeline from more than one company.\n\nYou may qualify if your income is below a certain level. You may also qualify if any member of your household gets SNAP, SSI, or Medicaid.\n\nIt may take 2 business days to 2 weeks to receive this benefit.",
-        "learn_more_link": "https://www.lifelinesupport.org/",
-        "apply_button_link": "https://www.texaslifeline.org/",
-        "apply_button_description": "Apply for Lifeline",
-        "estimated_application_time": "30 minutes",
-        "estimated_delivery_time": "2 business days to 2 weeks",
-        "estimated_value": ""
+        "description_short": "Discount on monthly phone or internet service",
+        "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. You may not get a discount on both phone and internet unless you have a bundled service. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs.\n\nTo get this benefit, choose an approved company in your state and sign up for service. The company will then apply the discount directly to your bill every month.\n\nOnly one Lifeline benefit is allowed per household, and you may not get Lifeline from more than one company. A household is a group of people who live together and share money. This might be different from how other programs count your household.\n\nYou may qualify based on your household income, or if anyone in your household gets SNAP, Medicaid, SSI, Federal Public Housing Assistance, or Veterans Pension and Survivors Benefit. You may also qualify through certain Tribal programs.\n\nOnce you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
+        "learn_more_link": "https://www.lifelinesupport.org/how-to-qualify/",
+        "apply_button_link": "https://www.lifelinesupport.org/how-to-apply/",
+        "apply_button_description": "",
+        "estimated_application_time": "10 minutes",
+        "estimated_delivery_time": "",
+        "estimated_value": "",
+        "base_program": "lifeline",
+        "website_description": "Discount on monthly phone or internet service",
+        "show_on_current_benefits": true,
+        "has_calculator": true,
+        "show_in_has_benefits_step": false
     },
     "documents": [
         {
-            "external_name": "tx_home",
-            "text": "Proof of home address (ex: lease, mortgage statement, utility bill)",
+            "external_name": "lifeline_program_participation",
+            "text": "Proof of participation in a qualifying program, if requested (ex: SNAP, Medicaid, SSI, or Federal Public Housing Assistance award letter)",
             "link_url": "",
             "link_text": ""
         },
         {
-            "external_name": "tx_earned_income",
-            "text": "Proof of earned income  (ex: pay stubs, tax returns, W-2, 1099) & employer information",
+            "external_name": "lifeline_income_proof",
+            "text": "Proof of household income, if requested (ex: pay stubs, prior-year tax return, or a Social Security, unemployment, or benefits statement)",
             "link_url": "",
             "link_text": ""
         },
         {
-            "external_name": "tx_other_program",
-            "text": "Evidence of participation in a qualifying benefits program (if applicable)",
+            "external_name": "lifeline_id_proof",
+            "text": "Proof of identity, if requested (ex: driver's license, state ID, passport, or Tribal ID)",
             "link_url": "",
             "link_text": ""
         },
         {
-            "external_name": "tx_id_proof",
-            "text": "Proof of identity (ex: driver's license, official state ID card)",
+            "external_name": "lifeline_home",
+            "text": "Proof of home address, if requested (ex: lease, utility bill, or mortgage statement)",
             "link_url": "",
             "link_text": ""
-        },
+        }
+    ],
+    "warning_messages": [
         {
-            "external_name": "tx_unearned_income",
-            "text": "Proof of unearned income (ex: child support, social security, unemployment)",
-            "link_url": "",
-            "link_text": ""
+            "external_name": "wa_lifeline_snap_enrollment",
+            "calculator": "_show",
+            "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
+        }
+    ],
+    "navigators": [
+        {
+            "external_name": "lifeline_support_center",
+            "name": "Universal Service Administrative Co - Lifeline Support Center",
+            "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
+            "phone_number": "+18005626150",
+            "email": "LifelineSupport@usac.org",
+            "assistance_link": "https://www.lifelinesupport.org/"
         }
     ]
 }

--- a/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_lifeline_initial_config.json
@@ -31,7 +31,9 @@
         "website_description": "Discount on monthly phone or internet service",
         "show_on_current_benefits": true,
         "has_calculator": true,
-        "show_in_has_benefits_step": false
+        "show_in_has_benefits_step": false,
+        "external_name": "tx_lifeline",
+        "value_format": null
     },
     "documents": [
         {

--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -63,7 +63,7 @@
     ],
     "warning_messages": [
         {
-            "external_name": "wa_lifeline_snap_enrollment",
+            "external_name": "lifeline_snap_enrollment",
             "calculator": "_show",
             "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
         }

--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -73,7 +73,7 @@
             "external_name": "lifeline_support_center",
             "name": "Universal Service Administrative Co - Lifeline Support Center",
             "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-            "phone_number": "+18005626150",
+            "phone_number": "+18002349473",
             "email": "LifelineSupport@usac.org",
             "assistance_link": "https://www.lifelinesupport.org/"
         }

--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -1,80 +1,80 @@
 {
-  "white_label": {
-    "code": "wa"
-  },
-  "program_category": {
-    "external_name": "wa_housing",
-    "name": "Housing and Utilities",
-    "icon": "housing"
-  },
-  "program": {
-    "name_abbreviated": "wa_lifeline",
-    "year": "2026",
-    "legal_status_required": [
-      "citizen",
-      "gc_5plus",
-      "gc_5less",
-      "refugee",
-      "otherWithWorkPermission",
-      "non_citizen"
+    "white_label": {
+        "code": "wa"
+    },
+    "program_category": {
+        "external_name": "wa_housing",
+        "name": "Housing and Utilities",
+        "icon": "housing"
+    },
+    "program": {
+        "name_abbreviated": "wa_lifeline",
+        "year": "2026",
+        "legal_status_required": [
+            "citizen",
+            "non_citizen",
+            "gc_5plus",
+            "gc_5less",
+            "refugee",
+            "otherWithWorkPermission"
+        ],
+        "name": "Lifeline",
+        "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. You may not get a discount on both phone and internet unless you have a bundled service. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs.\n\nTo get this benefit, choose an approved company in your state and sign up for service. The company will then apply the discount directly to your bill every month.\n\nOnly one Lifeline benefit is allowed per household, and you may not get Lifeline from more than one company. A household is a group of people who live together and share money. This might be different from how other programs count your household.\n\nYou may qualify based on your household income, or if anyone in your household gets SNAP, Medicaid, SSI, Federal Public Housing Assistance, or Veterans Pension and Survivors Benefit. You may also qualify through certain Tribal programs.\n\nOnce you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
+        "description_short": "Discount on monthly phone or internet service",
+        "learn_more_link": "https://www.lifelinesupport.org/how-to-qualify/",
+        "apply_button_link": "https://www.lifelinesupport.org/how-to-apply/",
+        "apply_button_description": "",
+        "estimated_application_time": "10 minutes",
+        "estimated_delivery_time": "",
+        "estimated_value": "",
+        "website_description": "Discount on monthly phone or internet service",
+        "base_program": "lifeline",
+        "value_format": null,
+        "show_on_current_benefits": true,
+        "has_calculator": true,
+        "show_in_has_benefits_step": false
+    },
+    "documents": [
+        {
+            "external_name": "lifeline_program_participation",
+            "text": "Proof of participation in a qualifying program, if requested (ex: SNAP, Medicaid, SSI, or Federal Public Housing Assistance award letter)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_income_proof",
+            "text": "Proof of household income, if requested (ex: pay stubs, prior-year tax return, or a Social Security, unemployment, or benefits statement)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_id_proof",
+            "text": "Proof of identity, if requested (ex: driver's license, state ID, passport, or Tribal ID)",
+            "link_url": "",
+            "link_text": ""
+        },
+        {
+            "external_name": "lifeline_home",
+            "text": "Proof of home address, if requested (ex: lease, utility bill, or mortgage statement)",
+            "link_url": "",
+            "link_text": ""
+        }
     ],
-    "name": "Lifeline",
-    "description": "Lifeline is a federal program that helps you pay for your phone or internet service. It gives you a monthly discount that can be used for a cell phone, home phone, or home internet plan. In Washington, some companies offer free plans by using this full discount. If you live on qualifying Tribal lands, you can get an additional discount each month to help lower your costs. \n\nTo get this benefit, you must choose an approved company in Washington and sign up for service. The company will then apply the discount directly to your bill every month. You must be at least 18 years old to apply. People living in full-time care facilities where Medicaid covers their care are not able to get this discount. \n\nOnly one Lifeline benefit is allowed per household. A household is a group of people who live together and share money. This might be different from how other programs count your household. You can qualify through Tribal or Veterans assistance programs. \n\nYou can apply online at the Lifeline Support website or by contacting an approved phone company in Washington. You will need to show a photo ID and proof of income. Once you are in the program, you must show you are still eligible once a year. You also need to use your service at least once every 30 days to keep your discount active.",
-    "description_short": "Lifeline is a federal program that helps you pay for your phone or internet service",
-    "learn_more_link": "https://www.lifelinesupport.org/how-to-qualify/",
-    "apply_button_link": "https://www.lifelinesupport.org/",
-    "apply_button_description": "",
-    "estimated_application_time": "10 minutes",
-    "estimated_delivery_time": "",
-    "estimated_value": "",
-    "website_description": "Lifeline is a federal program that helps you pay for your phone or internet service",
-    "base_program": "lifeline",
-    "value_format": null,
-    "show_on_current_benefits": true,
-    "has_calculator": true,
-    "show_in_has_benefits_step": false
-  },
-  "documents": [
-    {
-      "external_name": "wa_id_proof",
-      "text": "Proof of identity (ex: driver's license, state ID, passport, or Tribal ID)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "wa_home",
-      "text": "Proof of home address (ex: lease, utility bill, or mortgage statement)",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "wa_earned_income",
-      "text": "Proof of income (ex: pay stubs, tax return, or benefits statement) if applying based on income",
-      "link_url": "",
-      "link_text": ""
-    },
-    {
-      "external_name": "wa_program_participation",
-      "text": "Proof of participation in a qualifying program (ex: Medicaid card, SNAP letter, SSI award letter)",
-      "link_url": "",
-      "link_text": ""
-    }
-  ],
-  "warning_messages": [
-    {
-      "external_name": "wa_lifeline_snap_enrollment",
-      "calculator": "_show",
-      "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
-    }
-  ],
-  "navigators": [
-    {
-      "external_name": "lifeline_support_center",
-      "name": "Universal Service Administrative Co - Lifeline Support Center",
-      "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
-      "phone_number": "+18005626150",
-      "email": "LifelineSupport@usac.org",
-      "assistance_link": "https://www.lifelinesupport.org/"
-    }
-  ]
+    "warning_messages": [
+        {
+            "external_name": "wa_lifeline_snap_enrollment",
+            "calculator": "_show",
+            "message": "If your screener results indicate you are eligible for SNAP, you should enroll in SNAP before applying for Lifeline."
+        }
+    ],
+    "navigators": [
+        {
+            "external_name": "lifeline_support_center",
+            "name": "Universal Service Administrative Co - Lifeline Support Center",
+            "description": "Federal funding that provides support for the Lifeline program, including assistance with applications and eligibility questions.",
+            "phone_number": "+18005626150",
+            "email": "LifelineSupport@usac.org",
+            "assistance_link": "https://www.lifelinesupport.org/"
+        }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_lifeline_initial_config.json
@@ -32,7 +32,8 @@
         "value_format": null,
         "show_on_current_benefits": true,
         "has_calculator": true,
-        "show_in_has_benefits_step": false
+        "show_in_has_benefits_step": false,
+        "external_name": "wa_lifeline"
     },
     "documents": [
         {

--- a/programs/programs/mo/pe/__init__.py
+++ b/programs/programs/mo/pe/__init__.py
@@ -12,6 +12,7 @@ mo_member_calculators = {
 }
 
 mo_spm_calculators = {
+    "mo_lifeline": spm.MoLifeline,
     "mo_nslp": spm.MoNslp,
 }
 

--- a/programs/programs/mo/pe/spm.py
+++ b/programs/programs/mo/pe/spm.py
@@ -1,5 +1,35 @@
 import programs.programs.policyengine.calculators.dependencies as dependency
-from programs.programs.federal.pe.spm import SchoolLunch
+from programs.programs.federal.pe.spm import Lifeline, SchoolLunch
+
+
+class MoLifeline(Lifeline):
+    """
+    Missouri Lifeline Phone and Internet Discount calculator.
+
+    Uses PolicyEngine's federal ``lifeline`` calculator as-is. Missouri has no
+    state supplement in PolicyEngine: ``lifeline.py`` layers state amounts only for
+    CA and OR (via ``gov.states.<state>.fcc.lifeline.in_effect``) and adds explicit
+    per-state supplements only for TX (``tx_lifeline_supplement``) and KS
+    (``ks_lifeline_supplement``). MO matches none of those branches, so a Missouri
+    household receives the federal benefit — $9.25/month, or $34.25/month on
+    qualifying rural Tribal land — capped at its combined phone and broadband cost.
+
+    ``MoStateCodeDependency`` is added for the same reason the sibling states add
+    theirs: ``pe_input()`` never sends ``state_code`` on its own, and PE's Lifeline
+    chain reads ``state_code_str`` in both ``lifeline`` (state supplement branch) and
+    ``is_lifeline_income_eligible`` (the TX 150% FPG expansion versus the federal
+    135% limit). Sending MO explicitly keeps PE on the federal branch by fact rather
+    than by whichever state PE would otherwise default to. Mirrors the KsLifeline /
+    TxLifeline / WaLifeline pattern.
+
+    The base ``Lifeline.pe_inputs`` supply broadband and phone cost plus the IRS gross
+    income set that feeds ``fcc_fpg_ratio``; MO adds no inputs beyond the state code.
+    """
+
+    pe_inputs = [
+        *Lifeline.pe_inputs,
+        dependency.household.MoStateCodeDependency,
+    ]
 
 
 class MoNslp(SchoolLunch):

--- a/programs/programs/mo/pe/spm.py
+++ b/programs/programs/mo/pe/spm.py
@@ -6,24 +6,14 @@ class MoLifeline(Lifeline):
     """
     Missouri Lifeline Phone and Internet Discount calculator.
 
-    Uses PolicyEngine's federal ``lifeline`` calculator as-is. Missouri has no
-    state supplement in PolicyEngine: ``lifeline.py`` layers state amounts only for
-    CA and OR (via ``gov.states.<state>.fcc.lifeline.in_effect``) and adds explicit
-    per-state supplements only for TX (``tx_lifeline_supplement``) and KS
-    (``ks_lifeline_supplement``). MO matches none of those branches, so a Missouri
-    household receives the federal benefit — $9.25/month, or $34.25/month on
-    qualifying rural Tribal land — capped at its combined phone and broadband cost.
+    Uses PolicyEngine's federal ``lifeline`` calculator as-is: PE carries state
+    supplements for CA, OR, TX, and KS, and Missouri matches none of them, so a
+    Missouri household receives the federal benefit only.
 
-    ``MoStateCodeDependency`` is added for the same reason the sibling states add
-    theirs: ``pe_input()`` never sends ``state_code`` on its own, and PE's Lifeline
-    chain reads ``state_code_str`` in both ``lifeline`` (state supplement branch) and
-    ``is_lifeline_income_eligible`` (the TX 150% FPG expansion versus the federal
-    135% limit). Sending MO explicitly keeps PE on the federal branch by fact rather
-    than by whichever state PE would otherwise default to. Mirrors the KsLifeline /
-    TxLifeline / WaLifeline pattern.
-
-    The base ``Lifeline.pe_inputs`` supply broadband and phone cost plus the IRS gross
-    income set that feeds ``fcc_fpg_ratio``; MO adds no inputs beyond the state code.
+    ``MoStateCodeDependency`` is load-bearing. ``pe_input()`` never sends
+    ``state_code`` on its own, and PE's Lifeline chain branches on it for both the
+    state supplement and the income limit (TX expands to 150% FPG against the
+    federal 135%). Without it PE falls back to its own default state.
     """
 
     pe_inputs = [

--- a/programs/programs/mo/pe/tests/test_spm.py
+++ b/programs/programs/mo/pe/tests/test_spm.py
@@ -1,5 +1,14 @@
 """
-Unit tests for the MO SPM-level PolicyEngine calculator ``MoNslp`` (mo_nslp).
+Unit tests for the MO SPM-level PolicyEngine calculators ``MoLifeline`` (mo_lifeline)
+and ``MoNslp`` (mo_nslp).
+
+Both are straight passthroughs to their federal PolicyEngine calculators, so the MFB-side
+surface under test is registration and ``pe_inputs`` wiring rather than benefit math.
+
+MoLifeline is a Fed (as-is) program: PolicyEngine's ``lifeline`` supplies eligibility and
+value unchanged, and Missouri has no state supplement in PE (only CA/OR via ``in_effect``,
+plus explicit TX and KS supplements). These tests pin that MO stays on the federal branch
+and that the state code reaches PE.
 
 MoNslp is a straight passthrough to PolicyEngine's federal ``SchoolLunch`` calculator:
 eligibility and the benefit dollar value come from PE, so there is no MFB-side routing
@@ -19,14 +28,70 @@ These tests pin that wiring so a future refactor can't silently drop it.
 
 from django.test import TestCase
 
-from programs.programs.federal.pe.spm import SchoolLunch
+from programs.programs.federal.pe.spm import Lifeline, SchoolLunch
 from programs.programs.mo.pe import mo_pe_calculators, mo_spm_calculators
-from programs.programs.mo.pe.spm import MoNslp
+from programs.programs.mo.pe.spm import MoLifeline, MoNslp
 from programs.programs.policyengine.calculators.registry import (
     all_calculators,
     all_spm_unit_calculators,
 )
 import programs.programs.policyengine.calculators.dependencies as dependency
+
+
+class TestMoLifelineWiring(TestCase):
+    """MoLifeline registration and MO-specific pe_inputs handling."""
+
+    def test_is_subclass_of_lifeline(self):
+        self.assertTrue(issubclass(MoLifeline, Lifeline))
+
+    def test_pe_name_is_lifeline(self):
+        """The federal SPM-level variable; MO adds no state variable of its own."""
+        self.assertEqual(MoLifeline.pe_name, "lifeline")
+
+    def test_is_registered_in_mo_spm_calculators(self):
+        self.assertIn("mo_lifeline", mo_spm_calculators)
+        self.assertIs(mo_spm_calculators["mo_lifeline"], MoLifeline)
+
+    def test_is_registered_in_mo_pe_calculators(self):
+        self.assertIn("mo_lifeline", mo_pe_calculators)
+        self.assertIs(mo_pe_calculators["mo_lifeline"], MoLifeline)
+
+    def test_is_registered_in_the_global_registry(self):
+        """screener.views matches Program.name_abbreviated against all_calculators keys,
+        so the MO spm calculators must be spread into the global registry too."""
+        self.assertIn("mo_lifeline", all_spm_unit_calculators)
+        self.assertIs(all_spm_unit_calculators["mo_lifeline"], MoLifeline)
+        self.assertIn("mo_lifeline", all_calculators)
+        self.assertIs(all_calculators["mo_lifeline"], MoLifeline)
+
+    def test_pe_outputs_are_inherited_from_lifeline(self):
+        self.assertEqual(MoLifeline.pe_outputs, [dependency.spm.Lifeline])
+
+    # --- the MO-specific input ---
+
+    def test_pe_inputs_includes_mo_state_code(self):
+        """``pe_input()`` never sends state_code on its own; PE's Lifeline chain reads
+        it for both the state supplement branch and the TX FPG expansion."""
+        self.assertIn(dependency.household.MoStateCodeDependency, MoLifeline.pe_inputs)
+
+    def test_mo_state_code_dependency_sends_mo(self):
+        self.assertEqual(dependency.household.MoStateCodeDependency.state, "MO")
+
+    # --- federal inputs must survive the MO override ---
+
+    def test_pe_inputs_retains_all_federal_inputs(self):
+        for federal_input in Lifeline.pe_inputs:
+            self.assertIn(federal_input, MoLifeline.pe_inputs)
+
+    def test_pe_inputs_includes_broadband_and_phone_cost(self):
+        """PE caps the benefit at combined phone + broadband cost, so both are needed
+        or an eligible household's value collapses toward $0."""
+        self.assertIn(dependency.spm.BroadbandCostDependency, MoLifeline.pe_inputs)
+        self.assertIn(dependency.spm.PhoneCostDependency, MoLifeline.pe_inputs)
+
+    def test_pe_inputs_adds_exactly_one_input_over_federal(self):
+        """Fed (as-is): the state code is the only MO addition."""
+        self.assertEqual(len(MoLifeline.pe_inputs), len(Lifeline.pe_inputs) + 1)
 
 
 class TestMoNslpWiring(TestCase):


### PR DESCRIPTION
## Context & Motivation

Adds Missouri Lifeline, and brings all eight states' Lifeline configs onto one standard.

- Linear: [MFB-1211](https://linear.app/myfriendben/issue/MFB-1211/program-mo-lifeline-phone-and-internet-discount)
- Discovery: [MFB-1275](https://linear.app/myfriendben/issue/MFB-1275/discovery-mo-lifeline-phone-and-internet-discount)

**Engine / Tier:** PE / `Fed (as-is)`.

## Changes Made

### MO Lifeline

`MoLifeline(Lifeline)` in `programs/programs/mo/pe/spm.py` — a thin subclass adding only `MoStateCodeDependency`. PE carries state supplements for CA, OR, TX, and KS; Missouri matches none, so a Missouri household receives the federal benefit only. The state code is load-bearing rather than boilerplate: `pe_input()` never sends `state_code` on its own, and PE's Lifeline chain branches on it for both the supplement and the income limit (TX expands to 150% FPG against the federal 135%).

No `registry.py` edit was needed — MO's SPM group was already wired via `MoNslp`.

### All eight configs standardized

They had drifted on nearly every field: three descriptions, three apply links, application times of 10, 15, and 30 minutes, and four separate sets of per-state document rows holding the same content.

**CO, IL, MA, and NC had no config file at all.** Their `Program` rows predate the config importer, so they were only editable by hand and had drifted furthest — `year` 2025, a 15-minute application time, an `nv.fcc.gov` apply link, and document rows named `earned income`, `MAearnedincome`, and `IL_earned_income` for the same thing. This PR adds configs for all four, keeping `name_abbreviated: lifeline` so `--override` matches their existing rows.

| Field | Value |
|---|---|
| `base_program` | `lifeline` (TX was missing it) |
| `year` | `2026` |
| `estimated_application_time` | `10 minutes` |
| `apply_button_description` | `""` → renders the standard "Apply Online" |
| `learn_more_link` | `lifelinesupport.org/how-to-qualify/` |
| `apply_button_link` | `lifelinesupport.org/how-to-apply/` |
| `legal_status_required` | the six user-selected statuses |
| `name` | `Lifeline` (KS was "Kansas Lifeline Phone and Internet Discount") |
| flags | TX was missing `show_on_current_benefits` / `has_calculator` / `show_in_has_benefits_step` entirely |
| dropped | `value_type` (removed by migration `0163`) |

`program.external_name` is now explicit in all eight. KS/MO/TX/WA previously omitted it and relied on `new_program()`'s uniqueness fallback, which makes a program's identity depend on import order.

### Documents — one shared set, hedged

Four per-state sets became **four shared rows** (`lifeline_program_participation`, `lifeline_income_proof`, `lifeline_id_proof`, `lifeline_home`), each linked to all eight programs.

Two substantive corrections, not just renaming:

- **Everything is hedged "if requested."** USAC's National Verifier auto-verifies identity and address and requests documents only when that check fails, so stating them flatly overstated what a household must gather. MO already hedged; that wording won.
- **Income covers unearned sources.** USAC accepts Social Security, unemployment, and worker's comp statements. Only TX listed unearned income, as a separate entry; it is merged into one.

### SNAP warning extended to all eight

`wa_lifeline_snap_enrollment` → `lifeline_snap_enrollment`. SNAP participation is an explicit Lifeline qualifying program per [USAC](https://www.lifelinesupport.org/how-to-qualify/), so advising a SNAP-eligible household to enroll in SNAP first is federal guidance, not Washington-specific. The warning already exists in staging and production for WA; this renames it and applies it everywhere.

## Testing

- Migrations to run: none
- 22 tests pass in `mo/pe/tests/test_spm.py`; full suite green
- Re-imported all eight locally with `--override` and verified each program at `year=2026` with the four shared documents, its navigator, correct links, and the rendered description

Browser QA was not possible: the local server runs the main checkout, which does not contain worktree code. Verified in-process instead — `mo_lifeline` resolves from `all_calculators` and returns eligible / $111/yr through `calc_pe_eligibility`.

## Deployment

**Do not run these imports as a bare loop.** `--override` deletes and recreates each program:

1. `new_program()` creates with `active=False`, so **every currently-active program goes inactive** until restored. Seven states are live today.
2. The shared support-center navigator is deleted and recreated on the first state's import, since it is the only reference at that moment. [MFB-1585](https://linear.app/myfriendben/issue/MFB-1585/config-import-commands-record-skipped-imports-as-successful-orphaning) fixed the delete guard to read `programs_ordered`, so every state after the first keeps its link — a re-link pass is now a safety net rather than a requirement.

`--reconcile` is **not** sufficient here: it is additive over warning messages, documents, and navigators only, and this change also moves program scalar fields (`year`, `estimated_application_time`) and translated fields (description, links).

Sequence per environment: capture the active set → import all eight with `--override` → restore the active flags → re-link the navigator → verify.

⚠️ **Larger blast radius than a single-program PR.** This changes **seven live white labels** (CO, IL, KS, MA, NC, TX, WA). CO/IL/MA/NC in particular have never been config-managed, so their descriptions, links, and documents change materially. QA each state's Lifeline results card.

`mo_lifeline` is left `active=False` and must be activated on deploy.

## Notes for Reviewers

- **PE has no MO Lifeline supplement**, so Missouri shows the federal benefit only — $111/yr. The config's own `learn_more_link` (MO PSC) documents a combined federal+state landline rate that PE cannot model, and the description says Missouri "may also provide an extra discount for some landline services." Consistent with the 07-28 scope decision not to expand scope, since neither MFB nor PE collects landline detail — but the estimate understates landline households.
- **The support-center phone number was wrong in every config** (`+18005626150`, not a USAC number; corrected to `(800) 234-9473`). It never reached the database because `_import_navigators` reuses an existing navigator without updating it — so a wrong config value was indistinguishable from a correct one. Relevant to the MFB-1585 audit direction.
- `programs/models.py:782` resolves `calculators[name_abbreviated]` unguarded, so a single active row with no matching calculator 500s eligibility for an entire white label. Out of scope here; worth its own ticket.
