### PR TITLE
Remove stale Trump Account availability warning (7 states)

### DIFF
--- a/programs/management/commands/import_program_config_data/data/co_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/co_trump_account_initial_config.json
@@ -49,10 +49,5 @@
             "link_url": "https://www.irs.gov/trumpaccounts",
             "link_text": "IRS Trump Accounts page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/il_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/il_trump_account_initial_config.json
@@ -49,10 +49,5 @@
             "link_url": "https://www.irs.gov/trumpaccounts",
             "link_text": "IRS Trump Accounts page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/ks_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ks_trump_account_initial_config.json
@@ -53,10 +53,5 @@
             "link_url": "https://www.irs.gov/form4547",
             "link_text": "IRS Form 4547 page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/ma_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/ma_trump_account_initial_config.json
@@ -49,10 +49,5 @@
             "link_url": "https://www.irs.gov/trumpaccounts",
             "link_text": "IRS Trump Accounts page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/nc_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/nc_trump_account_initial_config.json
@@ -49,10 +49,5 @@
             "link_url": "https://www.irs.gov/trumpaccounts",
             "link_text": "IRS Trump Accounts page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/tx_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/tx_trump_account_initial_config.json
@@ -49,10 +49,5 @@
             "link_url": "https://www.irs.gov/trumpaccounts",
             "link_text": "IRS Trump Accounts page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/management/commands/import_program_config_data/data/wa_fap_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_fap_initial_config.json
@@ -8,22 +8,23 @@
     "icon": "food"
   },
   "program": {
-    "name_abbreviated": "wa_snap",
+    "name_abbreviated": "wa_fap",
     "year": "2026",
     "legal_status_required": [
-      "citizen",
-      "gc_5plus"
+      "gc_5less",
+      "refugee",
+      "otherWithWorkPermission"
     ],
-    "name": "Basic Food - Supplemental Nutrition Assistance Program (SNAP)",
-    "description": "Basic Food (also called SNAP or food stamps) helps you buy groceries each month. You get a card that works like a debit card at most grocery stores. The amount you get depends on your household size and income.\n\nMost people with low income can apply. Washington has higher income limits than many states. For most people, you do not need to meet an asset or savings test. If you get TANF (cash help) or SSI (disability benefits), you may qualify right away. College students may need to work at least 20 hours a week to qualify.",
-    "description_short": "Monthly help buying groceries for low-income households",
-    "learn_more_link": "https://www.dshs.wa.gov/esa/community-services-offices/basic-food",
+    "name": "Food Assistance Program (FAP) for Legal Immigrants",
+    "description": "The Food Assistance Program (FAP) helps you buy groceries each month if you are a legal immigrant who cannot get Basic Food (SNAP) because of your immigration status. You get a card that works like a debit card at most grocery stores.\n\nFAP pays the same amount as Basic Food. The amount you get depends on your household size and income. You may qualify if you have a green card but have not had it for 5 years yet, or if you are lawfully present in another way, such as having temporary protected status, being paroled into the U.S., or having a pending asylum application.\n\nYou must meet the same income and other rules as Basic Food. People without lawful immigration status cannot get FAP. You apply using the same application as Basic Food.",
+    "description_short": "Monthly help buying groceries for legal immigrants who cannot get Basic Food",
+    "learn_more_link": "https://www.dshs.wa.gov/esa/program-summary/food-assistance-program-legal-immigrants-fap",
     "apply_button_link": "https://www.washingtonconnection.org/home/",
     "apply_button_description": "",
     "estimated_application_time": "45 - 90 minutes",
     "estimated_delivery_time": "30 days",
     "estimated_value": "",
-    "website_description": "Monthly assistance to buy food",
+    "website_description": "Monthly assistance to buy food for legal immigrants",
     "show_in_has_benefits_step": true
   },
   "documents": [

--- a/programs/management/commands/import_program_config_data/data/wa_trump_account_initial_config.json
+++ b/programs/management/commands/import_program_config_data/data/wa_trump_account_initial_config.json
@@ -54,10 +54,5 @@
             "link_url": "https://www.irs.gov/trumpaccounts",
             "link_text": "IRS Trump Accounts page"
         }
