### PR TITLE
fix: hash passwords saved through the user admin

### DIFF
--- a/authentication/admin.py
+++ b/authentication/admin.py
@@ -136,6 +136,8 @@ class CustomUserAdmin(SecureAdmin, UserAdmin):
             },
         ),
         ("Contact preferences", {"fields": ("tcpa_consent", "explicit_tcpa_consent", "send_offers", "send_updates")}),
+        # external_id is the HubSpot contact ID, used when debugging CRM sync.
+        ("Integrations", {"fields": ("external_id",)}),
         ("Important dates", {"fields": ("last_login", "date_joined")}),
     )
 

--- a/authentication/admin.py
+++ b/authentication/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.models import Group
-from django.contrib.auth.admin import GroupAdmin
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.core.exceptions import PermissionDenied
 from rest_framework.authtoken.models import TokenProxy
 from rest_framework.authtoken.admin import TokenAdmin
@@ -106,12 +106,40 @@ class SecureAdmin(ModelAdmin):
         return request.user.is_superuser
 
 
-class CustomUserAdmin(SecureAdmin):
-    search_fields = ("email",)
-    ordering = ("email_or_cell", "email")
+# UserAdmin supplies the password-hashing forms (UserCreationForm/UserChangeForm) and
+# renders the stored hash as a read-only field with a link to the change-password view.
+# Without it the password renders as a plain editable CharField and whatever is submitted
+# is saved unhashed, locking the account out.
+class CustomUserAdmin(SecureAdmin, UserAdmin):
+    search_fields = ("email_or_cell", "email", "first_name", "last_name")
+    ordering = ("email_or_cell",)
     filter_horizontal = ["white_labels", "user_permissions"]
 
     list_display = ("email_or_cell", "is_staff")
+
+    # UserAdmin's default fieldsets reference the "username" field, which this model
+    # replaces with email_or_cell, so they are declared explicitly.
+    fieldsets = (
+        (None, {"fields": ("email_or_cell", "password")}),
+        ("Personal info", {"fields": ("first_name", "last_name", "email", "cell", "language_code")}),
+        (
+            "Permissions",
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "white_labels",
+                    "groups",
+                    "user_permissions",
+                )
+            },
+        ),
+        ("Contact preferences", {"fields": ("tcpa_consent", "explicit_tcpa_consent", "send_offers", "send_updates")}),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
+
+    add_fieldsets = ((None, {"classes": ("wide",), "fields": ("email_or_cell", "password1", "password2")}),)
 
 
 class CustomGroupAdmin(SecureAdmin, GroupAdmin):

--- a/authentication/models.py
+++ b/authentication/models.py
@@ -13,7 +13,7 @@ class UserManager(BaseUserManager):
         if not email_or_cell:
             raise ValueError("Users must have an email address or cell phone number")
 
-        user = self.model(email_or_cell=email_or_cell, password=password, explicit_tcpa_consent=False)
+        user = self.model(email_or_cell=email_or_cell, explicit_tcpa_consent=False)
 
         user.set_password(password)
         user.save(using=self._db)

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -1,3 +1,137 @@
-# from django.test import TestCase
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.forms import AdminPasswordChangeForm
+from django.test import TestCase, override_settings
+from django.urls import reverse
 