-    ],
-    "warning_message": {
-        "external_name": "trump_account_notices",
-        "calculator": "_show",
-        "message": "Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates."
-    }
+    ]
 }

--- a/programs/programs/wa/pe/__init__.py
+++ b/programs/programs/wa/pe/__init__.py
@@ -11,6 +11,7 @@ wa_member_calculators = {
 }
 
 wa_spm_calculators = {
+    "wa_fap": spm.WaFap,
     "wa_lifeline": spm.WaLifeline,
     "wa_snap": spm.WaSnap,
     "wa_tanf": spm.WaTanf,

--- a/programs/programs/wa/pe/spm.py
+++ b/programs/programs/wa/pe/spm.py
@@ -16,6 +16,33 @@ class WaSnap(Snap):
     ]
 
 
+class WaFap(Snap):
+    """
+    Washington state-funded Food Assistance Program (FAP) for legal immigrants.
+
+    FAP pays 100% of the federal SNAP benefit level (WAC 388-400-0050), so the
+    dollar value is identical to Basic Food by design.  This class therefore
+    reuses the federal `snap` PolicyEngine variable and the same inputs as
+    `WaSnap`; there is deliberately no FAP-specific benefit math.
+
+    The programs differ only in *who* qualifies.  FAP serves legal immigrants
+    who are excluded from federal Basic Food solely by immigration status —
+    qualified aliens who have not yet met the five-year bar, and lawfully
+    present nonqualified aliens (PRUCOL).  That gate is expressed in the
+    program config's `legal_status_required` rather than here, matching the
+    approach documented on `WaTanf`.
+
+    The `legal_status_required` lists for `wa_fap` and `wa_snap` are mutually
+    exclusive so that a household is never shown both programs, which would
+    double-count the same PolicyEngine value.
+    """
+
+    pe_inputs = [
+        *Snap.pe_inputs,
+        dependency.household.WaStateCodeDependency,
+    ]
+
+
 class WaTanf(Tanf):
     """
     Washington TANF / SFA cash assistance calculator using PolicyEngine.

--- a/programs/programs/wa/pe/tests/test_spm.py
+++ b/programs/programs/wa/pe/tests/test_spm.py
@@ -4,6 +4,7 @@ Unit tests for WA SPM-level PolicyEngine calculator classes.
 These tests verify WA-specific calculator logic including:
 - WaLifeline calculator registration
 - WaSnap calculator registration
+- WaFap calculator registration and parity with WaSnap
 - WA-specific pe_inputs (WaStateCodeDependency)
 """
 
@@ -12,7 +13,7 @@ from django.test import TestCase
 from programs.programs.federal.pe.spm import Lifeline, Snap
 from programs.programs.policyengine.calculators.dependencies.household import WaStateCodeDependency
 from programs.programs.wa.pe import wa_pe_calculators, wa_spm_calculators
-from programs.programs.wa.pe.spm import WaLifeline, WaSnap
+from programs.programs.wa.pe.spm import WaFap, WaLifeline, WaSnap
 
 
 class TestWaSnap(TestCase):
@@ -53,6 +54,51 @@ class TestWaSnap(TestCase):
     def test_pe_inputs_has_more_than_parent(self):
         """Test that WaSnap has more inputs than the parent Snap class."""
         self.assertGreater(len(WaSnap.pe_inputs), len(Snap.pe_inputs))
+
+
+class TestWaFap(TestCase):
+    """Tests for WaFap calculator class."""
+
+    def test_exists_and_is_subclass_of_snap(self):
+        """Test that WaFap is a subclass of federal Snap."""
+        self.assertTrue(issubclass(WaFap, Snap))
+
+    def test_pe_name_is_snap(self):
+        """Test that pe_name is snap, since FAP pays 100% of the SNAP benefit."""
+        self.assertEqual(WaFap.pe_name, "snap")
+
+    def test_is_registered_in_wa_pe_calculators(self):
+        """Test that WaFap is registered in the calculators dictionary."""
+        self.assertIn("wa_fap", wa_pe_calculators)
+        self.assertEqual(wa_pe_calculators["wa_fap"], WaFap)
+
+    def test_is_registered_in_wa_spm_calculators(self):
+        """Test that WaFap is registered in the SPM calculators dictionary."""
+        self.assertIn("wa_fap", wa_spm_calculators)
+        self.assertEqual(wa_spm_calculators["wa_fap"], WaFap)
+
+    def test_pe_inputs_includes_wa_state_code_dependency(self):
+        """Test that WaStateCodeDependency is in pe_inputs."""
+        self.assertIn(WaStateCodeDependency, WaFap.pe_inputs)
+
+    def test_pe_inputs_includes_all_parent_inputs(self):
+        """Test that all parent Snap inputs are included in WaFap."""
+        for parent_input in Snap.pe_inputs:
+            self.assertIn(parent_input, WaFap.pe_inputs)
+
+    def test_pe_inputs_has_more_than_parent(self):
+        """Test that WaFap has more inputs than the parent Snap class."""
+        self.assertGreater(len(WaFap.pe_inputs), len(Snap.pe_inputs))
+
+    def test_pe_inputs_match_wa_snap(self):
+        """
+        Test that WaFap requests exactly the same PolicyEngine inputs as WaSnap.
+
+        FAP pays 100% of the SNAP benefit, so any divergence in inputs would
+        make the two programs return different dollar values for the same
+        household.
+        """
+        self.assertEqual(WaFap.pe_inputs, WaSnap.pe_inputs)
 
 
 class TestWaLifeline(TestCase):


### PR DESCRIPTION
## Context & Motivation

Every Trump Account config except MO carries this warning:

> Trump Accounts are expected to become available on or after July 4, 2026. Check IRS.gov/trumpaccounts for updates.

That date has passed and the premise is wrong. Treasury's portal at `trumpaccounts.gov` is live and accepting Form 4547 submissions today, so the warning now tells users to wait for something they can already do.

The original text also conflated two milestones: July 4, 2026 was when **contributions** begin, not when accounts became available. Activation emails have been going out in phases to people who filed earlier.

MO deliberately omits this warning (flagged during MO's discovery review as stale — do not copy). This brings the other seven in line with MO rather than the reverse.

Sources: [Treasury — Launch of the Trump Accounts App](https://home.treasury.gov/news/press-releases/sb0508), [Treasury/IRS proposed regulations](https://www.irs.gov/newsroom/treasury-irs-issue-proposed-regulations-on-how-to-open-initial-trump-accounts-under-the-one-big-beautiful-bill)

## Changes Made

Removed the top-level `warning_message` block from seven configs: `co`, `il`, `ks`, `ma`, `nc`, `tx`, `wa`. Seven lines deleted per file, nothing else touched.

## Testing

- Migrations to run: none
- Configuration updates needed: see Deployment — the config change alone is **not** sufficient
- Manual testing: removed the row in the local DB and confirmed the warning no longer renders

## Deployment

**A re-import will not remove the existing warning.** `_delete_program_and_related` only deletes a warning message when `warning.programs.count() == 1`. This row (`trump_account_notices`) is shared by all seven programs, so every per-state override re-import keeps it.

It must be deleted directly in each environment:

```bash
heroku run --app cobenefits-api-staging -- \
  python manage.py shell -c "from programs.models import WarningMessage; \
  WarningMessage.objects.filter(external_name='trump_account_notices').delete()"
```

Then the same on `cobenefits-api` for production. Deleting the shared row clears it for all seven white labels at once.

## Notes for Reviewers

The `programs.count() == 1` guard is correct behavior — it protects shared entities from a single program's re-import. It just means a shared row can never be cleaned up through the config path, which is worth knowing for any future shared-entity removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Washington’s 2026 Food Assistance Program, including eligibility details, application information, required documents, and navigator resources.
  * Added Washington FAP benefit calculations using SNAP-based rules.

* **Updates**
  * Updated Washington SNAP eligibility requirements to accept only citizenship or qualifying permanent-resident status.
  * Removed outdated warning messages from Trump Account program information across supported states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->