-# Create your tests here.
+from .admin import CustomUserAdmin
+from .models import User
+
+
+class UserAdminPasswordTests(TestCase):
+    """
+    The admin must never write an unhashed value to User.password.
+
+    CustomUserAdmin previously extended only ModelAdmin, so `password` rendered as an
+    ordinary editable CharField and its submitted value was saved verbatim. Any admin
+    edit to a user (or a browser autofilling the field) silently replaced the hash with
+    plain text and locked the account out.
+    """
+
+    def setUp(self):
+        self.password = "correct-horse-battery-staple"
+        self.user = User.objects.create_user(email_or_cell="graciela@example.com", password=self.password)
+        self.superuser = User.objects.create_superuser(email_or_cell="admin@example.com", password="admin-password-123")
+        self.admin = CustomUserAdmin(User, AdminSite())
+
+    def test_password_field_is_not_editable_as_plain_text(self):
+        """The change form must expose the hash read-only, not as a writable CharField."""
+        form_class = self.admin.get_form(self._request_for(self.superuser), obj=self.user)
+        password_field = form_class.base_fields["password"]
+
+        # ReadOnlyPasswordHashField renders the hash and discards any submitted value.
+        self.assertEqual(password_field.__class__.__name__, "ReadOnlyPasswordHashField")
+
+    def test_saving_user_via_admin_form_preserves_password(self):
+        """Editing an unrelated field through the admin form must not damage the hash."""
+        request = self._request_for(self.superuser)
+        form_class = self.admin.get_form(request, obj=self.user)
+
+        data = {
+            "email_or_cell": self.user.email_or_cell,
+            "password": self.user.password,  # what the rendered form would submit back
+            "first_name": "Graciela",
+            "is_active": "on",
+            "date_joined_0": "2026-01-01",
+            "date_joined_1": "00:00:00",
+        }
+        form = form_class(data, instance=self.user)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "Graciela")
+        self.assertTrue(
+            self.user.check_password(self.password),
+            "admin save destroyed the password hash",
+        )
+
+    def test_admin_password_change_form_hashes_new_password(self):
+        """The dedicated change-password view stores a hash, never the raw input."""
+        new_password = "a-brand-new-password-456"
+        form = AdminPasswordChangeForm(
+            self.user,
+            {"password1": new_password, "password2": new_password},
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.user.refresh_from_db()
+        self.assertNotEqual(self.user.password, new_password)
+        self.assertTrue(self.user.check_password(new_password))
+
+    def test_add_form_hashes_password(self):
+        """Creating a user through the admin add form must hash the password."""
+        request = self._request_for(self.superuser)
+        form_class = self.admin.get_form(request, obj=None)
+        raw_password = "freshly-created-pw-789"
+
+        form = form_class(
+            {
+                "email_or_cell": "newstaff@example.com",
+                "password1": raw_password,
+                "password2": raw_password,
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        created = form.save()
+
+        self.assertNotEqual(created.password, raw_password)
+        self.assertTrue(created.check_password(raw_password))
+
+    def test_search_uses_username_field(self):
+        """
+        Admin search must cover email_or_cell. The nullable `email` field is empty for
+        most screener-created users, so searching it alone returns nothing.
+        """
+        self.assertIn("email_or_cell", self.admin.search_fields)
+
+    def _request_for(self, user):
+        request = self.client.request().wsgi_request
+        request.user = user
+        return request
+
+
+# Rendering the admin templates resolves unfold's static assets, which requires a
+# collectstatic manifest that is not built in the test environment.
+@override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
+class UserAdminChangePasswordViewTests(TestCase):
+    """End-to-end check through the real admin URLs."""
+
+    def setUp(self):
+        self.password = "staff-password-123"
+        self.superuser = User.objects.create_superuser(email_or_cell="admin@example.com", password=self.password)
+        self.target = User.objects.create_user(email_or_cell="target@example.com", password="target-password-123")
+        self.client.force_login(self.superuser)
+
+    def test_change_view_post_preserves_password(self):
+        url = reverse("admin:authentication_user_change", args=[self.target.pk])
+        original_hash = self.target.password
+
+        response = self.client.post(
+            url,
+            {
+                "email_or_cell": self.target.email_or_cell,
+                "password": original_hash,
+                "first_name": "Updated",
+                "is_active": "on",
+                "date_joined_0": "2026-01-01",
+                "date_joined_1": "00:00:00",
+                "_continue": "Save and continue editing",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.target.refresh_from_db()
+        self.assertEqual(self.target.password, original_hash)
+        self.assertTrue(self.target.check_password("target-password-123"))

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -33,13 +33,19 @@ class UserAdminPasswordTests(TestCase):
         self.assertEqual(password_field.__class__.__name__, "ReadOnlyPasswordHashField")
 
     def test_saving_user_via_admin_form_preserves_password(self):
-        """Editing an unrelated field through the admin form must not damage the hash."""
+        """
+        Editing an unrelated field through the admin form must not damage the hash.
+
+        The submitted password must differ from the stored hash. Submitting the hash
+        back over itself is a no-op even on the broken code path, so the test would
+        pass regardless of whether the field is writable.
+        """
         request = self._request_for(self.superuser)
         form_class = self.admin.get_form(request, obj=self.user)
 
         data = {
             "email_or_cell": self.user.email_or_cell,
-            "password": self.user.password,  # what the rendered form would submit back
+            "password": "autofilled-by-the-browser",
             "first_name": "Graciela",
             "is_active": "on",
             "date_joined_0": "2026-01-01",
@@ -89,12 +95,15 @@ class UserAdminPasswordTests(TestCase):
         self.assertNotEqual(created.password, raw_password)
         self.assertTrue(created.check_password(raw_password))
 
-    def test_search_uses_username_field(self):
+    def test_search_finds_user_by_email_or_cell(self):
         """
-        Admin search must cover email_or_cell. The nullable `email` field is empty for
-        most screener-created users, so searching it alone returns nothing.
+        Admin search must find a user by email_or_cell. The nullable `email` field is
+        empty for most screener-created users, so searching it alone returns nothing.
         """
-        self.assertIn("email_or_cell", self.admin.search_fields)
+        request = self._request_for(self.superuser)
+        queryset, _ = self.admin.get_search_results(request, User.objects.all(), "graciela@example.com")
+
+        self.assertIn(self.user, queryset)
 
     def test_fieldsets_cover_every_editable_field(self):
         """
@@ -130,6 +139,11 @@ class UserAdminChangePasswordViewTests(TestCase):
         self.client.force_login(self.superuser)
 
     def test_change_view_post_preserves_password(self):
+        """
+        Simulates the production failure: a browser autofills the password field on the
+        change form and the admin saves it. The submitted value must differ from the
+        stored hash, or the corrupting write is a no-op and proves nothing.
+        """
         url = reverse("admin:authentication_user_change", args=[self.target.pk])
         original_hash = self.target.password
 
@@ -137,7 +151,7 @@ class UserAdminChangePasswordViewTests(TestCase):
             url,
             {
                 "email_or_cell": self.target.email_or_cell,
-                "password": original_hash,
+                "password": "autofilled-by-the-browser",
                 "first_name": "Updated",
                 "is_active": "on",
                 "date_joined_0": "2026-01-01",

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -1,6 +1,7 @@
 from django.contrib.admin.sites import AdminSite
+from django.contrib.admin.utils import flatten_fieldsets
 from django.contrib.auth.forms import AdminPasswordChangeForm
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 from .admin import CustomUserAdmin
@@ -95,8 +96,23 @@ class UserAdminPasswordTests(TestCase):
         """
         self.assertIn("email_or_cell", self.admin.search_fields)
 
+    def test_fieldsets_cover_every_editable_field(self):
+        """
+        Declaring explicit fieldsets replaces Django's auto-generated field list, so a
+        field added to the model is silently absent from the admin until it is listed
+        here. external_id (the HubSpot contact ID) was dropped this way once already.
+        """
+        declared = set(flatten_fieldsets(self.admin.fieldsets))
+        editable = {f.name for f in User._meta.get_fields() if getattr(f, "editable", False) and not f.auto_created}
+
+        self.assertEqual(
+            editable - declared,
+            set(),
+            "editable User fields missing from CustomUserAdmin.fieldsets",
+        )
+
     def _request_for(self, user):
-        request = self.client.request().wsgi_request
+        request = RequestFactory().get("/")
         request.user = user
         return request
 
@@ -133,5 +149,8 @@ class UserAdminChangePasswordViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.target.refresh_from_db()
+        # A form-error re-render also returns 200, so assert the edit actually persisted.
+        # Otherwise this test could silently rot into a no-op that proves nothing.
+        self.assertEqual(self.target.first_name, "Updated")
         self.assertEqual(self.target.password, original_hash)
         self.assertTrue(self.target.check_password("target-password-123"))


### PR DESCRIPTION
## Problem

Admin users keep reporting that they cannot log in to `api.myfriendben.org/admin/` and ask for a password reset. It is not a forgotten password — the admin is corrupting stored password hashes.

`CustomUserAdmin` extended only unfold's `ModelAdmin`, not `django.contrib.auth.admin.UserAdmin`. `UserAdmin` is what supplies the password-specific form handling: `UserCreationForm` / `UserChangeForm`, the `ReadOnlyPasswordHashField`, and the separate change-password view.

Without it, `password` was rendered as an ordinary editable `CharField` pre-filled with the stored hash. On save, whatever the form submitted was written to `User.password` verbatim and unhashed. `check_password()` then failed, and the admin login reported generic invalid credentials — which reads as a forgotten password rather than a damaged record.

This needs no human error to trigger: browser password managers readily autofill a field named `password`, so simply opening a user, editing an unrelated field, and saving could destroy that user's password. Demonstrated against the pre-fix admin:

```
password field class : CharField
form valid           : True
stored password      : autofilled-plaintext
check_password works : False
```

## Fix

- Mix in `UserAdmin` so the change form uses `ReadOnlyPasswordHashField` and password changes go through `AdminPasswordChangeForm`.
- Declare `fieldsets` / `add_fieldsets` explicitly, since `UserAdmin`'s defaults reference the `username` field that this model replaces with `email_or_cell`.
- `SecureAdmin` is listed first in the MRO so its white-label permission and queryset overrides continue to win. `User` has no `white_label` attribute and `always_can_view` is `False`, so non-superusers resolve `False` on every permission hook — adding `UserAdmin` does not widen access.
- Add `email_or_cell` to `search_fields`. Search previously covered only the nullable `email` field, which is empty for most screener-created users, so admin lookups usually returned nothing — a large part of why these reports were painful to diagnose.
- Narrow `ordering` from `("email_or_cell", "email")` to `("email_or_cell",)`. `email_or_cell` is `unique=True`, so the second key was never reachable as a tiebreaker.
- Drop the `password=password` kwarg from `UserManager.create_user`. `set_password()` immediately overwrites it, so there is no behavior change, but assigning an unhashed value to `User.password` is the same footgun this PR fixes in the admin.

## Tests

Seven tests in `authentication/tests.py`. **Reverting the `admin.py` fix fails 5 of them.**

The two end-to-end tests submit a password value that *differs* from the stored hash, reproducing the autofill scenario above. This matters: an earlier revision of this PR submitted the existing hash back, and because writing the hash over itself is a no-op even on a writable `CharField`, both tests passed with the bug fully reinstated. They proved nothing. Caught in review.

`test_fieldsets_cover_every_editable_field` guards a hazard introduced by this PR itself — explicit `fieldsets` replace Django's auto-generated field list, so any field not listed silently vanishes from the admin, including fields added to the model later. It diffs the model's editable fields against the declared fieldsets. (This caught a real regression in review: `external_id`, the HubSpot contact ID, had been dropped.)

The end-to-end test overrides `STATICFILES_STORAGE`, because rendering the admin templates resolves unfold's static assets and requires a `collectstatic` manifest that is not built in the test environment. It matches the deprecated setting already in `benefits/settings.py:306`; both should move to `STORAGES` together at the Django 5.1 upgrade.

## Validation

- `pytest authentication/ configuration/ screener/tests/test_has_benefits_programs.py screener/tests/test_current_benefits_toggle.py screener/tests/test_referral_sources.py` — **88 passed, 0 failed**
- `manage.py check` — 0 issues
- `black` — clean

Correcting an earlier claim in this description: it previously reported "17 pre-existing failures on `main`." That was wrong. Those failures came from a dirty local working tree during the earlier run, not from `main`; the suites pass clean.

## Follow-up: audit prod for already-corrupted hashes

Run and complete. Two rows matched, both `is_staff = false`, so **no other admin account was locked out** — the damage was limited to the one reported user, since reset.

For the follow-up ticket, the more reliable detector is to match rows whose `password` contains no `$` separator, rather than enumerating known-good prefixes. Enumeration misses legacy `md5$`/`sha1$` hashers and, given the corruption mode, would let through arbitrary plaintext that happens to start with a hasher prefix. `set_unusable_password()` values (`!`-prefixed) must be excluded either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
